### PR TITLE
feat(core): infraestrutura comum - HTTP client, logging, config, erros

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
     "pydantic>=2.0",
     "lxml>=5.0",
     "python-dateutil>=2.9.0",
+    "tenacity>=9.1.4",
+    "cachetools>=7.0.5",
+    "aiolimiter>=1.2.1",
+    "structlog>=25.5.0",
+    "pydantic-settings>=2.13.1",
 ]
 
 [project.optional-dependencies]
@@ -59,3 +64,8 @@ plugins = ["pydantic.mypy"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=7.1.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,4 +68,5 @@ testpaths = ["tests"]
 [dependency-groups]
 dev = [
     "pytest-cov>=7.1.0",
+    "types-cachetools>=7.0.0.20260518",
 ]

--- a/src/mcp_fiscal_brasil/_core/__init__.py
+++ b/src/mcp_fiscal_brasil/_core/__init__.py
@@ -1,0 +1,24 @@
+"""Core public API for mcp-fiscal-brasil."""
+
+from .config import Settings, settings
+from .errors import (
+    FiscalError,
+    FiscalHTTPError,
+    FiscalNotFoundError,
+    FiscalRateLimitError,
+    FiscalValidationError,
+)
+from .http import HTTPClient
+from .logging import get_logger
+
+__all__ = [
+    "FiscalError",
+    "FiscalHTTPError",
+    "FiscalNotFoundError",
+    "FiscalRateLimitError",
+    "FiscalValidationError",
+    "HTTPClient",
+    "Settings",
+    "get_logger",
+    "settings",
+]

--- a/src/mcp_fiscal_brasil/_core/config.py
+++ b/src/mcp_fiscal_brasil/_core/config.py
@@ -1,0 +1,23 @@
+"""Application configuration for mcp-fiscal-brasil."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime settings loaded from environment variables or a local .env file."""
+
+    mcp_fiscal_env: str = "development"
+    mcp_fiscal_log_level: str = "INFO"
+    mcp_fiscal_cache_ttl: int = 300
+    mcp_fiscal_rate_limit: int = 10
+    mcp_fiscal_http_timeout: float = 30.0
+    mcp_fiscal_max_retries: int = 3
+    brasilapi_base_url: str = "https://brasilapi.com.br/api"
+    receita_base_url: str = "https://receitaws.com.br/v1"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+settings = Settings()
+
+__all__ = ["Settings", "settings"]

--- a/src/mcp_fiscal_brasil/_core/errors.py
+++ b/src/mcp_fiscal_brasil/_core/errors.py
@@ -1,0 +1,132 @@
+"""Shared fiscal error types."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FiscalError(Exception):
+    """Base exception for fiscal domain failures."""
+
+    def __init__(self, message: str, detail: Any | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return self.message
+
+    def __repr__(self) -> str:
+        return self._format_repr()
+
+    def _repr_fields(self) -> dict[str, Any]:
+        return {
+            "message": self.message,
+            "detail": self.detail,
+        }
+
+    def _format_repr(self) -> str:
+        fields = ", ".join(f"{name}={value!r}" for name, value in self._repr_fields().items())
+        return f"{self.__class__.__name__}({fields})"
+
+
+class FiscalHTTPError(FiscalError):
+    """Exception raised for HTTP failures from external fiscal services."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int,
+        url: str,
+        detail: Any | None = None,
+    ) -> None:
+        super().__init__(message, detail=detail)
+        self.status_code = status_code
+        self.url = url
+
+    def _repr_fields(self) -> dict[str, Any]:
+        fields = super()._repr_fields()
+        fields.update(
+            {
+                "status_code": self.status_code,
+                "url": self.url,
+            }
+        )
+        return fields
+
+
+class FiscalRateLimitError(FiscalError):
+    """Exception raised when a fiscal service rate limit is reached."""
+
+    def __init__(
+        self,
+        message: str,
+        retry_after: float | None = None,
+        detail: Any | None = None,
+    ) -> None:
+        super().__init__(message, detail=detail)
+        self.retry_after = retry_after
+
+    def _repr_fields(self) -> dict[str, Any]:
+        fields = super()._repr_fields()
+        fields["retry_after"] = self.retry_after
+        return fields
+
+
+class FiscalValidationError(FiscalError):
+    """Exception raised when an input value fails fiscal validation."""
+
+    def __init__(
+        self,
+        message: str,
+        field: str,
+        value: Any,
+        detail: Any | None = None,
+    ) -> None:
+        super().__init__(message, detail=detail)
+        self.field = field
+        self.value = value
+
+    def _repr_fields(self) -> dict[str, Any]:
+        fields = super()._repr_fields()
+        fields.update(
+            {
+                "field": self.field,
+                "value": self.value,
+            }
+        )
+        return fields
+
+
+class FiscalNotFoundError(FiscalError):
+    """Exception raised when a requested fiscal resource is not found."""
+
+    def __init__(
+        self,
+        message: str,
+        resource_type: str,
+        identifier: str,
+        detail: Any | None = None,
+    ) -> None:
+        super().__init__(message, detail=detail)
+        self.resource_type = resource_type
+        self.identifier = identifier
+
+    def _repr_fields(self) -> dict[str, Any]:
+        fields = super()._repr_fields()
+        fields.update(
+            {
+                "resource_type": self.resource_type,
+                "identifier": self.identifier,
+            }
+        )
+        return fields
+
+
+__all__ = [
+    "FiscalError",
+    "FiscalHTTPError",
+    "FiscalNotFoundError",
+    "FiscalRateLimitError",
+    "FiscalValidationError",
+]

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 import httpx
 from aiolimiter import AsyncLimiter
-from cachetools import TTLCache  # type: ignore[import-untyped]
+from cachetools import TTLCache
 from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 __all__ = ["HTTPClient"]
@@ -84,7 +84,7 @@ class HTTPClient:
         cache_key = self._cache_key("GET", url, params)
 
         if self.cache_ttl > 0 and cache_key in self._cache:
-            return cast(dict[str, Any], self._cache[cache_key])
+            return self._cache[cache_key]
 
         response = await self._request("GET", path, params=params, headers=headers)
         data = self._json_object(response)

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -1,0 +1,278 @@
+"""Async HTTP client with retries, rate limiting and short lived GET caching."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from importlib import import_module
+from inspect import Parameter, signature
+from typing import Any, cast
+
+import httpx
+from aiolimiter import AsyncLimiter
+from cachetools import TTLCache  # type: ignore[import-untyped]
+from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential
+
+__all__ = ["HTTPClient"]
+
+_CacheKey = tuple[str, str, tuple[tuple[str, Any], ...]]
+
+
+class _ReadableQuery(bytes):
+    def __str__(self) -> str:
+        return self.decode("ascii")
+
+
+class _ReadableQueryURL(httpx.URL):
+    @property
+    def query(self) -> bytes:
+        return _ReadableQuery(super().query)
+
+
+class HTTPClient:
+    """Small async JSON client for external fiscal services."""
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+        cache_ttl: int = 300,
+        rate_limit_per_second: int = 10,
+    ) -> None:
+        self.base_url = base_url.rstrip("/") + "/"
+        self.timeout = timeout
+        self.max_retries = max(1, max_retries)
+        self.cache_ttl = max(0, cache_ttl)
+        self.rate_limit_per_second = max(1, rate_limit_per_second)
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=timeout,
+            event_hooks={"request": [self._prepare_request]},
+        )
+        self._cache: TTLCache[_CacheKey, dict[str, Any]] = TTLCache(
+            maxsize=1024,
+            ttl=self.cache_ttl,
+        )
+        self._limiter = AsyncLimiter(
+            self.rate_limit_per_second,
+            self.rate_limit_per_second,
+        )
+
+    async def __aenter__(self) -> HTTPClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    async def _prepare_request(self, request: httpx.Request) -> None:
+        # Preserve bytes semantics while keeping stringified queries readable for callers.
+        if request.url.query:
+            request.url = _ReadableQueryURL(str(request.url))
+
+    async def get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Run a GET request and return the JSON object response."""
+        url = self._absolute_url(path)
+        cache_key = self._cache_key("GET", url, params)
+
+        if self.cache_ttl > 0 and cache_key in self._cache:
+            return cast(dict[str, Any], self._cache[cache_key])
+
+        response = await self._request("GET", path, params=params, headers=headers)
+        data = self._json_object(response)
+
+        if self.cache_ttl > 0 and 200 <= response.status_code < 300:
+            self._cache[cache_key] = data
+
+        return data
+
+    async def post(
+        self,
+        path: str,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Run a POST request and return the JSON object response."""
+        response = await self._request("POST", path, json=json, headers=headers)
+        return self._json_object(response)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        try:
+            await self._limiter.acquire()
+        except ValueError as exc:
+            raise self._rate_limit_error(
+                "Limite de requisições excedido",
+                retry_after=float(self.rate_limit_per_second),
+            ) from exc
+
+        try:
+            async for attempt in AsyncRetrying(
+                retry=retry_if_exception(self._is_retryable_error),
+                wait=wait_exponential(min=1, max=60),
+                stop=stop_after_attempt(self.max_retries),
+                reraise=True,
+            ):
+                with attempt:
+                    response = await self._client.request(
+                        method,
+                        path.lstrip("/"),
+                        params=self._sorted_params(params),
+                        json=json,
+                        headers=headers,
+                    )
+                    if not 200 <= response.status_code < 300:
+                        if self._is_retryable_status(response.status_code):
+                            response.raise_for_status()
+                        raise self._http_error(method, response)
+                    return response
+        except httpx.HTTPStatusError as exc:
+            raise self._http_error(method, exc.response) from exc
+        except httpx.RequestError as exc:
+            raise self._request_error(method, exc) from exc
+
+        raise self._http_error(method, None)
+
+    def _absolute_url(self, path: str) -> str:
+        return str(httpx.URL(self.base_url).join(path.lstrip("/")))
+
+    def _cache_key(
+        self,
+        method: str,
+        url: str,
+        params: dict[str, Any] | None,
+    ) -> _CacheKey:
+        sorted_params = tuple(
+            sorted((str(key), self._freeze(value)) for key, value in (params or {}).items())
+        )
+        return (method.upper(), url, sorted_params)
+
+    def _sorted_params(self, params: dict[str, Any] | None) -> list[tuple[str, Any]] | None:
+        if params is None:
+            return None
+        return sorted((str(key), value) for key, value in params.items())
+
+    def _freeze(self, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return tuple(sorted((str(key), self._freeze(item)) for key, item in value.items()))
+        if isinstance(value, list | tuple):
+            return tuple(self._freeze(item) for item in value)
+        if isinstance(value, set | frozenset):
+            return tuple(sorted(self._freeze(item) for item in value))
+        return value
+
+    def _json_object(self, response: httpx.Response) -> dict[str, Any]:
+        data = response.json()
+        if isinstance(data, dict):
+            return cast(dict[str, Any], data)
+        raise self._http_error(
+            response.request.method,
+            response,
+            message="Resposta JSON inválida",
+        )
+
+    def _is_retryable_error(self, exc: BaseException) -> bool:
+        if isinstance(exc, httpx.RequestError):
+            return True
+        if isinstance(exc, httpx.HTTPStatusError):
+            return self._is_retryable_status(exc.response.status_code)
+        return False
+
+    def _is_retryable_status(self, status_code: int) -> bool:
+        return status_code == 429 or 500 <= status_code <= 599
+
+    def _request_error(self, method: str, exc: httpx.RequestError) -> Exception:
+        request = exc.request
+        url = str(request.url) if request is not None else self.base_url
+        return self._make_core_error(
+            "FiscalHTTPError",
+            "Falha de comunicação com serviço externo",
+            method=method.upper(),
+            url=url,
+            endpoint=url,
+            status_code=None,
+            details={"error": str(exc)},
+        )
+
+    def _http_error(
+        self,
+        method: str,
+        response: httpx.Response | None,
+        message: str | None = None,
+    ) -> Exception:
+        status_code = response.status_code if response is not None else None
+        url = str(response.request.url) if response is not None else self.base_url
+        response_text = response.text if response is not None else None
+        return self._make_core_error(
+            "FiscalHTTPError",
+            message or self._status_message(status_code),
+            method=method.upper(),
+            url=url,
+            endpoint=url,
+            status_code=status_code,
+            response_text=response_text,
+            response_body=response_text,
+            details={"response": response_text},
+        )
+
+    def _rate_limit_error(self, message: str, retry_after: float | None = None) -> Exception:
+        return self._make_core_error(
+            "FiscalRateLimitError",
+            message,
+            retry_after=retry_after,
+            rate_limit_per_second=self.rate_limit_per_second,
+        )
+
+    def _status_message(self, status_code: int | None) -> str:
+        messages = {
+            400: "Requisição inválida",
+            401: "Não autorizado",
+            403: "Acesso negado",
+            404: "Recurso não encontrado",
+            422: "Dados inválidos",
+            429: "Limite de requisições excedido",
+            500: "Erro interno do servidor",
+            502: "Gateway inválido",
+            503: "Serviço indisponível",
+            504: "Tempo limite do gateway",
+        }
+        if status_code is None:
+            return "Falha na requisição HTTP"
+        return messages.get(status_code, f"Erro HTTP {status_code}")
+
+    def _make_core_error(self, error_name: str, message: str, **kwargs: Any) -> Exception:
+        errors_module = import_module("mcp_fiscal_brasil._core.errors")
+        error_cls = getattr(errors_module, error_name)
+        accepted_kwargs = self._accepted_kwargs(error_cls, kwargs)
+
+        try:
+            return cast(Exception, error_cls(message=message, **accepted_kwargs))
+        except TypeError:
+            return cast(Exception, error_cls(message, **accepted_kwargs))
+
+    def _accepted_kwargs(
+        self, error_cls: type[Exception], kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        try:
+            parameters = signature(error_cls).parameters
+        except (TypeError, ValueError):
+            return kwargs
+
+        if any(parameter.kind == Parameter.VAR_KEYWORD for parameter in parameters.values()):
+            return kwargs
+
+        return {key: value for key, value in kwargs.items() if key in parameters}

--- a/src/mcp_fiscal_brasil/_core/logging.py
+++ b/src/mcp_fiscal_brasil/_core/logging.py
@@ -1,0 +1,53 @@
+"""Structured logging helpers for the MCP Fiscal Brasil package."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Final, cast
+
+import structlog
+from structlog.typing import Processor
+
+__all__ = ["get_logger"]
+
+_ENV_VAR: Final = "MCP_FISCAL_ENV"
+_PRODUCTION_ENV: Final = "production"
+
+
+def _is_production() -> bool:
+    return os.getenv(_ENV_VAR, "").strip().lower() == _PRODUCTION_ENV
+
+
+def _processors(json_output: bool) -> list[Processor]:
+    renderer: Processor
+    if json_output:
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer(colors=False)
+
+    return [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+        renderer,
+    ]
+
+
+def _configure_structlog() -> None:
+    json_output = _is_production()
+    structlog.configure(
+        processors=_processors(json_output),
+        context_class=dict,
+        logger_factory=structlog.WriteLoggerFactory(file=sys.stderr),
+        wrapper_class=structlog.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+
+
+def get_logger(name: str) -> structlog.BoundLogger:
+    """Return a configured structlog logger for the current runtime environment."""
+    _configure_structlog()
+    return cast(structlog.BoundLogger, structlog.get_logger().bind(logger=name))

--- a/src/mcp_fiscal_brasil/cnpj/client.py
+++ b/src/mcp_fiscal_brasil/cnpj/client.py
@@ -1,7 +1,7 @@
 """Cliente para consulta de CNPJ via BrasilAPI e ReceitaWS."""
 
 from datetime import date
-from typing import Any, cast
+from typing import Any
 
 from mcp_fiscal_brasil._core import HTTPClient, Settings, get_logger
 
@@ -46,12 +46,12 @@ class CNPJClient:
 
     async def _consultar_brasil_api(self, cnpj: str) -> CNPJResponse:
         async with self._http_client(_settings.brasilapi_base_url) as client:
-            data = cast(dict[str, Any], await client.get(f"/cnpj/v1/{cnpj}"))
+            data = await client.get(f"/cnpj/v1/{cnpj}")
         return self._parse_brasil_api(data, cnpj)
 
     async def _consultar_receita_ws(self, cnpj: str) -> CNPJResponse:
         async with self._http_client(_settings.receita_base_url) as client:
-            data = cast(dict[str, Any], await client.get(f"/cnpj/{cnpj}"))
+            data = await client.get(f"/cnpj/{cnpj}")
         return self._parse_receita_ws(data, cnpj)
 
     def _parse_brasil_api(self, data: dict[str, Any], cnpj: str) -> CNPJResponse:

--- a/src/mcp_fiscal_brasil/cnpj/client.py
+++ b/src/mcp_fiscal_brasil/cnpj/client.py
@@ -1,22 +1,28 @@
 """Cliente para consulta de CNPJ via BrasilAPI e ReceitaWS."""
 
-import logging
 from datetime import date
-from typing import Any
+from typing import Any, cast
 
-from ..shared.http_client import FiscalHTTPClient
-from ..shared.rate_limiter import brasil_api_limiter, receita_limiter
+from mcp_fiscal_brasil._core import HTTPClient, Settings, get_logger
+
 from ..shared.schemas import Endereco
 from .schemas import AtividadeCNAE, CNPJResponse, QSASocio
 
-logger = logging.getLogger(__name__)
-
-BRASIL_API_BASE = "https://brasilapi.com.br/api"
-RECEITA_WS_BASE = "https://receitaws.com.br/v1"
+logger = get_logger(__name__)
+_settings = Settings()
 
 
 class CNPJClient:
     """Cliente para busca de dados de CNPJ em fontes publicas."""
+
+    def _http_client(self, base_url: str) -> HTTPClient:
+        return HTTPClient(
+            base_url,
+            timeout=_settings.mcp_fiscal_http_timeout,
+            max_retries=_settings.mcp_fiscal_max_retries,
+            cache_ttl=_settings.mcp_fiscal_cache_ttl,
+            rate_limit_per_second=_settings.mcp_fiscal_rate_limit,
+        )
 
     async def consultar(self, cnpj: str) -> CNPJResponse:
         """
@@ -25,30 +31,27 @@ class CNPJClient:
         Tenta BrasilAPI primeiro; em caso de falha, tenta ReceitaWS.
         """
         cnpj_limpo = "".join(c for c in cnpj if c.isdigit())
-        logger.info("Consultando CNPJ %s", cnpj_limpo)
+        logger.info("cnpj_lookup_started", cnpj=cnpj_limpo)
 
         try:
             return await self._consultar_brasil_api(cnpj_limpo)
-        except Exception as e:
+        except Exception as exc:
             logger.warning(
-                "BrasilAPI falhou para CNPJ %s: %s. Tentando ReceitaWS...", cnpj_limpo, e
+                "brasilapi_cnpj_lookup_failed",
+                cnpj=cnpj_limpo,
+                error=str(exc),
+                fallback="receitaws",
             )
             return await self._consultar_receita_ws(cnpj_limpo)
 
     async def _consultar_brasil_api(self, cnpj: str) -> CNPJResponse:
-        async with FiscalHTTPClient(BRASIL_API_BASE, rate_limiter=brasil_api_limiter) as client:
-            data: dict[str, Any] = await client.get(  # type: ignore[assignment]
-                f"/cnpj/v1/{cnpj}",
-                rate_limit_key="brasilapi/cnpj",
-            )
+        async with self._http_client(_settings.brasilapi_base_url) as client:
+            data = cast(dict[str, Any], await client.get(f"/cnpj/v1/{cnpj}"))
         return self._parse_brasil_api(data, cnpj)
 
     async def _consultar_receita_ws(self, cnpj: str) -> CNPJResponse:
-        async with FiscalHTTPClient(RECEITA_WS_BASE, rate_limiter=receita_limiter) as client:
-            data: dict[str, Any] = await client.get(  # type: ignore[assignment]
-                f"/cnpj/{cnpj}",
-                rate_limit_key="receitaws/cnpj",
-            )
+        async with self._http_client(_settings.receita_base_url) as client:
+            data = cast(dict[str, Any], await client.get(f"/cnpj/{cnpj}"))
         return self._parse_receita_ws(data, cnpj)
 
     def _parse_brasil_api(self, data: dict[str, Any], cnpj: str) -> CNPJResponse:

--- a/src/mcp_fiscal_brasil/cnpj/tools.py
+++ b/src/mcp_fiscal_brasil/cnpj/tools.py
@@ -1,13 +1,31 @@
 """Ferramentas MCP para consulta de CNPJ."""
 
-import logging
+from mcp_fiscal_brasil._core import FiscalValidationError, get_logger
 
-from ..shared.exceptions import ValidationError
+from ..shared.exceptions import ValidationError as SharedValidationError
 from ..shared.validators import format_cnpj, validate_cnpj
 from .client import CNPJClient
 from .schemas import CNPJResponse
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
+_INVALID_CNPJ_REASON = "CNPJ inválido. Verifique os 14 dígitos e o dígito verificador."
+
+
+class _CNPJValidationError(FiscalValidationError, SharedValidationError):
+    """Validation error compatible with both core and legacy fiscal errors."""
+
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        message = f"Valor inválido para '{field}': {value!r}. {reason}"
+        detail = {"field": field, "value": value, "reason": reason}
+        Exception.__init__(self, message)
+        self.message = message
+        self.detail = detail
+        self.field = field
+        self.value = value
+        self.code = "VALIDATION_ERROR"
+        self.details = {"field": field, "value": value}
+        self.reason = reason
+
 
 _client = CNPJClient()
 
@@ -31,14 +49,10 @@ async def consultar_cnpj(cnpj: str) -> CNPJResponse:
         APIError: Em caso de falha nas APIs consultadas.
     """
     if not validate_cnpj(cnpj):
-        raise ValidationError(
-            field="cnpj",
-            value=cnpj,
-            reason="CNPJ inválido. Verifique os 14 dígitos e o dígito verificador.",
-        )
+        raise _CNPJValidationError(field="cnpj", value=cnpj, reason=_INVALID_CNPJ_REASON)
 
     cnpj_formatado = format_cnpj(cnpj)
-    logger.info("Consultando CNPJ: %s", cnpj_formatado)
+    logger.info("cnpj_lookup_requested", cnpj=cnpj_formatado)
     return await _client.consultar(cnpj)
 
 
@@ -56,9 +70,7 @@ async def listar_cnpjs_por_nome(nome: str, uf: str | None = None) -> list[dict[s
     Returns:
         Lista de dicionários com 'cnpj' e 'razao_social'.
     """
-    # Esta implementação é um stub - a busca por nome requer APIs pagas
-    # como a da Receita Federal (acesso via certificado digital) ou serviços como CNPJ.ws
-    logger.info("Busca por nome '%s' (UF=%s) - funcionalidade limitada", nome, uf)
+    logger.info("cnpj_name_lookup_limited", nome=nome, uf=uf)
     return [
         {
             "aviso": (

--- a/src/mcp_fiscal_brasil/nfe/client.py
+++ b/src/mcp_fiscal_brasil/nfe/client.py
@@ -1,29 +1,28 @@
-"""Cliente para consulta de NFe via SEFAZ e APIs de terceiros."""
+"""NFe lookup client backed by BrasilAPI and the National NFe Portal."""
 
-import logging
-from typing import Any
+from typing import Any, cast
+
+from mcp_fiscal_brasil._core import (
+    FiscalHTTPError,
+    FiscalRateLimitError,
+    HTTPClient,
+    get_logger,
+    settings,
+)
 
 from ..shared.constants import CODIGO_UF
-from ..shared.exceptions import APIError, RateLimitError
-from ..shared.http_client import FiscalHTTPClient
-from ..shared.rate_limiter import brasil_api_limiter
 from .schemas import NFeResponse, StatusSEFAZResponse
 from .xml_parser import parse_nfe_xml
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
-# URL da API de consulta publica do SEFAZ (ambiente nacional)
-SEFAZ_CONSULTA_URL = "https://www.nfe.fazenda.gov.br/portal/consultaRecaptcha.aspx"
-
-# Portal Nacional da NFe - endpoint de consulta publica (nao requer autenticacao)
+# National NFe Portal public lookup endpoint, no certificate required.
 PORTAL_NFE_BASE = "https://www.nfe.fazenda.gov.br/portal"
-
-# BrasilAPI oferece consulta de NFe por chave
-BRASIL_API_BASE = "https://brasilapi.com.br/api"
+PORTAL_NFE_CONSULTA_PATH = "/consultaRecaptcha.aspx"
 
 
 def _extrair_info_chave(chave: str) -> dict[str, str]:
-    """Extrai campos estruturais da chave de acesso de 44 digitos."""
+    """Extract structural fields from a 44 digit NFe access key."""
     cod_uf = int(chave[:2])
     return {
         "uf": CODIGO_UF.get(cod_uf, f"UF {cod_uf}"),
@@ -36,76 +35,104 @@ def _extrair_info_chave(chave: str) -> dict[str, str]:
 
 
 class NFEClient:
-    """Cliente para consulta de NFe."""
+    """Client for NFe lookup flows."""
+
+    def _http_client(self, base_url: str) -> HTTPClient:
+        return HTTPClient(
+            base_url,
+            timeout=settings.mcp_fiscal_http_timeout,
+            max_retries=settings.mcp_fiscal_max_retries,
+            cache_ttl=settings.mcp_fiscal_cache_ttl,
+            rate_limit_per_second=settings.mcp_fiscal_rate_limit,
+        )
+
+    async def _get_json_or_text(
+        self,
+        client: HTTPClient,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | str:
+        response = await client._request("GET", path, params=params)
+        content_type = response.headers.get("content-type", "").lower()
+
+        if "json" in content_type:
+            data = response.json()
+            if isinstance(data, dict):
+                return cast(dict[str, Any], data)
+            raise FiscalHTTPError(
+                "Resposta JSON inválida",
+                status_code=response.status_code,
+                url=str(response.request.url),
+                detail={"response": response.text},
+            )
+
+        return response.text
 
     async def consultar_por_chave(self, chave: str) -> NFeResponse:
         """
-        Consulta os dados de uma NFe pela chave de acesso de 44 digitos.
+        Look up NFe data by its 44 digit access key.
 
-        Cadeia de fallback:
-          1. BrasilAPI (cobertura parcial por estado)
-          2. Portal Nacional NFe (consulta publica, sem autenticacao)
-          3. Informacoes parciais extraidas da propria chave
+        Fallback chain:
+          1. BrasilAPI, with partial state coverage
+          2. National NFe Portal, public lookup without authentication
+          3. Partial fields extracted from the access key itself
         """
-        logger.info("Consultando NFe chave: %s", chave)
+        logger.info("nfe_lookup_started", chave_prefix=chave[:10])
 
-        # Tentativa 1: BrasilAPI
         try:
             resultado = await self._consultar_brasil_api(chave)
-            logger.info("NFe %s consultada via BrasilAPI com sucesso", chave[:10])
+            logger.info("nfe_lookup_brasilapi_success", chave_prefix=chave[:10])
             return resultado
-        except RateLimitError as e:
+        except FiscalRateLimitError as exc:
             logger.warning(
-                "BrasilAPI retornou rate limit (429) para NFe %s: %s. Tentando Portal NFe.",
-                chave[:10],
-                e,
+                "nfe_lookup_brasilapi_rate_limited",
+                chave_prefix=chave[:10],
+                error=str(exc),
+                fallback="portal_nfe",
             )
-        except APIError as e:
+        except FiscalHTTPError as exc:
             logger.warning(
-                "BrasilAPI falhou para NFe %s (status=%s): %s. Tentando Portal NFe.",
-                chave[:10],
-                e.status_code,
-                e,
+                "nfe_lookup_brasilapi_http_failed",
+                chave_prefix=chave[:10],
+                status_code=exc.status_code,
+                error=str(exc),
+                fallback="portal_nfe",
             )
-        except Exception as e:
+        except Exception as exc:
             logger.warning(
-                "BrasilAPI erro inesperado para NFe %s: %s. Tentando Portal NFe.",
-                chave[:10],
-                e,
+                "nfe_lookup_brasilapi_unexpected_failed",
+                chave_prefix=chave[:10],
+                error=str(exc),
+                fallback="portal_nfe",
             )
 
-        # Tentativa 2: Portal Nacional NFe
         try:
             resultado = await self._consultar_portal_nfe(chave)
-            logger.info("NFe %s consultada via Portal NFe com sucesso", chave[:10])
+            logger.info("nfe_lookup_portal_success", chave_prefix=chave[:10])
             return resultado
-        except Exception as e:
+        except Exception as exc:
             logger.warning(
-                "Portal NFe falhou para NFe %s: %s. Retornando dados parciais da chave.",
-                chave[:10],
-                e,
+                "nfe_lookup_portal_failed",
+                chave_prefix=chave[:10],
+                error=str(exc),
+                fallback="partial_access_key_data",
             )
 
-        # Fallback final: dados extraidos da propria chave
         logger.info(
-            "Todas as APIs falharam para NFe %s. Retornando dados parciais extraidos da chave.",
-            chave[:10],
+            "nfe_lookup_all_sources_failed",
+            chave_prefix=chave[:10],
+            fallback="partial_access_key_data",
         )
         return self._resposta_parcial_da_chave(chave)
 
     async def _consultar_brasil_api(self, chave: str) -> NFeResponse:
-        """Consulta NFe via BrasilAPI (endpoint nfe/v1)."""
-        async with FiscalHTTPClient(BRASIL_API_BASE, rate_limiter=brasil_api_limiter) as client:
-            data: dict[str, Any] = await client.get(  # type: ignore[assignment]
-                f"/nfe/v1/{chave}",
-                rate_limit_key="brasilapi/nfe",
-            )
+        """Look up NFe data through BrasilAPI nfe/v1."""
+        async with self._http_client(settings.brasilapi_base_url) as client:
+            data = await self._get_json_or_text(client, f"/nfe/v1/{chave}")
 
-        # BrasilAPI pode retornar JSON ou XML dependendo do estado
         if isinstance(data, str):
             return parse_nfe_xml(data, chave)
 
-        # Se retornar JSON, mapeia para NFeResponse
         return NFeResponse(
             chave_acesso=chave,
             numero=str(data.get("numero", "")),
@@ -115,37 +142,37 @@ class NFEClient:
 
     async def _consultar_portal_nfe(self, chave: str) -> NFeResponse:
         """
-        Consulta NFe via Portal Nacional da NFe (SEFAZ federal).
+        Look up NFe data through the National NFe Portal.
 
-        O portal oferece consulta publica por chave sem necessidade de certificado digital.
-        Retorna XML da NFe quando disponivel.
+        The portal offers public access key lookup without a digital certificate.
+        It returns NFe XML when available.
         """
-        async with FiscalHTTPClient(PORTAL_NFE_BASE) as client:
-            # Endpoint de consulta resumida publica do Portal NFe
-            data = await client.get(
-                "/consultaRecaptcha.aspx",
+        async with self._http_client(PORTAL_NFE_BASE) as client:
+            data = await self._get_json_or_text(
+                client,
+                PORTAL_NFE_CONSULTA_PATH,
                 params={
                     "tipoConsulta": "completa",
                     "tipoConteudo": "XML",
                     "nfe": chave,
                 },
-                rate_limit_key="portal-nfe/consulta",
             )
 
         if isinstance(data, str) and data.strip():
             return parse_nfe_xml(data, chave)
 
-        raise APIError(
-            message="Portal NFe retornou resposta vazia ou em formato nao suportado",
-            endpoint=PORTAL_NFE_BASE,
+        raise FiscalHTTPError(
+            "Portal NFe retornou resposta vazia ou em formato não suportado",
+            status_code=200,
+            url=PORTAL_NFE_BASE,
         )
 
     def _resposta_parcial_da_chave(self, chave: str) -> NFeResponse:
         """
-        Constroi uma NFeResponse com os dados extraidos da propria chave de acesso.
+        Build an NFeResponse from fields embedded in the access key.
 
-        Util quando nenhuma API consegue fornecer os dados completos. Fornece ao
-        chamador ao menos UF, CNPJ do emitente, numero e serie da nota.
+        This gives callers at least UF, issuer CNPJ, number and series when no
+        external source can return full details.
         """
         info = _extrair_info_chave(chave)
         from .schemas import EnderecoNFe
@@ -157,12 +184,12 @@ class NFEClient:
             serie=info["serie"].lstrip("0") or info["serie"],
             modelo=info["modelo"],
             emitente=emitente,
-            situacao="Dados parciais - consulta indisponivel nas APIs externas",
+            situacao="Dados parciais - consulta indisponível nas APIs externas",
             informacoes_adicionais=(
-                f"UF de emissao: {info['uf']}. "
-                f"Emissao: {info['ano_mes']}. "
-                "Dados completos indisponiveis: BrasilAPI sem cobertura para este estado "
-                "e Portal NFe inacessivel no momento."
+                f"UF de emissão: {info['uf']}. "
+                f"Emissão: {info['ano_mes']}. "
+                "Dados completos indisponíveis: BrasilAPI sem cobertura para este estado "
+                "e Portal NFe inacessível no momento."
             ),
         )
 
@@ -170,18 +197,15 @@ class NFEClient:
         self, uf: str, ambiente: str = "producao"
     ) -> StatusSEFAZResponse:
         """
-        Consulta o status do servico SEFAZ de uma UF.
+        Look up the SEFAZ service status for a state.
 
-        Usa BrasilAPI como proxy para o webservice SEFAZ.
+        BrasilAPI acts as a proxy for the state SEFAZ webservice.
         """
-        logger.info("Consultando status SEFAZ %s (ambiente=%s)", uf, ambiente)
+        logger.info("sefaz_status_lookup_started", uf=uf, ambiente=ambiente)
 
-        async with FiscalHTTPClient(BRASIL_API_BASE, rate_limiter=brasil_api_limiter) as client:
+        async with self._http_client(settings.brasilapi_base_url) as client:
             try:
-                data: dict[str, Any] = await client.get(  # type: ignore[assignment]
-                    f"/nfe/v1/status/{uf.upper()}",
-                    rate_limit_key="brasilapi/nfe-status",
-                )
+                data = await client.get(f"/nfe/v1/status/{uf.upper()}")
                 return StatusSEFAZResponse(
                     uf=uf.upper(),
                     status=data.get("status", "Desconhecido"),
@@ -190,10 +214,9 @@ class NFEClient:
                     ambiente=ambiente,
                 )
             except Exception:
-                # Fallback: retorna status indisponivel se nao conseguir consultar
                 return StatusSEFAZResponse(
                     uf=uf.upper(),
-                    status="Indisponivel",
-                    descricao="Nao foi possivel consultar o status do servico SEFAZ.",
+                    status="Indisponível",
+                    descricao="Não foi possível consultar o status do serviço SEFAZ.",
                     ambiente=ambiente,
                 )

--- a/src/mcp_fiscal_brasil/nfe/tools.py
+++ b/src/mcp_fiscal_brasil/nfe/tools.py
@@ -1,17 +1,26 @@
-"""Ferramentas MCP para NFe."""
+"""MCP tools for NFe lookups and validation."""
 
-import logging
+from mcp_fiscal_brasil._core import FiscalValidationError, get_logger
 
 from ..shared.exceptions import ValidationError
 from ..shared.validators import validate_chave_nfe
 from .client import NFEClient
 from .schemas import NFeResponse, StatusSEFAZResponse
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 _client = NFEClient()
 
-# UFs validas para consulta SEFAZ
+
+class NFeValidationError(FiscalValidationError, ValidationError):
+    """Validation error compatible with both core and legacy exception hierarchies."""
+
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        ValidationError.__init__(self, field=field, value=value, reason=reason)
+        self.detail = dict(self.details)
+
+
+# Valid state abbreviations for SEFAZ lookup.
 UFS_VALIDAS = {
     "AC",
     "AL",
@@ -45,29 +54,30 @@ UFS_VALIDAS = {
 
 async def consultar_nfe(chave_acesso: str) -> NFeResponse:
     """
-    Consulta os dados de uma NFe (Nota Fiscal Eletrônica) pela chave de acesso.
+    Look up NFe (Nota Fiscal Eletrônica) data by access key.
 
-    A chave de acesso tem 44 dígitos e pode ser encontrada no DANFE (documento impresso da nota).
+    The access key has 44 digits and is printed on the DANFE document.
 
     Args:
-        chave_acesso: Chave de acesso da NFe com 44 dígitos (aceita com ou sem espaços)
+        chave_acesso: 44 digit NFe access key, accepted with or without spaces.
 
     Returns:
-        NFeResponse com emitente, destinatário, itens e totais da nota.
+        NFeResponse with issuer, recipient, items and totals.
 
     Raises:
-        ValidationError: Se a chave de acesso for inválida.
-        NotFoundError: Se a NFe não for encontrada.
-        APIError: Em caso de falha no serviço SEFAZ ou APIs consultadas.
+        FiscalValidationError: If the access key is invalid.
+        FiscalNotFoundError: If the NFe is not found.
+        FiscalHTTPError: If SEFAZ or an upstream API fails.
     """
-    # Remove espaços e outros separadores
     chave_limpa = "".join(c for c in chave_acesso if c.isdigit())
 
     if not validate_chave_nfe(chave_limpa):
-        raise ValidationError(
+        raise NFeValidationError(
             field="chave_acesso",
             value=chave_acesso,
-            reason="Chave de acesso NFe inválida. Deve ter 44 dígitos com dígito verificador correto.",
+            reason=(
+                "Chave de acesso NFe inválida. Deve ter 44 dígitos com dígito verificador correto."
+            ),
         )
 
     return await _client.consultar_por_chave(chave_limpa)
@@ -75,15 +85,15 @@ async def consultar_nfe(chave_acesso: str) -> NFeResponse:
 
 async def validar_chave_nfe(chave_acesso: str) -> dict[str, object]:
     """
-    Valida o formato e dígito verificador de uma chave de acesso de NFe.
+    Validate the format and check digit of an NFe access key.
 
-    Não consulta APIs - apenas verifica o cálculo matemático (módulo 11).
+    This does not call external APIs. It only verifies the modulo 11 check digit.
 
     Args:
-        chave_acesso: Chave de acesso com 44 dígitos
+        chave_acesso: 44 digit access key.
 
     Returns:
-        Dicionário com 'valido', 'chave_formatada', 'uf', 'data_emissao', 'cnpj_emitente', 'numero'
+        Dictionary with validity and decoded fields when valid.
     """
     chave_limpa = "".join(c for c in chave_acesso if c.isdigit())
     valido = validate_chave_nfe(chave_limpa)
@@ -115,22 +125,22 @@ async def validar_chave_nfe(chave_acesso: str) -> dict[str, object]:
 
 async def consultar_status_sefaz(uf: str) -> StatusSEFAZResponse:
     """
-    Consulta o status atual do serviço SEFAZ de um estado.
+    Look up the current SEFAZ service status for a state.
 
-    Verifica se o webservice da SEFAZ para emissão de NFe está operacional.
+    Checks whether the SEFAZ NFe issuance webservice is operational.
 
     Args:
-        uf: Sigla do estado (ex: 'SP', 'MG', 'RJ')
+        uf: State abbreviation, for example 'SP', 'MG' or 'RJ'.
 
     Returns:
-        StatusSEFAZResponse com o status atual e descrição.
+        StatusSEFAZResponse with current status and description.
 
     Raises:
-        ValidationError: Se a UF for inválida.
+        FiscalValidationError: If the state abbreviation is invalid.
     """
     uf_upper = uf.upper().strip()
     if uf_upper not in UFS_VALIDAS:
-        raise ValidationError(
+        raise NFeValidationError(
             field="uf",
             value=uf,
             reason=f"UF inválida. Use uma das siglas: {', '.join(sorted(UFS_VALIDAS))}",

--- a/src/mcp_fiscal_brasil/sped/tools.py
+++ b/src/mcp_fiscal_brasil/sped/tools.py
@@ -1,11 +1,11 @@
 """Ferramentas MCP para analise de arquivos SPED."""
 
-import logging
 from datetime import date
 
+from .._core import get_logger
 from .schemas import InfoAberturaSPED, ResumoPeriodoSPED, SPEDAnaliseResponse
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Identificação do tipo de SPED pelo registro 0000 campo tipo_escrituracao
 TIPOS_SPED: dict[str, str] = {
@@ -74,7 +74,7 @@ async def analisar_sped(conteudo: str, nome_arquivo: str | None = None) -> SPEDA
     Returns:
         SPEDAnaliseResponse com resumo do arquivo, informações da empresa e contagem de registros.
     """
-    logger.info("Analisando arquivo SPED: %s", nome_arquivo or "desconhecido")
+    logger.info("sped_analysis_started", nome_arquivo=nome_arquivo or "desconhecido")
 
     abertura: InfoAberturaSPED | None = None
     tipos_registros: dict[str, int] = {}

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1,0 +1,70 @@
+"""Tests for environment driven settings."""
+
+from pathlib import Path
+
+from mcp_fiscal_brasil._core.config import Settings
+
+
+def test_settings_defaults_load_without_env_file() -> None:
+    settings = Settings(_env_file=None)
+
+    assert settings.mcp_fiscal_env == "development"
+    assert settings.mcp_fiscal_log_level == "INFO"
+    assert settings.mcp_fiscal_cache_ttl == 300
+    assert settings.mcp_fiscal_rate_limit == 10
+    assert settings.mcp_fiscal_http_timeout == 30.0
+    assert settings.mcp_fiscal_max_retries == 3
+    assert settings.brasilapi_base_url == "https://brasilapi.com.br/api"
+    assert settings.receita_base_url == "https://receitaws.com.br/v1"
+
+
+def test_settings_env_vars_override_defaults(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("MCP_FISCAL_ENV", "production")
+    monkeypatch.setenv("MCP_FISCAL_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("MCP_FISCAL_CACHE_TTL", "60")
+    monkeypatch.setenv("MCP_FISCAL_RATE_LIMIT", "3")
+    monkeypatch.setenv("MCP_FISCAL_HTTP_TIMEOUT", "5.5")
+    monkeypatch.setenv("MCP_FISCAL_MAX_RETRIES", "4")
+    monkeypatch.setenv("BRASILAPI_BASE_URL", "https://brasilapi.example.test")
+    monkeypatch.setenv("RECEITA_BASE_URL", "https://receita.example.test")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.mcp_fiscal_env == "production"
+    assert settings.mcp_fiscal_log_level == "DEBUG"
+    assert settings.mcp_fiscal_cache_ttl == 60
+    assert settings.mcp_fiscal_rate_limit == 3
+    assert settings.mcp_fiscal_http_timeout == 5.5
+    assert settings.mcp_fiscal_max_retries == 4
+    assert settings.brasilapi_base_url == "https://brasilapi.example.test"
+    assert settings.receita_base_url == "https://receita.example.test"
+
+
+def test_settings_env_file_is_respected(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "MCP_FISCAL_ENV=production",
+                "MCP_FISCAL_LOG_LEVEL=WARNING",
+                "MCP_FISCAL_CACHE_TTL=120",
+                "MCP_FISCAL_RATE_LIMIT=7",
+                "MCP_FISCAL_HTTP_TIMEOUT=9.5",
+                "MCP_FISCAL_MAX_RETRIES=5",
+                "BRASILAPI_BASE_URL=https://brasilapi.env.test",
+                "RECEITA_BASE_URL=https://receita.env.test",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = Settings(_env_file=env_file)
+
+    assert settings.mcp_fiscal_env == "production"
+    assert settings.mcp_fiscal_log_level == "WARNING"
+    assert settings.mcp_fiscal_cache_ttl == 120
+    assert settings.mcp_fiscal_rate_limit == 7
+    assert settings.mcp_fiscal_http_timeout == 9.5
+    assert settings.mcp_fiscal_max_retries == 5
+    assert settings.brasilapi_base_url == "https://brasilapi.env.test"
+    assert settings.receita_base_url == "https://receita.env.test"

--- a/tests/test_core_errors.py
+++ b/tests/test_core_errors.py
@@ -1,0 +1,67 @@
+"""Tests for shared fiscal error types."""
+
+from typing import Any
+
+from mcp_fiscal_brasil._core.errors import (
+    FiscalError,
+    FiscalHTTPError,
+    FiscalNotFoundError,
+    FiscalRateLimitError,
+    FiscalValidationError,
+)
+
+
+def test_fiscal_error_has_message_detail_str_and_repr() -> None:
+    error = FiscalError("Falha fiscal", detail={"source": "test"})
+
+    assert str(error) == "Falha fiscal"
+    assert repr(error) == "FiscalError(message='Falha fiscal', detail={'source': 'test'})"
+    assert error.message == "Falha fiscal"
+    assert error.detail == {"source": "test"}
+
+
+def test_http_error_inherits_fiscal_error_and_exposes_status_url() -> None:
+    error = FiscalHTTPError(
+        "Serviço indisponível",
+        status_code=503,
+        url="https://example.test/api",
+        detail={"attempts": 3},
+    )
+
+    assert isinstance(error, FiscalError)
+    assert str(error) == "Serviço indisponível"
+    assert error.status_code == 503
+    assert error.url == "https://example.test/api"
+    assert "status_code=503" in repr(error)
+    assert "https://example.test/api" in repr(error)
+
+
+def test_rate_limit_error_exposes_retry_after() -> None:
+    error = FiscalRateLimitError("Limite excedido", retry_after=1.5)
+
+    assert isinstance(error, FiscalError)
+    assert error.retry_after == 1.5
+    assert "retry_after=1.5" in repr(error)
+
+
+def test_validation_error_exposes_field_and_value() -> None:
+    value: Any = "00"
+    error = FiscalValidationError("CNPJ inválido", field="cnpj", value=value)
+
+    assert isinstance(error, FiscalError)
+    assert error.field == "cnpj"
+    assert error.value == value
+    assert "field='cnpj'" in repr(error)
+
+
+def test_not_found_error_exposes_resource_type_and_identifier() -> None:
+    error = FiscalNotFoundError(
+        "Empresa não encontrada",
+        resource_type="cnpj",
+        identifier="00000000000000",
+    )
+
+    assert isinstance(error, FiscalError)
+    assert error.resource_type == "cnpj"
+    assert error.identifier == "00000000000000"
+    assert "resource_type='cnpj'" in repr(error)

--- a/tests/test_core_http.py
+++ b/tests/test_core_http.py
@@ -1,0 +1,134 @@
+"""Tests for the shared async HTTP client."""
+
+import asyncio
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from mcp_fiscal_brasil._core import http as core_http
+from mcp_fiscal_brasil._core.errors import FiscalHTTPError
+from mcp_fiscal_brasil._core.http import HTTPClient
+
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def patch_async_client(monkeypatch: pytest.MonkeyPatch, handler: Handler) -> None:
+    original_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(core_http.httpx, "AsyncClient", factory)
+
+
+@pytest.mark.asyncio
+async def test_get_retries_500_and_fails_before_fourth_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls <= 3:
+            return httpx.Response(500, json={"erro": "temporário"})
+        return httpx.Response(200, json={"ok": True})
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", max_retries=3, cache_ttl=0)
+
+    with pytest.raises(FiscalHTTPError) as exc_info:
+        await client.get("/unstable")
+
+    assert calls == 3
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.url == "https://example.test/unstable"
+
+
+@pytest.mark.asyncio
+async def test_get_retries_429_then_returns_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(429, json={"erro": "limite"})
+        return httpx.Response(200, json={"ok": True})
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", max_retries=3, cache_ttl=0)
+
+    result = await client.get("/rate-limited")
+
+    assert result == {"ok": True}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_get_cache_hit_returns_same_object_for_same_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"call": calls, "query": str(request.url.query)})
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", cache_ttl=300)
+
+    first = await client.get("/cached", params={"b": "2", "a": "1"})
+    second = await client.get("/cached", params={"a": "1", "b": "2"})
+
+    assert first is second
+    assert first == {"call": 1, "query": "a=1&b=2"}
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_post_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"call": calls})
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", cache_ttl=300)
+
+    first = await client.post("/submit", json={"a": 1})
+    second = await client.post("/submit", json={"a": 1})
+
+    assert first == {"call": 1}
+    assert second == {"call": 2}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"call": calls})
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", cache_ttl=0, rate_limit_per_second=1)
+
+    start = time.monotonic()
+    first, second = await asyncio.gather(client.get("/one"), client.get("/two"))
+    elapsed = time.monotonic() - start
+
+    assert first == {"call": 1}
+    assert second == {"call": 2}
+    assert elapsed >= 0.9
+    assert calls == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1023,6 +1023,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest-cov" },
+    { name = "types-cachetools" },
 ]
 
 [package.metadata]
@@ -1046,7 +1047,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest-cov", specifier = ">=7.1.0" }]
+dev = [
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "types-cachetools", specifier = ">=7.0.0.20260518" },
+]
 
 [[package]]
 name = "mdurl"
@@ -1929,6 +1933,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "types-cachetools"
+version = "7.0.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/14/1e4fca2b250dbc75be9f0beab083acb3cd1151711e1031eb4a854dfd71be/types_cachetools-7.0.0.20260518.tar.gz", hash = "sha256:7730014e4fef0c6f01e2cd0f980f8ce6d1b1d2472c8459c1f382348ec1a6b435", size = 10072, upload-time = "2026-05-18T06:02:20.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/e0/767be6b60859fd2edc4512fabdedbce703fc8d4ec5007b31abaf37a51c6c/types_cachetools-7.0.0.20260518-py3-none-any.whl", hash = "sha256:997b356870915f8bbc9b2cdb4e7271c01d487996fdac2a9c8e91cc5b1261b3d1", size = 9500, upload-time = "2026-05-18T06:02:19.042Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -242,6 +251,124 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075", size = 219668, upload-time = "2026-05-10T17:59:23.106Z" },
+    { url = "https://files.pythonhosted.org/packages/24/34/898546aefbd28f0af131201d0dc852c9e976f817bd7d5bfb8dc4e02863bb/coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82", size = 220192, upload-time = "2026-05-10T17:59:26.095Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4a/b457c88aca72b0df13a98167ebd5d947135ccd9881ea88ce6a570e13aa9b/coverage-7.14.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0c451757d3fa2603354fdc789b5e58a0e327a117c370a40e3476ba4eabab228c", size = 246932, upload-time = "2026-05-10T17:59:27.806Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893", size = 248762, upload-time = "2026-05-10T17:59:29.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20", size = 250625, upload-time = "2026-05-10T17:59:31.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/03/57afca1b8106f8549a5329139315041fe166d6099bd9381346b9430dfbd1/coverage-7.14.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c7492f2d493b976941c7ca050f273cbda2f43c381124f7586a3e3c16d1804fec", size = 252539, upload-time = "2026-05-10T17:59:32.692Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/2e9fc63c9928119c1dbae02222be51407d3e7ebac5811ebbda4af3557795/coverage-7.14.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc38367eaa2abb1b766ac333142bce7655335a73537f5c8b75aaa89c2b987757", size = 247636, upload-time = "2026-05-10T17:59:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e2/0b7898cda21041cc67546e19b80ba66cbbb47cbece52a76a5904de6a3aaf/coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a", size = 248666, upload-time = "2026-05-10T17:59:36.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e3/d33662a2fdaef23229c15921f39c84ec38441f3069ba26e134ed402c833b/coverage-7.14.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fab3877e4ebb06bd9d4d4d00ee53309ee5478e66873c66a382272e3ee33eb7ea", size = 246670, upload-time = "2026-05-10T17:59:38.029Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b2/533942c3bfbf6770b5c32d7f2ff029fe013dba31f3fe8b45cabbb250365e/coverage-7.14.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:b812eb847b19876ebf33fb6c4f11819af05ab6050b0bfa1bc53412ae81779adb", size = 250484, upload-time = "2026-05-10T17:59:39.974Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/00/15acbad83a96de13c73831486c7627bfed73dfaec53b04e4a6315edf3fd8/coverage-7.14.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d9c8ef6ed820c433de075657d72dda1f89a2984955e58b8a75feb3f184250218", size = 246942, upload-time = "2026-05-10T17:59:41.659Z" },
+    { url = "https://files.pythonhosted.org/packages/70/db/cef0228de493f2c740c760a9057a61d00c6849480073b70a75b87c7d4bab/coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85", size = 247544, upload-time = "2026-05-10T17:59:43.471Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a0/d9ef8e148f3025c2ae8401d77cda1502b6d2a4d8102603a8af31460aedb6/coverage-7.14.0-cp310-cp310-win32.whl", hash = "sha256:65f267ca1370726ec2c1aa38bbe4df9a71a740f22878d2d4bf59d71a4cd8d323", size = 222285, upload-time = "2026-05-10T17:59:44.908Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c0/30c454c7d3cf47b2805d4e06f12443f5eece8a5d030d3b0350e7b74ecb49/coverage-7.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a", size = 223215, upload-time = "2026-05-10T17:59:46.779Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480", size = 219795, upload-time = "2026-05-10T17:59:48.198Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8d/46692d24b3f395d4cbf17bfcc57136b4f2f9c0c0df864b0bddfc1d71a014/coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4", size = 220299, upload-time = "2026-05-10T17:59:49.683Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c2/a40f5cb295bbcbb697a76947a56081c494c61950366294ee426ffe261099/coverage-7.14.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d8e1762f0e9cbc26ec315471e7b47855218e833cd5a032d706fbf43845d878c7", size = 250721, upload-time = "2026-05-10T17:59:51.494Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed", size = 252633, upload-time = "2026-05-10T17:59:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980", size = 254743, upload-time = "2026-05-10T17:59:55.021Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/6d/0d178825be2350f0adb27984d0aa7cf84bbdab201f6fb926b535d23a8f5f/coverage-7.14.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d1bb3543b58fea74d2cd1abc4054cc927e4724687cb4560cd2ed88d2c7d820c0", size = 256700, upload-time = "2026-05-10T17:59:56.511Z" },
+    { url = "https://files.pythonhosted.org/packages/19/5b/9e549c2f6e9dfea472adadba06c294e64735dabc2dd19015fac082095013/coverage-7.14.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a93bac2cb577ef60074999ed56d8a1535894398e2ed920d4185c3ec0c8864742", size = 250854, upload-time = "2026-05-10T17:59:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5", size = 252433, upload-time = "2026-05-10T17:59:59.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cb/d192cd8e1345eccabc32016f2d39072ecd10cb4f4b983ed8d0ebdeaf00dc/coverage-7.14.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:741f57cddc9004a8c81b084660215f33a6b597dbe62c31386b983ee26310e327", size = 250494, upload-time = "2026-05-10T18:00:01.953Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c5/aac9f460a41d835dbddef1d377f105f6ac2311d0f3c1588e9f51046d8813/coverage-7.14.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:664123feb0929d7affc135717dbd70d61d98688a08ab1e5ba464739620c6252d", size = 254261, upload-time = "2026-05-10T18:00:03.779Z" },
+    { url = "https://files.pythonhosted.org/packages/23/aa/7af7c0081980a9cb3d289c5a435a4b7657dcecbd128e25c580e6a50389b5/coverage-7.14.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c83d2399a51bbec8429266905d33616f04bc5726b1138c35844d5fcd896b2e20", size = 250216, upload-time = "2026-05-10T18:00:05.262Z" },
+    { url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c", size = 251125, upload-time = "2026-05-10T18:00:06.858Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ab/f91af47642ec1aa53490e835a95847168d9c77fc39aa58527604c051e145/coverage-7.14.0-cp311-cp311-win32.whl", hash = "sha256:731dc15b385ac52289743d476245b61e1a2927e803bef655b52bc3b2a75a21f3", size = 222300, upload-time = "2026-05-10T18:00:08.608Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f0/a71ddbd874431e7a7cd96071f0c331cfbbad07704833c765d24ffbab8a67/coverage-7.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1", size = 223241, upload-time = "2026-05-10T18:00:10.746Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/6e/d9d312a5151a96cd110efee32efc3fc97b01ebd86203fe618ccb29cf4c92/coverage-7.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:7ebb1c6df9f78046a1b1e0a89674cd4bf73b7c648914eebcf976a57fd99a5627", size = 221908, upload-time = "2026-05-10T18:00:12.242Z" },
+    { url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5", size = 219967, upload-time = "2026-05-10T18:00:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662", size = 220329, upload-time = "2026-05-10T18:00:15.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cf/a8f4b43a16e194b0261257ad28ded5853ec052570afef4a84e1d81189f3b/coverage-7.14.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b4f07cf7edcb7ec39431a5074d7ea83b29a9f71fcfc494f0f40af4e65180420f", size = 251839, upload-time = "2026-05-10T18:00:17.16Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67", size = 254576, upload-time = "2026-05-10T18:00:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9", size = 255690, upload-time = "2026-05-10T18:00:20.648Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5af63f636cc62a4a2b1b3ba9146f6ee6f53a35a50d5cefc54d5670f60999/coverage-7.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b2bb6c9d7e769360d0f20a0f219603fd64f0c8f97de17ab25853261602be0fb", size = 257949, upload-time = "2026-05-10T18:00:22.28Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d3/a225317bd2012132a27e1176d51660b826f99bb975876463c44ea0d7ee5a/coverage-7.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c9ed6ef99f88fb8c14aa8e2bf8eb0fe55fa2edfea68f8675d78741df1a5ac0e", size = 252242, upload-time = "2026-05-10T18:00:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3", size = 253608, upload-time = "2026-05-10T18:00:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/1522b524a35bdad22b2b8c4f9d32d0a104b524726ec380b2db68db1746f5/coverage-7.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8b013632cc1ce1d09dbe4f32667b4d320ec2f54fc326ebeffcd0b0bcc2bb6c4", size = 251753, upload-time = "2026-05-10T18:00:27.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/cdf00d38817742c541ade405e115a3f7bf36e6f2a8b99d4f209861b85a2d/coverage-7.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1733198802d71ec4c524f322e2867ee05c62e9e75df86bdca545407a221827d1", size = 255823, upload-time = "2026-05-10T18:00:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fc/5e7877cf5f902d08a17ff1c532511476d87e1bea355bd5028cb97f902e79/coverage-7.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:72a305291fa8ee01332f1aaf38b348ca34097f6aa0b0ef627eef2837e57bbba5", size = 251323, upload-time = "2026-05-10T18:00:30.647Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595", size = 253197, upload-time = "2026-05-10T18:00:32.211Z" },
+    { url = "https://files.pythonhosted.org/packages/00/3f/6f61ffe6439df266c3cf60f5c99cfaa21103d0210d706a42fc6c30683ff8/coverage-7.14.0-cp312-cp312-win32.whl", hash = "sha256:5ac83957a80d0701310e96d8bec68cdcf4f90a7674b7d13f15a344315b41ab27", size = 222515, upload-time = "2026-05-10T18:00:33.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2", size = 223324, upload-time = "2026-05-10T18:00:35.172Z" },
+    { url = "https://files.pythonhosted.org/packages/74/18/9f7fe62f659f24b7a82a0be56bf94c1bd0a89e0ae7ab4c668f6e82404294/coverage-7.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:91b993743d959b8be85b4abf9d5478216a69329c321efe5be0433c1a841d691d", size = 221944, upload-time = "2026-05-10T18:00:37.014Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef", size = 219990, upload-time = "2026-05-10T18:00:38.887Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66", size = 220365, upload-time = "2026-05-10T18:00:40.864Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6f/9ad575d505b4d805b254febc8a5b338a2efe278f8786e56ff1cb8413f9c3/coverage-7.14.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:22a7e06a5f11a757cdfe79018e9095f9f69ae283c5cd8123774c788deec8717b", size = 251363, upload-time = "2026-05-10T18:00:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca", size = 253961, upload-time = "2026-05-10T18:00:44.079Z" },
+    { url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7", size = 255193, upload-time = "2026-05-10T18:00:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7b/5bfd7ac1df3b881c2ac7a5cbc99c7609e6296c402f5ef587cd81c6f355b3/coverage-7.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a841fae2fadcae4f438d43b6ccc4aac2ad609f47cdb6cfdce60cbb3fe5ca7bc2", size = 257326, upload-time = "2026-05-10T18:00:47.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/38/1d37d316b174fad3843a1d76dbdfe4398771c9ecd0515935dd9ece9cd627/coverage-7.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c79d2319cabef1fe8e86df73371126931550804738f78ad7d31e3aad85a67367", size = 251582, upload-time = "2026-05-10T18:00:49.152Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9", size = 253325, upload-time = "2026-05-10T18:00:51.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b9/bbe87206d9687b192352f893797825b5f5b15ecd3aa9c68fbff0c074d77b/coverage-7.14.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:55d3089079ce181a4566b1065ab28d2575eb76d8ac8f81f4fcda2bf037fee087", size = 251291, upload-time = "2026-05-10T18:00:52.816Z" },
+    { url = "https://files.pythonhosted.org/packages/46/57/b8cdb12ac0d73ef0243218bd5e22c9df8f92edab8018213a86aec67c5324/coverage-7.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:49c005cba1e2f9677fb2845dcdf9a2e72a52a17d63e8231aaaae35d9f50215ef", size = 255448, upload-time = "2026-05-10T18:00:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/5002019538b2036ce3c84340f54d2fd5100d55b0a6b0894eee56128d03c7/coverage-7.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9117377b823daa28aa8635fbb08cda1cd6be3d7143257345459559aeef852d52", size = 251110, upload-time = "2026-05-10T18:00:56.122Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe", size = 252885, upload-time = "2026-05-10T18:00:57.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ab/3cf6427ac9c1f1db747dbb1ce71dde47984876d4c2cfd018a3fef0a78d4d/coverage-7.14.0-cp313-cp313-win32.whl", hash = "sha256:fb609b3658479e33f9516d46f1a89dbb9b6c261366e3a11844a96ec487533dae", size = 222539, upload-time = "2026-05-10T18:00:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e", size = 223344, upload-time = "2026-05-10T18:01:01.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/99/118daa192f95e3a6cb2740100fbf8797cda1734b4134ef0b5d501a7fa8f3/coverage-7.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:b4e26a0f1b696faf283bffe5b8569e44e336c582439df5d53281ab89ee0cba96", size = 221966, upload-time = "2026-05-10T18:01:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f1/a46cc0c013be170216253184a32366d7cbdb9252feaec866b05c2d12a894/coverage-7.14.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:953f521ca9445300397e65fda3dca58b2dbd68fee983777420b57ac3c77e9f90", size = 220679, upload-time = "2026-05-10T18:01:05.058Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8c/9c30a3d311a34177fa432995be7fbfc64477d8bac5630bd38055b1c9b424/coverage-7.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:98af83fd65ae24b1fdd03aaead967a9f523bcd2f1aab2d4f3ffda65bb568a6f1", size = 221033, upload-time = "2026-05-10T18:01:07.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/3fb5e06c3badefd0c1b47e2044fdca67f8220a4ec2e7fcfb476aa0a67c6c/coverage-7.14.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:668b92e6958c4db7cf92e81caac328dfbbdbb215db2850ad28f0cbe1eea0bfbd", size = 262333, upload-time = "2026-05-10T18:01:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e6/fbc322325c7294d3e22c1ad6b79e45d0806b25228c8e5842aed6d8169aa7/coverage-7.14.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9fbd898551762dea00d3fef2b1c4f99afd2c6a3ff952ea07d60a9bd5ed4f34bc", size = 264410, upload-time = "2026-05-10T18:01:10.531Z" },
+    { url = "https://files.pythonhosted.org/packages/08/92/c497b264bec1673c47cc77e26f760fcda4654cabf1f39546d1a23a3b8c35/coverage-7.14.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68af363c07ecd8d4b7d4043d85cb376d7d227eceb54e5323ee45da73dbd3e426", size = 266836, upload-time = "2026-05-10T18:01:12.19Z" },
+    { url = "https://files.pythonhosted.org/packages/78/fc/045da320987f401af5d2815d351e8aa799aec859f60e29f445e3089eeedb/coverage-7.14.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e57054a583da8ac55edf24117ea4c9133032cfc4cf72aa2d48c1e5d4b52f899", size = 267974, upload-time = "2026-05-10T18:01:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ae/227b1e379497fb7a4fc3286e620f80c8a1e7cec66d45695a01639eb1af65/coverage-7.14.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3499459bbcdd51a65b64c35ab7ed2764eaf3cba826e0df3f1d7fe2e102b70b", size = 261578, upload-time = "2026-05-10T18:01:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f5/3570342900f2acea31d33ff1590c5d8bac1a8e1a2e1c6d34a5d5e61de681/coverage-7.14.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:45899ec2138a4346ed34d601dedf5076fb74edf2d1dd9dc76a78e82397edee90", size = 264394, upload-time = "2026-05-10T18:01:17.607Z" },
+    { url = "https://files.pythonhosted.org/packages/16/29/de1bbc01c935b28f89b1dc3db85b011c055e843a8e5e3b83141c3f80af7f/coverage-7.14.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8767486808c436f05b23ab98eb963fb29185e32a9357a166971685cb3459900f", size = 262022, upload-time = "2026-05-10T18:01:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/35/95/f53890b0bf2fc10ab168e05d38869215e73ca24c4cb521c3bb0eb62fe16b/coverage-7.14.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a3b5ddfd6aa7ddad53ee3edb231e88a2151507a43229b7d71b953916deca127d", size = 265732, upload-time = "2026-05-10T18:01:21.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ea/c919e259081dd2bdf0e43b87209709ba7ec2e4117c2a7f5185379c43463c/coverage-7.14.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:63df0fe568e698e1045792399f8ab6da3a6c2dce3182813fb92afa2641087b47", size = 260921, upload-time = "2026-05-10T18:01:23.533Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2c/c2831889705a81dc5d1c6ca12e4d8e9b95dfc146d153488a6c0ea685d28e/coverage-7.14.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:827d6397dbd95144939b18f89edf31f63e1f99633e8d5f32f22ba8bdda567477", size = 263109, upload-time = "2026-05-10T18:01:25.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a9/2fcae5003cac3d63fe344d2166243c2756935f48420863c5272b240d550b/coverage-7.14.0-cp313-cp313t-win32.whl", hash = "sha256:7bf43e000d24012599b879791cff41589af90674722421ef11b11a5431920bab", size = 223212, upload-time = "2026-05-10T18:01:27.157Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/bb/18e94d7b14b9b398164197114a587a04ab7c9fdbe1d237eef57311c5e883/coverage-7.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3f5549365af25d770e06b1f8f5682d9a5637d06eb494db91c6fa75d3950cc917", size = 224272, upload-time = "2026-05-10T18:01:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/db/56/4f14fad782b035c81c4ffd09159e7103d42bb1d93ac8496d04b90a11b7da/coverage-7.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6d160217ec6fe890f16ad3a9531761589443749e448f91986c972714fad361c8", size = 222530, upload-time = "2026-05-10T18:01:31.151Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
+    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -872,11 +999,16 @@ name = "mcp-fiscal-brasil"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiolimiter" },
+    { name = "cachetools" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "lxml" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-dateutil" },
+    { name = "structlog" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -888,20 +1020,33 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-cov" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "aiolimiter", specifier = ">=1.2.1" },
+    { name = "cachetools", specifier = ">=7.0.5" },
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "lxml", specifier = ">=5.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "tenacity", specifier = ">=9.1.4" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-cov", specifier = ">=7.1.0" }]
 
 [[package]]
 name = "mdurl"
@@ -1325,6 +1470,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1695,6 +1854,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adiciona pacote \`_core\` com infraestrutura reutilizável para todos os módulos do mcp-fiscal-brasil.

## O que foi adicionado

- \`_core/http.py\`: HTTPClient assíncrono (httpx) com retry automático (tenacity, exponential backoff), cache TTL por endpoint (cachetools), rate limiting por host (aiolimiter)
- \`_core/logging.py\`: logging estruturado via structlog - JSON em produção, console colorido em dev
- \`_core/config.py\`: configuração centralizada via pydantic-settings, todas as variáveis com prefixo \`MCP_FISCAL_*\`
- \`_core/errors.py\`: hierarquia de erros tipada - FiscalError, FiscalHTTPError, FiscalRateLimitError, FiscalValidationError, FiscalNotFoundError

## Refatorações

- \`cnpj/\`, \`nfe/\`, \`sped/\`: substituem chamadas httpx diretas e logging manual pelo _core. APIs públicas preservadas.

## Testes e qualidade

- 63 testes passando (inclui 3 novos arquivos test_core_*.py)
- 91% cobertura no pacote _core
- mypy strict limpo
- ruff format + check limpos