### PR TITLE
feat(agentic): tools de alto nivel para agentes de IA (fase 3 v0.2.0)

### DIFF
--- a/src/mcp_fiscal_brasil/agentic/__init__.py
+++ b/src/mcp_fiscal_brasil/agentic/__init__.py
@@ -1,0 +1,37 @@
+"""Ferramentas de alto nivel orientadas a agentes de IA.
+
+O modulo `agentic` reune tools compostas que combinam multiplos clientes
+de baixo nivel (cnpj, simples, cnae, certidoes, nfe, sped) em respostas
+estruturadas otimizadas para uso por LLMs (Claude, GPT, Gemini).
+
+Cada tool expoe:
+- Inputs simples (CNPJ, XML path, lista de fornecedores)
+- Outputs ricos via pydantic (campos auto-documentados)
+- Docstrings detalhadas com exemplos
+"""
+
+from .compliance import analyze_cnpj_compliance
+from .nfe import validate_nfe_full
+from .regimes import compare_tax_regimes
+from .schemas import (
+    ComplianceReport,
+    NFeValidationReport,
+    SPEDSummary,
+    SupplierRiskScore,
+    TaxRegimeComparison,
+)
+from .sped import summarize_sped
+from .supplier import risk_score_supplier
+
+__all__ = [
+    "ComplianceReport",
+    "NFeValidationReport",
+    "SPEDSummary",
+    "SupplierRiskScore",
+    "TaxRegimeComparison",
+    "analyze_cnpj_compliance",
+    "compare_tax_regimes",
+    "risk_score_supplier",
+    "summarize_sped",
+    "validate_nfe_full",
+]

--- a/src/mcp_fiscal_brasil/agentic/compliance.py
+++ b/src/mcp_fiscal_brasil/agentic/compliance.py
@@ -1,0 +1,207 @@
+"""Analise consolidada de compliance fiscal de um CNPJ."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from mcp_fiscal_brasil._core import get_logger
+
+from ..cnpj.client import CNPJClient
+from ..mei.client import MEIClient
+from ..simples.client import SimplesClient
+from .schemas import ComplianceFinding, ComplianceReport, RiskLevel
+
+logger = get_logger(__name__)
+
+
+_SITUACAO_RISCOS: dict[str, RiskLevel] = {
+    "ativa": "baixo",
+    "ativo": "baixo",
+    "suspensa": "medio",
+    "inapta": "alto",
+    "baixada": "critico",
+    "nula": "critico",
+}
+
+
+async def _consultar_seguro(coro: Any, fonte: str) -> tuple[str, Any | None]:
+    """Executa coroutine retornando None em qualquer falha (sem bloquear analise)."""
+    try:
+        result = await coro
+        return fonte, result
+    except Exception as exc:
+        logger.warning("compliance_source_failed", fonte=fonte, error=str(exc))
+        return fonte, None
+
+
+def _risco_situacao(situacao: str | None) -> tuple[RiskLevel, str]:
+    if not situacao:
+        return "medio", "Situacao cadastral nao retornada pela fonte"
+    chave = situacao.strip().lower()
+    for k, risco in _SITUACAO_RISCOS.items():
+        if k in chave:
+            return risco, situacao
+    return "medio", situacao
+
+
+def _score_de_risco(risco: RiskLevel) -> int:
+    return {"baixo": 90, "medio": 60, "alto": 30, "critico": 5}[risco]
+
+
+def _consolida_risco(achados: list[ComplianceFinding]) -> RiskLevel:
+    if not achados:
+        return "baixo"
+    severidades = [a.severidade for a in achados]
+    if "critico" in severidades:
+        return "critico"
+    if "alto" in severidades:
+        return "alto"
+    if "medio" in severidades:
+        return "medio"
+    return "baixo"
+
+
+async def analyze_cnpj_compliance(cnpj: str) -> ComplianceReport:
+    """
+    Analise consolidada de compliance fiscal de um CNPJ brasileiro.
+
+    Consulta em paralelo: dados cadastrais (Receita), regime Simples Nacional,
+    status MEI, CNAE principal e secundarios. Retorna um relatorio unico com
+    score 0-100, risco classificado e achados acionaveis.
+
+    Args:
+        cnpj: CNPJ com ou sem formatacao (so digitos sao usados).
+
+    Returns:
+        ComplianceReport com risco_geral, score, achados e resumo executivo.
+
+    Exemplo de uso por um agente:
+        report = await analyze_cnpj_compliance("12.345.678/0001-90")
+        if report.risco_geral in ("alto", "critico"):
+            # bloquear cadastro de fornecedor
+            ...
+
+    Nota:
+        Esta tool NAO consulta certidoes negativas reais (somente gera URLs).
+        Para validacao de certidoes use as ferramentas especificas do modulo certidoes.
+    """
+    cnpj_limpo = "".join(c for c in cnpj if c.isdigit())
+    if len(cnpj_limpo) != 14:
+        raise ValueError(f"CNPJ deve ter 14 digitos, recebido {len(cnpj_limpo)}: {cnpj}")
+
+    logger.info("compliance_analysis_started", cnpj=cnpj_limpo)
+
+    cnpj_client = CNPJClient()
+    simples_client = SimplesClient()
+    mei_client = MEIClient()
+
+    resultados = await asyncio.gather(
+        _consultar_seguro(cnpj_client.consultar(cnpj_limpo), "cnpj"),
+        _consultar_seguro(simples_client.get_simples_status(cnpj_limpo), "simples"),
+        _consultar_seguro(mei_client.get_mei_status(cnpj_limpo), "mei"),
+    )
+    dados = dict(resultados)
+
+    cnpj_data = dados.get("cnpj")
+    simples_data = dados.get("simples")
+    mei_data = dados.get("mei")
+
+    if cnpj_data is None:
+        raise RuntimeError(
+            f"Nao foi possivel consultar dados do CNPJ {cnpj_limpo} em nenhuma fonte"
+        )
+
+    achados: list[ComplianceFinding] = []
+    fontes_ok: list[str] = []
+
+    # Situacao cadastral
+    risco_sit, situacao_str = _risco_situacao(cnpj_data.situacao_cadastral)
+    if risco_sit != "baixo":
+        achados.append(
+            ComplianceFinding(
+                categoria="situacao_cadastral",
+                severidade=risco_sit,
+                titulo=f"Situacao cadastral: {situacao_str}",
+                detalhe=f"Empresa esta classificada como '{situacao_str}' na Receita Federal.",
+                recomendacao=(
+                    "Confirmar regularizacao antes de contratar"
+                    if risco_sit in ("alto", "critico")
+                    else "Monitorar evolucao da situacao"
+                ),
+            )
+        )
+    fontes_ok.append(getattr(cnpj_data, "origem", "Receita"))
+
+    # Regime tributario
+    if simples_data is not None:
+        fontes_ok.append("Simples Nacional")
+        if not simples_data.optante and simples_data.optante is not None:
+            achados.append(
+                ComplianceFinding(
+                    categoria="regime_tributario",
+                    severidade="baixo",
+                    titulo="Nao optante pelo Simples Nacional",
+                    detalhe="Empresa nao consta como optante do Simples Nacional.",
+                )
+            )
+
+    if mei_data is not None:
+        fontes_ok.append("MEI Receita")
+
+    # CNAE - sem flag por enquanto, mas registra como achado informativo
+    if cnpj_data.atividade_principal:
+        codigo = cnpj_data.atividade_principal.codigo
+        descricao = cnpj_data.atividade_principal.descricao
+        achados.append(
+            ComplianceFinding(
+                categoria="atividade",
+                severidade="baixo",
+                titulo=f"CNAE principal {codigo}",
+                detalhe=descricao,
+            )
+        )
+
+    # Endereco basico
+    if not cnpj_data.endereco or not cnpj_data.endereco.municipio:
+        achados.append(
+            ComplianceFinding(
+                categoria="endereco",
+                severidade="medio",
+                titulo="Endereco incompleto",
+                detalhe="Endereco cadastral incompleto ou nao retornado pela fonte.",
+                recomendacao="Solicitar comprovante de endereco atualizado.",
+            )
+        )
+
+    # QSA vazio
+    if not cnpj_data.qsa:
+        achados.append(
+            ComplianceFinding(
+                categoria="qsa",
+                severidade="medio",
+                titulo="Quadro de socios nao disponivel",
+                detalhe="QSA nao retornado, dificultando due diligence de socios.",
+                recomendacao="Solicitar contrato social atualizado.",
+            )
+        )
+
+    risco_geral = _consolida_risco(achados)
+    score = _score_de_risco(risco_geral)
+
+    resumo = (
+        f"CNPJ {cnpj_limpo} ({cnpj_data.razao_social}) apresenta risco "
+        f"{risco_geral} (score {score}/100). "
+        f"Situacao: {cnpj_data.situacao_cadastral or 'nao informada'}. "
+        f"Foram identificados {len(achados)} achado(s) na analise."
+    )
+
+    return ComplianceReport(
+        cnpj=cnpj_limpo,
+        razao_social=cnpj_data.razao_social,
+        risco_geral=risco_geral,
+        score=score,
+        achados=achados,
+        resumo_executivo=resumo,
+        fontes_consultadas=fontes_ok,
+    )

--- a/src/mcp_fiscal_brasil/agentic/nfe.py
+++ b/src/mcp_fiscal_brasil/agentic/nfe.py
@@ -1,0 +1,136 @@
+"""Validacao consolidada de NFe (XML + chave + emissor)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcp_fiscal_brasil._core import get_logger
+
+from ..cnpj.client import CNPJClient
+from ..nfe.tools import validar_chave_nfe
+from ..nfe.xml_parser import parse_nfe_xml
+from .schemas import NFeValidationIssue, NFeValidationReport
+
+logger = get_logger(__name__)
+
+
+async def validate_nfe_full(xml_path: str | Path) -> NFeValidationReport:
+    """
+    Validacao consolidada de uma NFe (XML).
+
+    Executa em sequencia:
+    1. Parse estrutural do XML (lxml)
+    2. Validacao do digito verificador da chave de acesso
+    3. Verificacao do CNPJ emissor (situacao ativa via Receita)
+
+    Args:
+        xml_path: Caminho para arquivo XML da NFe.
+
+    Returns:
+        NFeValidationReport com chave, validade, issues e resumo.
+
+    Exemplo:
+        report = await validate_nfe_full("/tmp/nota.xml")
+        if not report.valida_estruturalmente or report.issues:
+            # rejeitar nota
+            ...
+    """
+    path = Path(xml_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Arquivo XML nao encontrado: {xml_path}")
+
+    issues: list[NFeValidationIssue] = []
+    xml_content = path.read_bytes()
+
+    valida_estrut = False
+    chave_acesso = ""
+    cnpj_emissor: str | None = None
+    cnpj_destinatario: str | None = None
+    valor_total: float | None = None
+    data_emissao = None
+    nfe_data = None
+
+    try:
+        # Chave temporaria, parser preenche corretamente
+        nfe_data = parse_nfe_xml(xml_content, chave="")
+        chave_acesso = nfe_data.chave_acesso or ""
+        cnpj_emissor = getattr(nfe_data.emitente, "cnpj", None) if nfe_data.emitente else None
+        cnpj_destinatario = (
+            getattr(nfe_data.destinatario, "cnpj", None) if nfe_data.destinatario else None
+        )
+        valor_total = nfe_data.totais.valor_nota if nfe_data.totais else None
+        data_emissao = nfe_data.data_emissao.date() if nfe_data.data_emissao else None
+        valida_estrut = True
+    except Exception as exc:
+        issues.append(
+            NFeValidationIssue(
+                severidade="critico",
+                codigo="XML_PARSE_ERROR",
+                descricao=f"Falha ao parsear XML: {exc}",
+            )
+        )
+
+    # Validacao da chave
+    chave_consistente = False
+    if chave_acesso:
+        try:
+            chave_result = await validar_chave_nfe(chave_acesso)
+            chave_consistente = bool(chave_result.get("valida", False))
+            if not chave_consistente:
+                issues.append(
+                    NFeValidationIssue(
+                        severidade="alto",
+                        codigo="CHAVE_INVALIDA",
+                        descricao="Digito verificador da chave de acesso nao confere.",
+                        campo="chave_acesso",
+                    )
+                )
+        except Exception as exc:
+            issues.append(
+                NFeValidationIssue(
+                    severidade="medio",
+                    codigo="CHAVE_VALIDACAO_FALHOU",
+                    descricao=f"Nao foi possivel validar chave: {exc}",
+                )
+            )
+
+    # Verificacao do emissor
+    emissor_ativo: bool | None = None
+    if cnpj_emissor:
+        try:
+            cnpj_client = CNPJClient()
+            emissor_data = await cnpj_client.consultar(cnpj_emissor)
+            situacao = (emissor_data.situacao_cadastral or "").lower()
+            emissor_ativo = "ativ" in situacao
+            if not emissor_ativo:
+                issues.append(
+                    NFeValidationIssue(
+                        severidade="alto",
+                        codigo="EMISSOR_INATIVO",
+                        descricao=f"CNPJ emissor com situacao '{emissor_data.situacao_cadastral}'.",
+                        campo="emit/CNPJ",
+                    )
+                )
+        except Exception as exc:
+            logger.warning("nfe_emissor_lookup_failed", error=str(exc))
+            emissor_ativo = None
+
+    if valida_estrut and not issues:
+        resumo = f"NFe valida estruturalmente, chave {chave_acesso} consistente, emissor ativo."
+    elif valida_estrut:
+        resumo = f"NFe parseou ok mas tem {len(issues)} issue(s) ({issues[0].codigo})."
+    else:
+        resumo = "NFe falhou no parse XML. Verifique arquivo e schema."
+
+    return NFeValidationReport(
+        chave_acesso=chave_acesso,
+        valida_estruturalmente=valida_estrut,
+        chave_consistente=chave_consistente,
+        emissor_ativo=emissor_ativo,
+        issues=issues,
+        cnpj_emissor=cnpj_emissor,
+        cnpj_destinatario=cnpj_destinatario,
+        valor_total=valor_total,
+        data_emissao=data_emissao,
+        resumo=resumo,
+    )

--- a/src/mcp_fiscal_brasil/agentic/regimes.py
+++ b/src/mcp_fiscal_brasil/agentic/regimes.py
@@ -1,0 +1,255 @@
+"""Comparativo entre regimes tributarios brasileiros.
+
+Calculo simplificado, baseado em premissas publicas e tabelas vigentes em 2025.
+Nao substitui parecer de contador. Util para estimativa rapida e direcionamento.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from .schemas import TaxRegimeComparison, TaxRegimeOption
+
+_LIMITE_MEI = 81_000.0
+_LIMITE_SIMPLES = 4_800_000.0
+_LIMITE_LUCRO_PRESUMIDO = 78_000_000.0
+
+
+def _calc_simples(
+    faturamento: float,
+    setor: Literal["comercio", "servicos", "industria"],
+    folha: float | None,
+) -> tuple[bool, float | None, float | None, str | None]:
+    if faturamento > _LIMITE_SIMPLES:
+        return (
+            False,
+            None,
+            None,
+            "Faturamento excede o limite anual do Simples Nacional (R$ 4,8 milhoes).",
+        )
+
+    # Aliquotas efetivas simplificadas por anexo (medias por faixa)
+    if setor == "comercio":
+        # Anexo I - aliquota efetiva media
+        if faturamento <= 180_000:
+            aliquota = 4.0
+        elif faturamento <= 360_000:
+            aliquota = 7.3
+        elif faturamento <= 720_000:
+            aliquota = 9.5
+        elif faturamento <= 1_800_000:
+            aliquota = 10.7
+        elif faturamento <= 3_600_000:
+            aliquota = 14.3
+        else:
+            aliquota = 19.0
+    elif setor == "industria":
+        # Anexo II - 0.5pp acima do comercio em geral
+        if faturamento <= 180_000:
+            aliquota = 4.5
+        elif faturamento <= 360_000:
+            aliquota = 7.8
+        elif faturamento <= 720_000:
+            aliquota = 10.0
+        elif faturamento <= 1_800_000:
+            aliquota = 11.2
+        elif faturamento <= 3_600_000:
+            aliquota = 14.7
+        else:
+            aliquota = 30.0
+    else:  # servicos
+        # Anexo III ou V conforme Fator R (folha / faturamento >= 0.28)
+        fator_r = (folha or 0) / faturamento if faturamento > 0 else 0
+        if fator_r >= 0.28:
+            # Anexo III
+            if faturamento <= 180_000:
+                aliquota = 6.0
+            elif faturamento <= 360_000:
+                aliquota = 11.2
+            elif faturamento <= 720_000:
+                aliquota = 13.5
+            elif faturamento <= 1_800_000:
+                aliquota = 16.0
+            elif faturamento <= 3_600_000:
+                aliquota = 21.0
+            else:
+                aliquota = 33.0
+        else:
+            # Anexo V (servicos sem folha relevante)
+            if faturamento <= 180_000:
+                aliquota = 15.5
+            elif faturamento <= 360_000:
+                aliquota = 18.0
+            elif faturamento <= 720_000:
+                aliquota = 19.5
+            elif faturamento <= 1_800_000:
+                aliquota = 20.5
+            elif faturamento <= 3_600_000:
+                aliquota = 23.0
+            else:
+                aliquota = 30.5
+
+    imposto = faturamento * aliquota / 100
+    return True, aliquota, imposto, None
+
+
+def _calc_lucro_presumido(
+    faturamento: float, setor: Literal["comercio", "servicos", "industria"]
+) -> tuple[bool, float | None, float | None, str | None]:
+    if faturamento > _LIMITE_LUCRO_PRESUMIDO:
+        return (
+            False,
+            None,
+            None,
+            "Faturamento excede o limite anual do Lucro Presumido (R$ 78 milhoes).",
+        )
+    # Presuncao de lucro
+    if setor == "servicos":
+        presuncao = 0.32
+    else:
+        presuncao = 0.08
+    base_irpj = faturamento * presuncao
+    irpj = base_irpj * 0.15
+    csll = base_irpj * 0.09
+    # PIS+COFINS regime cumulativo
+    pis_cofins = faturamento * 0.0365
+    # ISS estimado (servicos) ou ICMS estimado (comercio/industria)
+    if setor == "servicos":
+        outros = faturamento * 0.05  # ISS medio
+    else:
+        outros = faturamento * 0.12  # ICMS medio com beneficios
+    total = irpj + csll + pis_cofins + outros
+    aliquota_efetiva = total / faturamento * 100
+    return True, aliquota_efetiva, total, None
+
+
+def _calc_lucro_real_simplificado(
+    faturamento: float, setor: Literal["comercio", "servicos", "industria"]
+) -> tuple[bool, float | None, float | None, str | None]:
+    # Estimativa muito grosseira: margem operacional 15% (lucro liquido)
+    margem = 0.15
+    lucro = faturamento * margem
+    irpj = lucro * 0.15
+    adicional = max(0.0, lucro - 240_000) * 0.10
+    csll = lucro * 0.09
+    pis_cofins = faturamento * 0.0925  # nao-cumulativo
+    if setor == "servicos":
+        outros = faturamento * 0.05
+    else:
+        outros = faturamento * 0.12
+    total = irpj + adicional + csll + pis_cofins + outros
+    aliquota_efetiva = total / faturamento * 100
+    return True, aliquota_efetiva, total, None
+
+
+def _calc_mei(
+    faturamento: float, setor: Literal["comercio", "servicos", "industria"]
+) -> tuple[bool, float | None, float | None, str | None]:
+    if faturamento > _LIMITE_MEI:
+        return False, None, None, "Faturamento excede o limite anual do MEI (R$ 81 mil)."
+    # Valor mensal MEI 2025 ~ R$ 75 comercio/industria, R$ 80 servicos
+    mensal = 80 if setor == "servicos" else 75
+    total = mensal * 12
+    aliquota_efetiva = total / faturamento * 100 if faturamento else 0
+    return True, aliquota_efetiva, total, None
+
+
+def compare_tax_regimes(
+    faturamento_anual: float,
+    setor: Literal["comercio", "servicos", "industria"],
+    folha_pagamento_anual: float | None = None,
+) -> TaxRegimeComparison:
+    """
+    Compara regimes tributarios brasileiros (MEI, Simples, Lucro Presumido, Lucro Real).
+
+    Estimativa rapida baseada em tabelas publicas vigentes. NAO substitui parecer
+    de contador. Util para direcionamento em decisoes de planejamento tributario.
+
+    Args:
+        faturamento_anual: Receita bruta anual em reais.
+        setor: Setor da empresa (impacta anexo do Simples e presuncoes do LP).
+        folha_pagamento_anual: Folha anual em reais. Importante para Fator R no Simples
+            (servicos): se folha/faturamento >= 28%, usa Anexo III (mais barato).
+
+    Returns:
+        TaxRegimeComparison com opcoes avaliadas, melhor regime e economia estimada.
+
+    Exemplo:
+        resultado = compare_tax_regimes(
+            faturamento_anual=500_000,
+            setor="servicos",
+            folha_pagamento_anual=180_000,
+        )
+        print(resultado.melhor_opcao)  # "simples_nacional"
+        print(resultado.economia_anual_vs_pior)  # economia vs pior opcao
+    """
+    if faturamento_anual <= 0:
+        raise ValueError("faturamento_anual deve ser positivo")
+
+    opcoes_calc = [
+        ("mei", _calc_mei(faturamento_anual, setor)),
+        ("simples_nacional", _calc_simples(faturamento_anual, setor, folha_pagamento_anual)),
+        ("lucro_presumido", _calc_lucro_presumido(faturamento_anual, setor)),
+        ("lucro_real", _calc_lucro_real_simplificado(faturamento_anual, setor)),
+    ]
+
+    opcoes: list[TaxRegimeOption] = []
+    for regime, (aplicavel, aliquota, imposto, motivo) in opcoes_calc:
+        pros: list[str] = []
+        contras: list[str] = []
+        if regime == "mei":
+            pros = ["Tributacao fixa mensal", "Burocracia minima"]
+            contras = ["Limite baixo de faturamento", "Restrito a algumas atividades"]
+        elif regime == "simples_nacional":
+            pros = ["Recolhimento unificado (DAS)", "Aliquotas progressivas"]
+            contras = ["Limite de R$ 4,8 mi anual", "Limitacoes em servicos especificos"]
+        elif regime == "lucro_presumido":
+            pros = ["Calculo simples", "Aproveitamento de margens altas"]
+            contras = ["PIS/COFINS cumulativos", "Pode pagar imposto sobre lucro inexistente"]
+        else:
+            pros = [
+                "Sem teto de faturamento",
+                "PIS/COFINS nao-cumulativos com creditos",
+                "Imposto sobre lucro real",
+            ]
+            contras = [
+                "Burocracia alta (escrituracao completa)",
+                "Custo contabil maior",
+                "Antecipacoes mensais",
+            ]
+        opcoes.append(
+            TaxRegimeOption(
+                regime=regime,
+                aplicavel=aplicavel,
+                motivo_inaplicavel=motivo,
+                aliquota_efetiva_estimada=aliquota,
+                imposto_anual_estimado=imposto,
+                pros=pros,
+                contras=contras,
+            )
+        )
+
+    aplicaveis = [o for o in opcoes if o.aplicavel and o.imposto_anual_estimado is not None]
+    if not aplicaveis:
+        raise RuntimeError("Nenhum regime aplicavel ao cenario fornecido")
+
+    aplicaveis.sort(key=lambda o: o.imposto_anual_estimado or float("inf"))
+    melhor = aplicaveis[0]
+    pior_aplicavel = aplicaveis[-1]
+    economia = (pior_aplicavel.imposto_anual_estimado or 0) - (melhor.imposto_anual_estimado or 0)
+
+    obs = (
+        "Estimativa simplificada usando tabelas publicas vigentes em 2025. "
+        "Considera presuncoes medias de ICMS/ISS. Nao inclui beneficios estaduais nem "
+        "regimes especiais. Consulte contador para decisao final."
+    )
+
+    return TaxRegimeComparison(
+        cenario_faturamento_anual=faturamento_anual,
+        cenario_setor=setor,
+        folha_pagamento_anual=folha_pagamento_anual,
+        opcoes=[*aplicaveis, *(o for o in opcoes if not o.aplicavel)],
+        melhor_opcao=melhor.regime,
+        economia_anual_vs_pior=economia,
+        observacoes=obs,
+    )

--- a/src/mcp_fiscal_brasil/agentic/schemas.py
+++ b/src/mcp_fiscal_brasil/agentic/schemas.py
@@ -1,0 +1,170 @@
+"""Schemas de saida das tools agenticas.
+
+Cada modelo e desenhado para ser auto-explicativo quando serializado para
+um LLM. Campos com `description` rica ajudam o agente a entender o significado
+sem precisar consultar documentacao externa.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+RiskLevel = Literal["baixo", "medio", "alto", "critico"]
+
+
+class ComplianceFinding(BaseModel):
+    """Um achado isolado de uma analise de compliance fiscal."""
+
+    categoria: Literal[
+        "situacao_cadastral",
+        "regime_tributario",
+        "atividade",
+        "endereco",
+        "certidoes",
+        "qsa",
+    ] = Field(description="Categoria do achado dentro da analise.")
+    severidade: RiskLevel = Field(description="Severidade do achado.")
+    titulo: str = Field(description="Resumo curto do achado.")
+    detalhe: str = Field(description="Descricao detalhada explicando o porque.")
+    recomendacao: str | None = Field(
+        default=None, description="Acao sugerida ao operador, quando aplicavel."
+    )
+
+
+class ComplianceReport(BaseModel):
+    """Relatorio agregado de compliance fiscal de um CNPJ.
+
+    Combina dados de CNPJ, Simples Nacional, MEI, CNAE e certidoes em uma
+    visao unica orientada a decisao (contratar, recusar, investigar).
+    """
+
+    cnpj: str = Field(description="CNPJ analisado (somente digitos).")
+    razao_social: str = Field(description="Razao social conforme Receita Federal.")
+    risco_geral: RiskLevel = Field(description="Risco consolidado da empresa.")
+    score: int = Field(
+        ge=0,
+        le=100,
+        description="Score de 0 (critico) a 100 (excelente). Combina situacao, regime, atividade.",
+    )
+    achados: list[ComplianceFinding] = Field(
+        default_factory=list, description="Lista de achados detalhados."
+    )
+    resumo_executivo: str = Field(
+        description="Paragrafo unico em pt-BR resumindo a situacao para um humano."
+    )
+    fontes_consultadas: list[str] = Field(
+        default_factory=list,
+        description="Fontes que responderam com sucesso (ex: BrasilAPI, ReceitaWS).",
+    )
+
+
+class TaxRegimeOption(BaseModel):
+    """Comparativo de um regime tributario para um cenario especifico."""
+
+    regime: Literal["simples_nacional", "lucro_presumido", "lucro_real", "mei"]
+    aplicavel: bool = Field(description="Se o regime e legalmente acessivel ao perfil.")
+    motivo_inaplicavel: str | None = Field(
+        default=None,
+        description="Quando aplicavel=False, motivo curto (ex: faturamento excede limite).",
+    )
+    aliquota_efetiva_estimada: float | None = Field(
+        default=None,
+        description="Aliquota efetiva estimada (%) sobre faturamento, considerando anexo/setor.",
+    )
+    imposto_anual_estimado: float | None = Field(
+        default=None, description="Imposto anual estimado em reais para o cenario fornecido."
+    )
+    pros: list[str] = Field(default_factory=list, description="Vantagens do regime.")
+    contras: list[str] = Field(default_factory=list, description="Desvantagens do regime.")
+
+
+class TaxRegimeComparison(BaseModel):
+    """Comparativo entre regimes tributarios para um cenario."""
+
+    cenario_faturamento_anual: float = Field(
+        description="Faturamento anual usado no calculo (reais)."
+    )
+    cenario_setor: Literal["comercio", "servicos", "industria"] = Field(
+        description="Setor da empresa (impacta anexo do Simples)."
+    )
+    folha_pagamento_anual: float | None = Field(
+        default=None, description="Folha de pagamento anual usada no Fator R (opcional)."
+    )
+    opcoes: list[TaxRegimeOption] = Field(
+        description="Opcoes avaliadas, do mais ao menos vantajoso."
+    )
+    melhor_opcao: Literal["simples_nacional", "lucro_presumido", "lucro_real", "mei"] = Field(
+        description="Regime recomendado considerando aplicabilidade e custo."
+    )
+    economia_anual_vs_pior: float = Field(
+        description="Economia anual estimada do melhor versus pior regime aplicavel."
+    )
+    observacoes: str = Field(
+        description="Notas qualitativas: limitacoes do calculo, premissas, alertas."
+    )
+
+
+class SupplierRiskScore(BaseModel):
+    """Score de risco de um fornecedor para due diligence."""
+
+    cnpj: str
+    razao_social: str
+    risco: RiskLevel
+    score: int = Field(ge=0, le=100, description="0=critico, 100=excelente.")
+    fatores: list[str] = Field(
+        description="Fatores que contribuiram para o score (positivos e negativos)."
+    )
+    recomendacao: Literal["aprovar", "aprovar_com_ressalvas", "investigar", "recusar"] = Field(
+        description="Recomendacao binaria/quaternaria de contratacao."
+    )
+    data_analise: date = Field(default_factory=date.today)
+
+
+class NFeValidationIssue(BaseModel):
+    """Problema individual detectado em validacao de NFe."""
+
+    severidade: RiskLevel
+    codigo: str = Field(description="Codigo curto do tipo de problema (ex: CHAVE_INVALIDA).")
+    descricao: str
+    campo: str | None = Field(default=None, description="Campo XML afetado, se aplicavel.")
+
+
+class NFeValidationReport(BaseModel):
+    """Relatorio completo de validacao de uma NFe (XML)."""
+
+    chave_acesso: str = Field(description="Chave de 44 digitos.")
+    valida_estruturalmente: bool = Field(description="XML bem-formado e schema-compatible.")
+    chave_consistente: bool = Field(description="Digito verificador da chave bate com o conteudo.")
+    emissor_ativo: bool | None = Field(
+        default=None, description="Se conseguiu confirmar emissor ativo via CNPJ lookup."
+    )
+    issues: list[NFeValidationIssue] = Field(default_factory=list)
+    cnpj_emissor: str | None = None
+    cnpj_destinatario: str | None = None
+    valor_total: float | None = None
+    data_emissao: date | None = None
+    resumo: str = Field(description="Sumario em uma frase do estado da NFe.")
+
+
+class SPEDSummary(BaseModel):
+    """Sumario executivo de um arquivo SPED."""
+
+    arquivo: str = Field(description="Nome do arquivo SPED analisado.")
+    tipo: Literal["fiscal", "contribuicoes", "ecf", "ecd"] = Field(description="Tipo do SPED.")
+    periodo_inicio: date | None = None
+    periodo_fim: date | None = None
+    total_registros: int = Field(ge=0, description="Numero total de registros validos.")
+    total_blocos: int = Field(ge=0)
+    cnpj: str | None = None
+    razao_social: str | None = None
+    inconsistencias: list[str] = Field(
+        default_factory=list, description="Inconsistencias estruturais encontradas."
+    )
+    metricas_chave: dict[str, float] = Field(
+        default_factory=dict,
+        description="Metricas extraidas (ex: faturamento total, total icms, total pis_cofins).",
+    )
+    resumo: str = Field(description="Paragrafo executivo em pt-BR.")

--- a/src/mcp_fiscal_brasil/agentic/sped.py
+++ b/src/mcp_fiscal_brasil/agentic/sped.py
@@ -1,0 +1,107 @@
+"""Sumarizacao executiva de arquivos SPED."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from mcp_fiscal_brasil._core import get_logger
+
+from ..sped.tools import analisar_sped
+from .schemas import SPEDSummary
+
+logger = get_logger(__name__)
+
+
+_TIPO_MAP: dict[str, Literal["fiscal", "contribuicoes", "ecf", "ecd"]] = {
+    "EFD-ICMS-IPI": "fiscal",
+    "EFD-Contribuicoes": "contribuicoes",
+    "ECD": "ecd",
+    "ECF": "ecf",
+}
+
+
+async def summarize_sped(file_path: str | Path) -> SPEDSummary:
+    """
+    Sumarizacao executiva de um arquivo SPED.
+
+    Le o arquivo, identifica tipo (Fiscal, Contribuicoes, ECF, ECD), extrai
+    periodo, empresa, total de registros e produz resumo em pt-BR.
+
+    Args:
+        file_path: Caminho para arquivo .txt do SPED.
+
+    Returns:
+        SPEDSummary com periodo, empresa, metricas e resumo executivo.
+
+    Exemplo:
+        sumario = await summarize_sped("/tmp/sped_fiscal_201912.txt")
+        print(sumario.resumo)
+        for metrica, valor in sumario.metricas_chave.items():
+            print(f"{metrica}: {valor}")
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Arquivo SPED nao encontrado: {file_path}")
+
+    conteudo = path.read_text(encoding="latin-1")
+    analise = await analisar_sped(conteudo, nome_arquivo=path.name)
+
+    tipo_norm = _TIPO_MAP.get(analise.tipo_sped, "fiscal")
+
+    cnpj = None
+    razao = None
+    periodo_ini = None
+    periodo_fim = None
+    total_registros = 0
+    tipos_registros: dict[str, int] = {}
+
+    if analise.abertura:
+        cnpj = analise.abertura.cnpj
+        razao = analise.abertura.nome_empresarial
+
+    if analise.resumo:
+        periodo_ini = analise.resumo.periodo_inicial
+        periodo_fim = analise.resumo.periodo_final
+        total_registros = analise.resumo.total_registros
+        tipos_registros = analise.resumo.tipos_registros
+        if not cnpj:
+            cnpj = analise.resumo.cnpj
+        if not razao:
+            razao = analise.resumo.razao_social
+
+    total_blocos = len({k[0] for k in tipos_registros if k})
+
+    metricas: dict[str, float] = {
+        "total_registros": float(total_registros),
+        "tipos_distintos": float(len(tipos_registros)),
+    }
+
+    inconsistencias = list(analise.erros) + [f"AVISO: {a}" for a in analise.avisos]
+
+    periodo_str = ""
+    if periodo_ini and periodo_fim:
+        periodo_str = f" entre {periodo_ini.isoformat()} e {periodo_fim.isoformat()}"
+    elif periodo_ini:
+        periodo_str = f" iniciado em {periodo_ini.isoformat()}"
+
+    empresa_str = f" para {razao}" if razao else ""
+    resumo = (
+        f"Arquivo SPED {analise.tipo_sped}{empresa_str}{periodo_str}: "
+        f"{total_registros} registros validos em {total_blocos} blocos. "
+        f"{len(inconsistencias)} inconsistencia(s) identificada(s)."
+    )
+
+    return SPEDSummary(
+        arquivo=path.name,
+        tipo=tipo_norm,
+        periodo_inicio=periodo_ini,
+        periodo_fim=periodo_fim,
+        total_registros=total_registros,
+        total_blocos=total_blocos,
+        cnpj=cnpj,
+        razao_social=razao,
+        inconsistencias=inconsistencias,
+        metricas_chave=metricas,
+        resumo=resumo,
+    )

--- a/src/mcp_fiscal_brasil/agentic/supplier.py
+++ b/src/mcp_fiscal_brasil/agentic/supplier.py
@@ -1,0 +1,84 @@
+"""Score de risco de fornecedor combinando compliance + heuristica."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from .compliance import analyze_cnpj_compliance
+from .schemas import SupplierRiskScore
+
+
+def _recomendacao(
+    score: int,
+) -> Literal["aprovar", "aprovar_com_ressalvas", "investigar", "recusar"]:
+    if score >= 80:
+        return "aprovar"
+    if score >= 60:
+        return "aprovar_com_ressalvas"
+    if score >= 30:
+        return "investigar"
+    return "recusar"
+
+
+async def risk_score_supplier(cnpj: str, criterios_estritos: bool = False) -> SupplierRiskScore:
+    """
+    Calcula score de risco para due diligence de fornecedor.
+
+    Baseia-se em ComplianceReport e aplica ajustes para o contexto de
+    contratacao de fornecedor (mais conservador que compliance geral).
+
+    Args:
+        cnpj: CNPJ do fornecedor (com ou sem formatacao).
+        criterios_estritos: Se True, reduz tolerancia (subtrai 10 pontos do score).
+            Usar quando contratante tem politica anti-corrupcao agressiva.
+
+    Returns:
+        SupplierRiskScore com recomendacao acionavel.
+
+    Exemplo:
+        score = await risk_score_supplier("12.345.678/0001-90", criterios_estritos=True)
+        if score.recomendacao == "recusar":
+            # bloquear cadastro
+            ...
+    """
+    compliance = await analyze_cnpj_compliance(cnpj)
+
+    score = compliance.score
+    fatores: list[str] = []
+
+    if compliance.risco_geral == "baixo":
+        fatores.append("Situacao cadastral regular")
+    if compliance.razao_social:
+        fatores.append(f"Empresa identificada: {compliance.razao_social}")
+
+    for achado in compliance.achados:
+        if achado.severidade in ("alto", "critico"):
+            score -= 15
+            fatores.append(f"NEGATIVO: {achado.titulo}")
+        elif achado.severidade == "medio":
+            score -= 5
+            fatores.append(f"Atencao: {achado.titulo}")
+
+    if criterios_estritos:
+        score -= 10
+        fatores.append("Criterios estritos aplicados (-10)")
+
+    score = max(0, min(100, score))
+
+    if score >= 80:
+        risco = "baixo"
+    elif score >= 60:
+        risco = "medio"
+    elif score >= 30:
+        risco = "alto"
+    else:
+        risco = "critico"
+
+    return SupplierRiskScore(
+        cnpj=compliance.cnpj,
+        razao_social=compliance.razao_social,
+        risco=risco,
+        score=score,
+        fatores=fatores,
+        recomendacao=_recomendacao(score),
+    )

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -10,6 +10,13 @@ from typing import Any
 from fastmcp import FastMCP
 
 from . import __version__
+from .agentic import (
+    analyze_cnpj_compliance,
+    compare_tax_regimes,
+    risk_score_supplier,
+    summarize_sped,
+    validate_nfe_full,
+)
 from .certidoes.tools import consultar_certidao_federal, consultar_certidao_fgts
 
 # Importa todas as ferramentas dos modulos fiscais
@@ -262,6 +269,96 @@ async def tool_consultar_certidao_federal(cnpj_cpf: str) -> dict[str, str]:
 async def tool_consultar_certidao_fgts(cnpj: str) -> dict[str, str]:
     """Orienta consulta de CRF do FGTS."""
     return await consultar_certidao_fgts(cnpj)
+
+
+# ---------------------------------------------------------------------------
+# Agentic (tools de alto nivel orientadas a IA)
+# ---------------------------------------------------------------------------
+
+
+@app.tool(
+    name="analyze_cnpj_compliance",
+    description=(
+        "Analise consolidada de compliance fiscal de um CNPJ. "
+        "Combina dados cadastrais (Receita), regime tributario (Simples Nacional), "
+        "status MEI e CNAE em um relatorio unico com score 0-100, risco classificado "
+        "(baixo/medio/alto/critico) e achados acionaveis. "
+        "Use para decisao de contratar/recusar/investigar uma empresa em uma chamada."
+    ),
+)
+async def tool_analyze_cnpj_compliance(cnpj: str) -> dict[str, Any]:
+    """Analise consolidada de compliance fiscal."""
+    resultado = await analyze_cnpj_compliance(cnpj)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="compare_tax_regimes",
+    description=(
+        "Compara regimes tributarios brasileiros (MEI, Simples Nacional, Lucro Presumido, "
+        "Lucro Real) para um cenario de faturamento e setor. Retorna estimativa de aliquota "
+        "efetiva, imposto anual e melhor opcao. Util para planejamento tributario rapido. "
+        "Setor: comercio, servicos ou industria. Folha opcional impacta Fator R no Simples."
+    ),
+)
+async def tool_compare_tax_regimes(
+    faturamento_anual: float,
+    setor: str,
+    folha_pagamento_anual: float | None = None,
+) -> dict[str, Any]:
+    """Compara regimes tributarios para um cenario."""
+    if setor not in ("comercio", "servicos", "industria"):
+        raise ValueError("setor deve ser: comercio, servicos ou industria")
+    resultado = compare_tax_regimes(
+        faturamento_anual=faturamento_anual,
+        setor=setor,  # type: ignore[arg-type]
+        folha_pagamento_anual=folha_pagamento_anual,
+    )
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="risk_score_supplier",
+    description=(
+        "Calcula score de risco (0-100) para due diligence de fornecedor. "
+        "Combina ComplianceReport com ajustes conservadores para contratacao. "
+        "Retorna recomendacao binaria (aprovar/aprovar_com_ressalvas/investigar/recusar). "
+        "Opcao criterios_estritos=true reduz score em 10 para politicas anti-corrupcao."
+    ),
+)
+async def tool_risk_score_supplier(cnpj: str, criterios_estritos: bool = False) -> dict[str, Any]:
+    """Score de risco para due diligence de fornecedor."""
+    resultado = await risk_score_supplier(cnpj, criterios_estritos)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="validate_nfe_full",
+    description=(
+        "Validacao consolidada de uma NFe a partir do XML: parse estrutural, validacao "
+        "do digito verificador da chave, verificacao de situacao do CNPJ emissor. "
+        "Recebe caminho de arquivo XML local. Retorna relatorio com chave, validade, "
+        "issues e resumo."
+    ),
+)
+async def tool_validate_nfe_full(xml_path: str) -> dict[str, Any]:
+    """Validacao consolidada de NFe."""
+    resultado = await validate_nfe_full(xml_path)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="summarize_sped",
+    description=(
+        "Sumarizacao executiva de um arquivo SPED (Fiscal, Contribuicoes, ECF ou ECD). "
+        "Identifica tipo, extrai periodo, empresa, total de registros, blocos e produz "
+        "resumo em pt-BR. Recebe caminho de arquivo .txt local."
+    ),
+)
+async def tool_summarize_sped(file_path: str) -> dict[str, Any]:
+    """Sumarizacao executiva de arquivo SPED."""
+    resultado = await summarize_sped(file_path)
+    return resultado.model_dump(mode="json", exclude_none=True)
 
 
 def main() -> None:

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -1,0 +1,266 @@
+"""Testes das tools agenticas (alto nivel)."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_fiscal_brasil.agentic import (
+    analyze_cnpj_compliance,
+    compare_tax_regimes,
+    risk_score_supplier,
+)
+from mcp_fiscal_brasil.agentic.regimes import (
+    _calc_lucro_presumido,
+    _calc_mei,
+    _calc_simples,
+)
+from mcp_fiscal_brasil.agentic.schemas import (
+    ComplianceReport,
+    TaxRegimeComparison,
+)
+from mcp_fiscal_brasil.cnpj.schemas import AtividadeCNAE, CNPJResponse
+from mcp_fiscal_brasil.shared.schemas import Endereco
+
+
+def _cnpj_ativo() -> CNPJResponse:
+    return CNPJResponse(
+        cnpj="12345678000190",
+        razao_social="EMPRESA TESTE LTDA",
+        nome_fantasia="Teste",
+        situacao_cadastral="ATIVA",
+        natureza_juridica="206-2",
+        porte="Pequena",
+        capital_social=10000.0,
+        data_abertura=date(2020, 1, 1),
+        atividade_principal=AtividadeCNAE(
+            codigo="6201500", descricao="Desenvolvimento de software"
+        ),
+        atividades_secundarias=[],
+        endereco=Endereco(
+            logradouro="Rua A",
+            numero="100",
+            bairro="Centro",
+            municipio="Goiania",
+            uf="GO",
+            cep="74000000",
+        ),
+        telefone=None,
+        email=None,
+        qsa=[],
+        origem="BrasilAPI",
+    )
+
+
+def _cnpj_baixado() -> CNPJResponse:
+    return CNPJResponse(
+        cnpj="98765432000100",
+        razao_social="EMPRESA INATIVA",
+        nome_fantasia=None,
+        situacao_cadastral="BAIXADA",
+        natureza_juridica="206-2",
+        porte=None,
+        capital_social=None,
+        atividade_principal=None,
+        atividades_secundarias=[],
+        endereco=Endereco(),
+        telefone=None,
+        email=None,
+        qsa=[],
+        origem="BrasilAPI",
+    )
+
+
+# ---------------------------------------------------------------------------
+# analyze_cnpj_compliance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compliance_empresa_ativa() -> None:
+    with (
+        patch("mcp_fiscal_brasil.agentic.compliance.CNPJClient") as mock_cnpj_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.SimplesClient") as mock_simples_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.MEIClient") as mock_mei_class,
+    ):
+        cnpj_inst = MagicMock()
+        cnpj_inst.consultar = AsyncMock(return_value=_cnpj_ativo())
+        mock_cnpj_class.return_value = cnpj_inst
+
+        simples_inst = MagicMock()
+        simples_inst.get_simples_status = AsyncMock(side_effect=Exception("offline"))
+        mock_simples_class.return_value = simples_inst
+
+        mei_inst = MagicMock()
+        mei_inst.get_mei_status = AsyncMock(side_effect=Exception("offline"))
+        mock_mei_class.return_value = mei_inst
+
+        report = await analyze_cnpj_compliance("12.345.678/0001-90")
+
+    assert isinstance(report, ComplianceReport)
+    assert report.cnpj == "12345678000190"
+    assert report.risco_geral in ("baixo", "medio")
+    assert report.score >= 50
+    assert "BrasilAPI" in report.fontes_consultadas
+
+
+@pytest.mark.asyncio
+async def test_compliance_empresa_baixada_eleva_risco() -> None:
+    with (
+        patch("mcp_fiscal_brasil.agentic.compliance.CNPJClient") as mock_cnpj_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.SimplesClient") as mock_simples_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.MEIClient") as mock_mei_class,
+    ):
+        cnpj_inst = MagicMock()
+        cnpj_inst.consultar = AsyncMock(return_value=_cnpj_baixado())
+        mock_cnpj_class.return_value = cnpj_inst
+        mock_simples_class.return_value = MagicMock(
+            get_simples_status=AsyncMock(side_effect=Exception())
+        )
+        mock_mei_class.return_value = MagicMock(get_mei_status=AsyncMock(side_effect=Exception()))
+
+        report = await analyze_cnpj_compliance("98765432000100")
+
+    assert report.risco_geral == "critico"
+    assert report.score < 30
+    assert any(a.categoria == "situacao_cadastral" for a in report.achados)
+
+
+@pytest.mark.asyncio
+async def test_compliance_cnpj_invalido_levanta() -> None:
+    with pytest.raises(ValueError, match="14 digitos"):
+        await analyze_cnpj_compliance("123")
+
+
+# ---------------------------------------------------------------------------
+# compare_tax_regimes
+# ---------------------------------------------------------------------------
+
+
+def test_compare_tax_regimes_servicos_pequena_empresa() -> None:
+    resultado = compare_tax_regimes(
+        faturamento_anual=300_000,
+        setor="servicos",
+        folha_pagamento_anual=120_000,
+    )
+    assert isinstance(resultado, TaxRegimeComparison)
+    assert resultado.melhor_opcao in ("simples_nacional", "mei")
+    assert resultado.economia_anual_vs_pior >= 0
+    assert len(resultado.opcoes) >= 3
+
+
+def test_compare_tax_regimes_grande_empresa_exclui_simples() -> None:
+    resultado = compare_tax_regimes(
+        faturamento_anual=10_000_000,
+        setor="industria",
+        folha_pagamento_anual=2_000_000,
+    )
+    simples = next(o for o in resultado.opcoes if o.regime == "simples_nacional")
+    assert not simples.aplicavel
+    assert "limite" in (simples.motivo_inaplicavel or "").lower()
+    assert resultado.melhor_opcao in ("lucro_presumido", "lucro_real")
+
+
+def test_compare_tax_regimes_faturamento_negativo_levanta() -> None:
+    with pytest.raises(ValueError):
+        compare_tax_regimes(faturamento_anual=-100, setor="comercio")
+
+
+def test_calc_mei_dentro_limite() -> None:
+    aplicavel, _aliq, imposto, motivo = _calc_mei(60_000, "comercio")
+    assert aplicavel is True
+    assert imposto is not None
+    assert imposto < 1500
+    assert motivo is None
+
+
+def test_calc_mei_excede_limite() -> None:
+    aplicavel, _aliq, _imposto, motivo = _calc_mei(100_000, "servicos")
+    assert aplicavel is False
+    assert motivo is not None
+    assert "81" in motivo
+
+
+def test_calc_simples_fator_r_servicos() -> None:
+    # Folha alta -> anexo III (mais barato)
+    aplicavel_alto, aliq_alto, _imp_alto, _ = _calc_simples(500_000, "servicos", 200_000)
+    # Folha baixa -> anexo V (mais caro)
+    aplicavel_baixo, aliq_baixo, _imp_baixo, _ = _calc_simples(500_000, "servicos", 10_000)
+    assert aplicavel_alto and aplicavel_baixo
+    assert aliq_alto is not None and aliq_baixo is not None
+    assert aliq_alto < aliq_baixo
+
+
+def test_calc_lucro_presumido_aplicavel() -> None:
+    aplicavel, _aliq, imp, motivo = _calc_lucro_presumido(2_000_000, "comercio")
+    assert aplicavel is True
+    assert imp is not None
+    assert motivo is None
+
+
+# ---------------------------------------------------------------------------
+# risk_score_supplier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_risk_score_supplier_empresa_ativa_aprovado() -> None:
+    with patch("mcp_fiscal_brasil.agentic.supplier.analyze_cnpj_compliance") as mock_compliance:
+        mock_compliance.return_value = ComplianceReport(
+            cnpj="12345678000190",
+            razao_social="EMPRESA TESTE LTDA",
+            risco_geral="baixo",
+            score=92,
+            achados=[],
+            resumo_executivo="Empresa regular.",
+            fontes_consultadas=["BrasilAPI"],
+        )
+        resultado = await risk_score_supplier("12.345.678/0001-90")
+    assert resultado.recomendacao == "aprovar"
+    assert resultado.score >= 80
+
+
+@pytest.mark.asyncio
+async def test_risk_score_supplier_criterios_estritos_reduz_score() -> None:
+    with patch("mcp_fiscal_brasil.agentic.supplier.analyze_cnpj_compliance") as mock_compliance:
+        mock_compliance.return_value = ComplianceReport(
+            cnpj="12345678000190",
+            razao_social="EMPRESA TESTE LTDA",
+            risco_geral="baixo",
+            score=85,
+            achados=[],
+            resumo_executivo="Regular.",
+            fontes_consultadas=["BrasilAPI"],
+        )
+        normal = await risk_score_supplier("12.345.678/0001-90", criterios_estritos=False)
+        estrito = await risk_score_supplier("12.345.678/0001-90", criterios_estritos=True)
+    assert estrito.score == normal.score - 10
+    assert any("Criterios estritos" in f for f in estrito.fatores)
+
+
+@pytest.mark.asyncio
+async def test_risk_score_supplier_empresa_baixada_recusa() -> None:
+    with patch("mcp_fiscal_brasil.agentic.supplier.analyze_cnpj_compliance") as mock_compliance:
+        from mcp_fiscal_brasil.agentic.schemas import ComplianceFinding
+
+        mock_compliance.return_value = ComplianceReport(
+            cnpj="98765432000100",
+            razao_social="INATIVA",
+            risco_geral="critico",
+            score=5,
+            achados=[
+                ComplianceFinding(
+                    categoria="situacao_cadastral",
+                    severidade="critico",
+                    titulo="Empresa baixada",
+                    detalhe="Baixada na Receita.",
+                )
+            ],
+            resumo_executivo="Critico.",
+            fontes_consultadas=["BrasilAPI"],
+        )
+        resultado = await risk_score_supplier("98765432000100")
+    assert resultado.recomendacao == "recusar"
+    assert resultado.risco == "critico"


### PR DESCRIPTION
## Resumo

Fase 3 do roadmap v0.2.0. Adiciona modulo `src/mcp_fiscal_brasil/agentic/` com 5 tools compostas pensadas para uso por agentes de IA (Claude, GPT, Gemini).

## Tools entregues

| Tool | Funcao |
|------|--------|
| `analyze_cnpj_compliance` | Relatorio consolidado (CNPJ + Simples + MEI + CNAE) com score 0-100 e risco classificado |
| `compare_tax_regimes` | Comparativo MEI/Simples/Lucro Presumido/Lucro Real com aliquota efetiva e imposto anual |
| `risk_score_supplier` | Due diligence de fornecedor com recomendacao (aprovar / aprovar_com_ressalvas / investigar / recusar) |
| `validate_nfe_full` | Validacao consolidada de NFe (parse XML + chave + situacao do emissor) |
| `summarize_sped` | Sumario executivo de arquivo SPED (tipo, periodo, empresa, registros) |

Todas registradas no servidor MCP em `server.py`.

## Qualidade

- 13 testes novos cobrindo cenarios chave (empresa ativa, empresa baixada, Fator R do Simples, criterios estritos de supplier, edge cases)
- Suite completa: **101/101 passando**
- `ruff check` e `ruff format --check`: limpos
- `mypy --strict` no modulo agentic: zero erros

## Notas tecnicas

- Schemas pydantic com `description` ricas em cada campo, otimizando serializacao para LLMs
- `asyncio.gather` com captura de excecoes individuais em `analyze_cnpj_compliance` (uma fonte offline nao bloqueia a analise)
- Calculo de regimes baseado em tabelas publicas vigentes 2025, NAO substitui parecer contabil

## Branch base

`main` (atualizado, contendo PRs #7 #8 #9 ja merged)