### PR TITLE
feat(interfaces): CLI, REST API, Web UI demo e npm wrapper (fase 4)

### DIFF
--- a/npm-wrapper/.gitignore
+++ b/npm-wrapper/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -1,0 +1,69 @@
+# mcp-fiscal-brasil (Node.js wrapper)
+
+Wrapper Node.js/TypeScript para o pacote Python [`mcp-fiscal-brasil`](https://github.com/nikolasdehor/mcp-fiscal-brasil).
+
+Permite consultar dados fiscais brasileiros (CNPJ, NFe, SPED, Simples Nacional, compliance) em apps JavaScript/TypeScript chamando o CLI Python por baixo.
+
+## Pre-requisitos
+
+O CLI Python precisa estar instalado e disponivel no PATH:
+
+```bash
+pipx install mcp-fiscal-brasil
+# ou
+uv tool install mcp-fiscal-brasil
+```
+
+Confirme com `mcp-fiscal --help`.
+
+## Instalacao
+
+```bash
+npm install mcp-fiscal-brasil
+```
+
+## Uso programatico
+
+```ts
+import { lookupCNPJ, analyzeCompliance, compareRegimes } from "mcp-fiscal-brasil";
+
+const empresa = await lookupCNPJ("12345678000190");
+console.log(empresa.razao_social);
+
+const compliance = await analyzeCompliance("12345678000190");
+console.log(`Risco: ${compliance.risco_geral} (score ${compliance.score}/100)`);
+
+const regimes = await compareRegimes({
+  faturamento: 500_000,
+  setor: "servicos",
+  folha: 180_000,
+});
+console.log(`Melhor regime: ${regimes.melhor_opcao}`);
+```
+
+## Uso via CLI
+
+```bash
+npx mcp-fiscal cnpj 12345678000190
+npx mcp-fiscal compliance 12345678000190
+npx mcp-fiscal regimes --faturamento 500000 --setor servicos
+```
+
+## Funcoes disponiveis
+
+| Funcao | Descricao |
+|--------|-----------|
+| `lookupCNPJ(cnpj)` | Dados cadastrais de empresa |
+| `validateCPF(cpf)` | Validacao de CPF (offline) |
+| `lookupCEP(cep)` | Endereco por CEP |
+| `analyzeCompliance(cnpj)` | Compliance consolidado |
+| `scoreSupplier(cnpj, opts)` | Due diligence de fornecedor |
+| `compareRegimes(params)` | Comparativo MEI/Simples/LP/LR |
+
+## Por que wrapper e nao reimplementacao
+
+A logica fiscal brasileira muda com frequencia (tabelas Simples, regras CNAE, schemas SPED). Manter UMA implementacao em Python e expor por wrappers leves em outras linguagens reduz drift entre ecossistemas. Tradeoffs: requer Python instalado, overhead de subprocess por chamada (50-150ms).
+
+## Licenca
+
+MIT - Nikolas de Hor

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "mcp-fiscal-brasil",
+  "version": "0.2.0",
+  "description": "Node.js wrapper para o CLI Python mcp-fiscal-brasil. Consultas fiscais brasileiras (CNPJ, NFe, SPED) em JS/TS.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "mcp-fiscal": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build",
+    "test": "node --test test/*.test.js"
+  },
+  "keywords": [
+    "fiscal",
+    "brasil",
+    "cnpj",
+    "nfe",
+    "sped",
+    "mcp",
+    "tax"
+  ],
+  "author": "Nikolas de Hor <nikolasdehor79@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/nikolasdehor/mcp-fiscal-brasil",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nikolasdehor/mcp-fiscal-brasil.git",
+    "directory": "npm-wrapper"
+  },
+  "bugs": {
+    "url": "https://github.com/nikolasdehor/mcp-fiscal-brasil/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/npm-wrapper/src/cli.ts
+++ b/npm-wrapper/src/cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Bin entry point — proxies all args to the Python `mcp-fiscal` CLI.
+ *
+ * Requires the Python package `mcp-fiscal-brasil` to be installed and
+ * `mcp-fiscal` on PATH (via pipx, uv tool, or pip --user).
+ */
+import { spawn } from "node:child_process";
+
+const args = process.argv.slice(2);
+const proc = spawn("mcp-fiscal", args, { stdio: "inherit" });
+
+proc.on("error", (err: Error) => {
+  console.error(`[mcp-fiscal] Failed to spawn Python CLI: ${err.message}`);
+  console.error(
+    "[mcp-fiscal] Install the Python package first: `pipx install mcp-fiscal-brasil` or `uv tool install mcp-fiscal-brasil`",
+  );
+  process.exit(127);
+});
+
+proc.on("close", (code: number | null) => {
+  process.exit(code ?? 0);
+});

--- a/npm-wrapper/src/index.ts
+++ b/npm-wrapper/src/index.ts
@@ -1,0 +1,132 @@
+/**
+ * mcp-fiscal-brasil Node.js wrapper.
+ *
+ * Wraps the Python CLI (`mcp-fiscal`) as subprocess and returns parsed JSON.
+ * Requires `mcp-fiscal-brasil` Python package installed (pipx / uv tool / pip).
+ *
+ * Usage:
+ *   import { lookupCNPJ, analyzeCompliance, compareRegimes } from "mcp-fiscal-brasil";
+ *   const cnpj = await lookupCNPJ("12345678000190");
+ *   console.log(cnpj.razao_social);
+ */
+
+import { spawn } from "node:child_process";
+
+export interface CNPJData {
+  cnpj: string;
+  razao_social: string;
+  nome_fantasia?: string;
+  situacao_cadastral: string;
+  porte?: string;
+  [k: string]: unknown;
+}
+
+export interface ComplianceReport {
+  cnpj: string;
+  razao_social: string;
+  risco_geral: "baixo" | "medio" | "alto" | "critico";
+  score: number;
+  achados: Array<Record<string, unknown>>;
+  resumo_executivo: string;
+  fontes_consultadas: string[];
+}
+
+export interface RegimesComparison {
+  cenario_faturamento_anual: number;
+  cenario_setor: string;
+  melhor_opcao: string;
+  economia_anual_vs_pior: number;
+  opcoes: Array<Record<string, unknown>>;
+  observacoes: string;
+}
+
+export class MCPFiscalError extends Error {
+  constructor(message: string, public exitCode: number, public stderr: string) {
+    super(message);
+    this.name = "MCPFiscalError";
+  }
+}
+
+function runCli(args: string[]): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("mcp-fiscal", [...args, "--json"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+    proc.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+
+    proc.on("error", (err) =>
+      reject(new MCPFiscalError(`Failed to spawn mcp-fiscal: ${err.message}`, -1, "")),
+    );
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new MCPFiscalError(
+            `mcp-fiscal exited with code ${code}: ${stderr.trim()}`,
+            code ?? -1,
+            stderr,
+          ),
+        );
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch {
+        reject(new MCPFiscalError(`Failed to parse JSON output: ${stdout}`, 0, ""));
+      }
+    });
+  });
+}
+
+/** Consulta dados cadastrais de um CNPJ. */
+export async function lookupCNPJ(cnpj: string): Promise<CNPJData> {
+  return runCli(["cnpj", cnpj]) as Promise<CNPJData>;
+}
+
+/** Valida CPF brasileiro (offline). */
+export async function validateCPF(cpf: string): Promise<Record<string, unknown>> {
+  return runCli(["cpf", cpf]) as Promise<Record<string, unknown>>;
+}
+
+/** Consulta endereco pelo CEP. */
+export async function lookupCEP(cep: string): Promise<Record<string, unknown>> {
+  return runCli(["cep", cep]) as Promise<Record<string, unknown>>;
+}
+
+/** Analise consolidada de compliance fiscal de um CNPJ. */
+export async function analyzeCompliance(cnpj: string): Promise<ComplianceReport> {
+  return runCli(["compliance", cnpj]) as Promise<ComplianceReport>;
+}
+
+/** Score de risco para due diligence de fornecedor. */
+export async function scoreSupplier(
+  cnpj: string,
+  options: { estrito?: boolean } = {},
+): Promise<Record<string, unknown>> {
+  const args = ["supplier", cnpj];
+  if (options.estrito) args.push("--estrito");
+  return runCli(args) as Promise<Record<string, unknown>>;
+}
+
+/** Compara regimes tributarios. */
+export async function compareRegimes(params: {
+  faturamento: number;
+  setor: "comercio" | "servicos" | "industria";
+  folha?: number;
+}): Promise<RegimesComparison> {
+  const args = [
+    "regimes",
+    "--faturamento",
+    String(params.faturamento),
+    "--setor",
+    params.setor,
+  ];
+  if (params.folha !== undefined) {
+    args.push("--folha", String(params.folha));
+  }
+  return runCli(args) as Promise<RegimesComparison>;
+}

--- a/npm-wrapper/tsconfig.json
+++ b/npm-wrapper/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
     "aiolimiter>=1.2.1",
     "structlog>=25.5.0",
     "pydantic-settings>=2.13.1",
+    "typer>=0.25.1",
+    "fastapi>=0.136.1",
+    "uvicorn>=0.42.0",
 ]
 
 [project.optional-dependencies]
@@ -36,6 +39,8 @@ dev = [
 
 [project.scripts]
 mcp-fiscal-brasil = "mcp_fiscal_brasil.server:main"
+mcp-fiscal = "mcp_fiscal_brasil.cli:main"
+mcp-fiscal-api = "mcp_fiscal_brasil.api:run"
 
 [project.urls]
 Examples = "https://github.com/nikolasdehor/mcp-fiscal-brasil/tree/main/examples"
@@ -67,6 +72,7 @@ testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
+    "httpx>=0.28.1",
     "pytest-cov>=7.1.0",
     "types-cachetools>=7.0.0.20260518",
 ]

--- a/src/mcp_fiscal_brasil/api.py
+++ b/src/mcp_fiscal_brasil/api.py
@@ -1,0 +1,347 @@
+"""API REST do mcp-fiscal-brasil via FastAPI.
+
+Expoe as principais ferramentas fiscais como endpoints HTTP. Util para
+integrar com sistemas que nao falam MCP (frontends web, automacao no-code,
+microservicos legados).
+
+Executar:
+    mcp-fiscal-api
+    # ou
+    uvicorn mcp_fiscal_brasil.api:app --reload
+
+OpenAPI docs em http://localhost:8000/docs (Swagger UI).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+from . import __version__
+from .agentic import (
+    analyze_cnpj_compliance,
+    compare_tax_regimes,
+    risk_score_supplier,
+    summarize_sped,
+    validate_nfe_full,
+)
+from .cep.client import CEPClient
+from .cnpj.tools import consultar_cnpj
+from .cpf.tools import validar_cpf_tool
+from .ibge.client import IBGEClient
+from .nfe.tools import validar_chave_nfe
+from .simples.client import SimplesClient
+
+app = FastAPI(
+    title="MCP Fiscal Brasil",
+    version=__version__,
+    description=(
+        "API REST para integracoes fiscais brasileiras. Mesmas ferramentas do servidor "
+        "MCP, expostas via HTTP. Util para frontends, no-code e legados."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Health + versao
+# ---------------------------------------------------------------------------
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok"] = "ok"
+    version: str = __version__
+    service: str = "mcp-fiscal-brasil"
+
+
+@app.get("/health", response_model=HealthResponse, tags=["meta"])
+def health() -> HealthResponse:
+    """Retorna status do servico."""
+    return HealthResponse()
+
+
+# ---------------------------------------------------------------------------
+# CNPJ
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/cnpj/{cnpj}", tags=["cnpj"], summary="Consulta dados cadastrais")
+async def cnpj_lookup(cnpj: str) -> dict[str, Any]:
+    """Consulta dados cadastrais de uma empresa pelo CNPJ."""
+    resultado = await consultar_cnpj(cnpj)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# CPF
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/cpf/{cpf}", tags=["cpf"], summary="Valida CPF (digito verificador)")
+async def cpf_validate(cpf: str) -> dict[str, Any]:
+    """Valida CPF brasileiro (verificacao offline)."""
+    resultado = await validar_cpf_tool(cpf)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# CEP
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/cep/{cep}", tags=["cep"], summary="Consulta endereco por CEP")
+async def cep_lookup(cep: str) -> dict[str, Any]:
+    """Consulta endereco pelo CEP."""
+    client = CEPClient()
+    resultado = await client.get_address(cep)
+    data: dict[str, Any] = resultado.model_dump(mode="json", exclude_none=True)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Simples Nacional
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/simples/{cnpj}", tags=["simples"], summary="Situacao no Simples Nacional")
+async def simples_lookup(cnpj: str) -> dict[str, Any]:
+    """Consulta situacao da empresa no Simples Nacional."""
+    client = SimplesClient()
+    resultado = await client.get_simples_status(cnpj)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# IBGE
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/ibge/municipio/{codigo}", tags=["ibge"], summary="Municipio por codigo IBGE")
+async def ibge_municipio(codigo: int) -> dict[str, Any]:
+    """Consulta dados de um municipio pelo codigo IBGE."""
+    client = IBGEClient()
+    resultado = await client.get_municipality(codigo)
+    data: dict[str, Any] = resultado.model_dump(mode="json", exclude_none=True)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# NFe
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/nfe/chave/{chave}", tags=["nfe"], summary="Valida chave de acesso de NFe")
+async def nfe_chave_validate(chave: str) -> dict[str, Any]:
+    """Valida formato e digito verificador da chave de NFe."""
+    return await validar_chave_nfe(chave)
+
+
+class NFeValidateRequest(BaseModel):
+    xml_path: str = Field(description="Caminho absoluto para arquivo XML da NFe.")
+
+
+@app.post("/v1/nfe/validate", tags=["nfe", "agentic"], summary="Validacao consolidada de NFe")
+async def nfe_validate_full(req: NFeValidateRequest) -> dict[str, Any]:
+    """Parse XML + valida chave + verifica situacao do emissor."""
+    if not Path(req.xml_path).exists():
+        raise HTTPException(status_code=404, detail=f"Arquivo nao encontrado: {req.xml_path}")
+    resultado = await validate_nfe_full(req.xml_path)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# SPED
+# ---------------------------------------------------------------------------
+
+
+class SPEDSummarizeRequest(BaseModel):
+    file_path: str = Field(description="Caminho absoluto para arquivo .txt do SPED.")
+
+
+@app.post("/v1/sped/summarize", tags=["sped", "agentic"], summary="Sumario executivo de SPED")
+async def sped_summarize(req: SPEDSummarizeRequest) -> dict[str, Any]:
+    """Sumario executivo de arquivo SPED."""
+    if not Path(req.file_path).exists():
+        raise HTTPException(status_code=404, detail=f"Arquivo nao encontrado: {req.file_path}")
+    resultado = await summarize_sped(req.file_path)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# Agentic
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/v1/agentic/compliance/{cnpj}",
+    tags=["agentic"],
+    summary="Analise consolidada de compliance",
+)
+async def agentic_compliance(cnpj: str) -> dict[str, Any]:
+    """Compliance fiscal consolidado (CNPJ + Simples + MEI + CNAE)."""
+    resultado = await analyze_cnpj_compliance(cnpj)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.get(
+    "/v1/agentic/supplier/{cnpj}",
+    tags=["agentic"],
+    summary="Score de risco de fornecedor",
+)
+async def agentic_supplier(
+    cnpj: str, estrito: bool = Query(False, description="Criterios estritos")
+) -> dict[str, Any]:
+    """Score de risco para due diligence de fornecedor."""
+    resultado = await risk_score_supplier(cnpj, criterios_estritos=estrito)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.get(
+    "/v1/agentic/regimes",
+    tags=["agentic"],
+    summary="Comparativo de regimes tributarios",
+)
+def agentic_regimes(
+    faturamento_anual: float = Query(..., gt=0),
+    setor: Literal["comercio", "servicos", "industria"] = Query(...),
+    folha_pagamento_anual: float | None = Query(None, ge=0),
+) -> dict[str, Any]:
+    """Comparativo MEI/Simples/Lucro Presumido/Lucro Real."""
+    resultado = compare_tax_regimes(
+        faturamento_anual=faturamento_anual,
+        setor=setor,
+        folha_pagamento_anual=folha_pagamento_anual,
+    )
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# Web UI demo
+# ---------------------------------------------------------------------------
+
+
+_DEMO_HTML = """<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>MCP Fiscal Brasil - Demo</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="https://unpkg.com/htmx.org@2.0.4"></script>
+<style>
+:root { --bg:#0f172a; --fg:#e2e8f0; --accent:#22d3ee; --card:#1e293b; --border:#334155; }
+* { box-sizing:border-box; margin:0; padding:0; }
+body { font-family: system-ui, sans-serif; background:var(--bg); color:var(--fg);
+       min-height:100vh; padding:2rem; line-height:1.6; }
+.container { max-width:900px; margin:0 auto; }
+h1 { font-size:2rem; margin-bottom:0.5rem; }
+.tagline { color:#94a3b8; margin-bottom:2rem; }
+.card { background:var(--card); border:1px solid var(--border); border-radius:8px;
+        padding:1.5rem; margin-bottom:1.5rem; }
+h2 { font-size:1.2rem; margin-bottom:1rem; color:var(--accent); }
+.row { display:flex; gap:0.5rem; align-items:center; }
+input { flex:1; background:#0f172a; border:1px solid var(--border); color:var(--fg);
+        padding:0.6rem 0.8rem; border-radius:6px; font-size:1rem; font-family:inherit; }
+button { background:var(--accent); color:#0f172a; border:0; padding:0.6rem 1.2rem;
+         border-radius:6px; cursor:pointer; font-weight:600; font-size:1rem; }
+button:hover { background:#67e8f9; }
+pre { background:#0f172a; padding:1rem; border-radius:6px; overflow-x:auto;
+      font-size:0.85rem; margin-top:1rem; max-height:400px; overflow-y:auto;
+      border:1px solid var(--border); }
+.footer { color:#64748b; margin-top:2rem; text-align:center; font-size:0.85rem; }
+a { color:var(--accent); }
+.htmx-indicator { display:none; color:var(--accent); margin-left:1rem; }
+.htmx-request .htmx-indicator { display:inline; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MCP Fiscal Brasil</h1>
+  <p class="tagline">Demo interativa - dados fiscais brasileiros via API publica</p>
+
+  <div class="card">
+    <h2>Consulta de CNPJ</h2>
+    <form hx-get="/v1/cnpj/" hx-target="#cnpj-result" hx-trigger="submit"
+          hx-include="this" hx-on:submit="event.preventDefault();
+          const v=this.querySelector('input').value.replace(/\\D/g,'');
+          if(v.length===14){htmx.ajax('GET','/v1/cnpj/'+v,{target:'#cnpj-result',swap:'innerHTML'});}">
+      <div class="row">
+        <input type="text" placeholder="12.345.678/0001-90" required>
+        <button type="submit">Consultar</button>
+        <span class="htmx-indicator">Buscando...</span>
+      </div>
+    </form>
+    <pre id="cnpj-result"></pre>
+  </div>
+
+  <div class="card">
+    <h2>Compliance consolidado</h2>
+    <form hx-on:submit="event.preventDefault();
+          const v=this.querySelector('input').value.replace(/\\D/g,'');
+          if(v.length===14){htmx.ajax('GET','/v1/agentic/compliance/'+v,
+          {target:'#compl-result',swap:'innerHTML'});}">
+      <div class="row">
+        <input type="text" placeholder="CNPJ para analise completa" required>
+        <button type="submit">Analisar</button>
+        <span class="htmx-indicator">Analisando...</span>
+      </div>
+    </form>
+    <pre id="compl-result"></pre>
+  </div>
+
+  <div class="card">
+    <h2>Comparar regimes tributarios</h2>
+    <form hx-on:submit="event.preventDefault();
+          const f=this.faturamento.value, s=this.setor.value, fo=this.folha.value;
+          const url='/v1/agentic/regimes?faturamento_anual='+f+'&setor='+s+
+          (fo?'&folha_pagamento_anual='+fo:'');
+          htmx.ajax('GET',url,{target:'#reg-result',swap:'innerHTML'});">
+      <div class="row" style="flex-wrap:wrap;">
+        <input name="faturamento" type="number" placeholder="Faturamento anual (R$)"
+               required min="1" style="min-width:160px;">
+        <select name="setor" required style="background:#0f172a; color:var(--fg);
+                border:1px solid var(--border); padding:0.6rem; border-radius:6px;">
+          <option value="servicos">Servicos</option>
+          <option value="comercio">Comercio</option>
+          <option value="industria">Industria</option>
+        </select>
+        <input name="folha" type="number" placeholder="Folha anual (opcional)"
+               min="0" style="min-width:160px;">
+        <button type="submit">Comparar</button>
+      </div>
+    </form>
+    <pre id="reg-result"></pre>
+  </div>
+
+  <div class="footer">
+    <p>Dados de BrasilAPI, ReceitaWS, IBGE e fontes publicas |
+       <a href="/docs">OpenAPI docs</a> |
+       <a href="https://github.com/nikolasdehor/mcp-fiscal-brasil">GitHub</a></p>
+  </div>
+</div>
+</body>
+</html>
+"""
+
+
+@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+def root() -> HTMLResponse:
+    """Web UI demo (htmx)."""
+    return HTMLResponse(_DEMO_HTML)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run() -> None:
+    """Entry point para o comando `mcp-fiscal-api`."""
+    import uvicorn
+
+    host = os.environ.get("HOST", "127.0.0.1")
+    port = int(os.environ.get("PORT", "8000"))
+    uvicorn.run("mcp_fiscal_brasil.api:app", host=host, port=port, reload=False)

--- a/src/mcp_fiscal_brasil/cli.py
+++ b/src/mcp_fiscal_brasil/cli.py
@@ -1,0 +1,198 @@
+"""CLI standalone do mcp-fiscal-brasil.
+
+Permite usar as ferramentas fiscais direto no terminal sem precisar
+de servidor MCP. Util para automacao em scripts shell e exploracao rapida.
+
+Exemplos:
+    mcp-fiscal-brasil cnpj 12345678000190
+    mcp-fiscal-brasil cnpj 12345678000190 --json
+    mcp-fiscal-brasil compliance 12345678000190
+    mcp-fiscal-brasil regimes --faturamento 500000 --setor servicos --folha 180000
+    mcp-fiscal-brasil cpf 12345678909
+    mcp-fiscal-brasil cep 01001000
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+import typer
+from pydantic import BaseModel
+
+from . import __version__
+from .agentic import (
+    analyze_cnpj_compliance,
+    compare_tax_regimes,
+    risk_score_supplier,
+)
+from .cep.client import CEPClient
+from .cnpj.tools import consultar_cnpj
+from .cpf.tools import validar_cpf_tool
+from .ibge.client import IBGEClient
+from .simples.client import SimplesClient
+
+app = typer.Typer(
+    name="mcp-fiscal-brasil",
+    help="CLI fiscal brasileiro: CNPJ, CPF, Simples, NFe, SPED e mais.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+def _print(payload: BaseModel | dict[str, Any] | list[Any], as_json: bool) -> None:
+    data: Any
+    if isinstance(payload, BaseModel):
+        data = payload.model_dump(mode="json", exclude_none=True)
+    else:
+        data = payload
+    if as_json:
+        typer.echo(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    else:
+        _pretty(data, indent=0)
+
+
+def _pretty(value: Any, indent: int) -> None:
+    prefix = "  " * indent
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if isinstance(v, (dict, list)):
+                typer.echo(f"{prefix}{k}:")
+                _pretty(v, indent + 1)
+            else:
+                typer.echo(f"{prefix}{k}: {v}")
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, (dict, list)):
+                _pretty(item, indent)
+                typer.echo("")
+            else:
+                typer.echo(f"{prefix}- {item}")
+    else:
+        typer.echo(f"{prefix}{value}")
+
+
+@app.command()
+def version() -> None:
+    """Exibe versao do pacote."""
+    typer.echo(f"mcp-fiscal-brasil {__version__}")
+
+
+@app.command()
+def cnpj(
+    numero: str = typer.Argument(..., help="CNPJ com ou sem formatacao"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Consulta dados cadastrais de um CNPJ."""
+    resultado = asyncio.run(consultar_cnpj(numero))
+    _print(resultado, as_json)
+
+
+@app.command()
+def cpf(
+    numero: str = typer.Argument(..., help="CPF com ou sem formatacao"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Valida CPF brasileiro (digito verificador, offline)."""
+    resultado = asyncio.run(validar_cpf_tool(numero))
+    _print(resultado, as_json)
+
+
+@app.command()
+def cep(
+    numero: str = typer.Argument(..., help="CEP com ou sem hifen"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Consulta endereco pelo CEP."""
+
+    async def run() -> Any:
+        client = CEPClient()
+        return await client.get_address(numero)
+
+    resultado = asyncio.run(run())
+    _print(resultado, as_json)
+
+
+@app.command()
+def simples(
+    cnpj: str = typer.Argument(..., help="CNPJ com ou sem formatacao"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Consulta situacao no Simples Nacional."""
+
+    async def run() -> Any:
+        client = SimplesClient()
+        return await client.get_simples_status(cnpj)
+
+    resultado = asyncio.run(run())
+    _print(resultado, as_json)
+
+
+@app.command()
+def municipio(
+    codigo_ibge: str = typer.Argument(..., help="Codigo IBGE do municipio"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Consulta dados de um municipio pelo codigo IBGE."""
+
+    async def run() -> Any:
+        client = IBGEClient()
+        return await client.get_municipality(int(codigo_ibge))
+
+    resultado = asyncio.run(run())
+    _print(resultado, as_json)
+
+
+@app.command()
+def compliance(
+    cnpj: str = typer.Argument(..., help="CNPJ alvo da analise"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Analise consolidada de compliance fiscal (multiplas fontes)."""
+    resultado = asyncio.run(analyze_cnpj_compliance(cnpj))
+    _print(resultado, as_json)
+
+
+@app.command()
+def supplier(
+    cnpj: str = typer.Argument(..., help="CNPJ do fornecedor"),
+    estrito: bool = typer.Option(False, "--estrito", help="Criterios estritos"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Score de risco para due diligence de fornecedor."""
+    resultado = asyncio.run(risk_score_supplier(cnpj, criterios_estritos=estrito))
+    _print(resultado, as_json)
+
+
+@app.command()
+def regimes(
+    faturamento: float = typer.Option(..., "--faturamento", help="Faturamento anual em reais"),
+    setor: str = typer.Option(..., "--setor", help="comercio, servicos ou industria"),
+    folha: float | None = typer.Option(None, "--folha", help="Folha anual (impacta Fator R)"),
+    as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
+) -> None:
+    """Compara regimes tributarios (MEI/Simples/Lucro Presumido/Lucro Real)."""
+    if setor not in ("comercio", "servicos", "industria"):
+        typer.echo("Erro: setor deve ser comercio, servicos ou industria", err=True)
+        raise typer.Exit(code=1)
+    resultado = compare_tax_regimes(
+        faturamento_anual=faturamento,
+        setor=setor,  # type: ignore[arg-type]
+        folha_pagamento_anual=folha,
+    )
+    _print(resultado, as_json)
+
+
+def main() -> None:
+    """Entry point do CLI."""
+    try:
+        app()
+    except KeyboardInterrupt:
+        typer.echo("\nInterrompido pelo usuario", err=True)
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,95 @@
+"""Testes do FastAPI."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from mcp_fiscal_brasil import __version__
+from mcp_fiscal_brasil.agentic.schemas import ComplianceReport
+from mcp_fiscal_brasil.api import app
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["version"] == __version__
+    assert data["service"] == "mcp-fiscal-brasil"
+
+
+def test_root_serves_html() -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "MCP Fiscal Brasil" in response.text
+
+
+def test_openapi_docs_disponivel() -> None:
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    spec = response.json()
+    assert spec["info"]["title"] == "MCP Fiscal Brasil"
+
+
+def test_agentic_regimes_via_api() -> None:
+    response = client.get(
+        "/v1/agentic/regimes",
+        params={
+            "faturamento_anual": 500_000,
+            "setor": "servicos",
+            "folha_pagamento_anual": 180_000,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "melhor_opcao" in data
+    assert data["cenario_faturamento_anual"] == 500_000
+
+
+def test_agentic_regimes_setor_invalido() -> None:
+    response = client.get(
+        "/v1/agentic/regimes",
+        params={"faturamento_anual": 100_000, "setor": "invalido"},
+    )
+    assert response.status_code == 422
+
+
+def test_agentic_regimes_faturamento_zero() -> None:
+    response = client.get(
+        "/v1/agentic/regimes",
+        params={"faturamento_anual": 0, "setor": "comercio"},
+    )
+    assert response.status_code == 422
+
+
+def test_agentic_compliance_via_api() -> None:
+    fake = ComplianceReport(
+        cnpj="12345678000190",
+        razao_social="EMPRESA TESTE",
+        risco_geral="baixo",
+        score=85,
+        achados=[],
+        resumo_executivo="OK.",
+        fontes_consultadas=["BrasilAPI"],
+    )
+    with patch("mcp_fiscal_brasil.api.analyze_cnpj_compliance", AsyncMock(return_value=fake)):
+        response = client.get("/v1/agentic/compliance/12345678000190")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["razao_social"] == "EMPRESA TESTE"
+    assert data["score"] == 85
+
+
+def test_nfe_validate_arquivo_inexistente() -> None:
+    response = client.post("/v1/nfe/validate", json={"xml_path": "/tmp/nao_existe.xml"})
+    assert response.status_code == 404
+
+
+def test_sped_summarize_arquivo_inexistente() -> None:
+    response = client.post("/v1/sped/summarize", json={"file_path": "/tmp/nao_existe.txt"})
+    assert response.status_code == 404

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,122 @@
+"""Testes do CLI typer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from mcp_fiscal_brasil.agentic.schemas import (
+    ComplianceReport,
+    TaxRegimeComparison,
+    TaxRegimeOption,
+)
+from mcp_fiscal_brasil.cli import app
+
+runner = CliRunner()
+
+
+def test_cli_version() -> None:
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "mcp-fiscal-brasil" in result.stdout
+
+
+def test_cli_regimes_setor_invalido() -> None:
+    result = runner.invoke(app, ["regimes", "--faturamento", "100000", "--setor", "invalido"])
+    assert result.exit_code != 0
+
+
+def test_cli_regimes_calculo_valido() -> None:
+    result = runner.invoke(
+        app,
+        ["regimes", "--faturamento", "500000", "--setor", "servicos", "--folha", "180000"],
+    )
+    assert result.exit_code == 0
+    assert (
+        "melhor_opcao" in result.stdout
+        or "Melhor" in result.stdout
+        or "simples" in result.stdout.lower()
+    )
+
+
+def test_cli_regimes_json_output() -> None:
+    result = runner.invoke(
+        app,
+        ["regimes", "--faturamento", "500000", "--setor", "servicos", "--json"],
+    )
+    assert result.exit_code == 0
+    import json
+
+    data = json.loads(result.stdout)
+    assert "melhor_opcao" in data
+
+
+def test_cli_compliance_via_mock() -> None:
+    with patch("mcp_fiscal_brasil.cli.analyze_cnpj_compliance") as mock:
+        mock.return_value = ComplianceReport(
+            cnpj="12345678000190",
+            razao_social="EMPRESA TESTE",
+            risco_geral="baixo",
+            score=85,
+            achados=[],
+            resumo_executivo="OK.",
+            fontes_consultadas=["BrasilAPI"],
+        )
+        # AsyncMock para asyncio.run
+        mock.return_value = mock.return_value
+        mock.side_effect = None
+        mock_async = AsyncMock(return_value=mock.return_value)
+
+        with patch("mcp_fiscal_brasil.cli.analyze_cnpj_compliance", mock_async):
+            result = runner.invoke(app, ["compliance", "12345678000190", "--json"])
+
+    assert result.exit_code == 0
+    import json
+
+    data = json.loads(result.stdout)
+    assert data["razao_social"] == "EMPRESA TESTE"
+
+
+def test_cli_regimes_grande_empresa() -> None:
+    result = runner.invoke(
+        app,
+        ["regimes", "--faturamento", "20000000", "--setor", "industria", "--json"],
+    )
+    assert result.exit_code == 0
+    import json
+
+    data = json.loads(result.stdout)
+    # Empresa grande nao usa simples
+    assert data["melhor_opcao"] in ("lucro_presumido", "lucro_real")
+
+
+def _fake_regime() -> TaxRegimeComparison:
+    return TaxRegimeComparison(
+        cenario_faturamento_anual=500_000,
+        cenario_setor="servicos",
+        folha_pagamento_anual=180_000,
+        opcoes=[
+            TaxRegimeOption(
+                regime="simples_nacional",
+                aplicavel=True,
+                aliquota_efetiva_estimada=11.2,
+                imposto_anual_estimado=56000,
+                pros=["unificado"],
+                contras=[],
+            ),
+        ],
+        melhor_opcao="simples_nacional",
+        economia_anual_vs_pior=10000,
+        observacoes="ok",
+    )
+
+
+def test_cli_regimes_pretty_output() -> None:
+    result = runner.invoke(
+        app,
+        ["regimes", "--faturamento", "500000", "--setor", "servicos"],
+    )
+    assert result.exit_code == 0
+    # pretty output uses key: value
+    assert ":" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -507,6 +516,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1001,6 +1026,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
     { name = "cachetools" },
+    { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "lxml" },
@@ -1009,6 +1035,8 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "structlog" },
     { name = "tenacity" },
+    { name = "typer" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -1022,6 +1050,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest-cov" },
     { name = "types-cachetools" },
 ]
@@ -1030,6 +1059,7 @@ dev = [
 requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "cachetools", specifier = ">=7.0.5" },
+    { name = "fastapi", specifier = ">=0.136.1" },
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "lxml", specifier = ">=5.0" },
@@ -1043,11 +1073,14 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tenacity", specifier = ">=9.1.4" },
+    { name = "typer", specifier = ">=0.25.1" },
+    { name = "uvicorn", specifier = ">=0.42.0" },
 ]
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260518" },
 ]
@@ -1826,6 +1859,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1933,6 +1975,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Resumo

Fase 4 do roadmap v0.2.0. Quatro interfaces alternativas alem do servidor MCP.

## Componentes

### CLI Python (typer)
`mcp-fiscal cnpj 12345678000190`, `mcp-fiscal compliance ...`, `mcp-fiscal regimes ...`. Flag `--json` para uso programatico.

### REST API (FastAPI)
`mcp-fiscal-api` sobe servidor em :8000 com OpenAPI docs em `/docs`. Endpoints `/v1/cnpj/{cnpj}`, `/v1/agentic/compliance/{cnpj}`, etc.

### Web UI demo
Rota `/` da API serve pagina htmx 2.0 com 3 demos interativas (CNPJ lookup, compliance, comparativo de regimes). Dark mode, sem build step.

### npm wrapper
Pacote TypeScript em `npm-wrapper/` que spawna o CLI Python. Permite usar em apps Node.js: `import { lookupCNPJ } from 'mcp-fiscal-brasil'`.

## Qualidade

- 16 testes novos (8 CLI + 8 API)
- Suite total: **117/117 passando**
- mypy strict: limpo
- ruff check + format: limpos