### PR TITLE
docs: site mkdocs-material com deploy automatico GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+      - "CHANGELOG.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: docs-pip-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install dependencies
+        run: |
+          pip install \
+            mkdocs-material \
+            mkdocs-mermaid2-plugin \
+            pymdown-extensions
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ dmypy.json
 
 # Distribuição
 dist/
+site/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 </p>
 
 <p align="center">
+  <a href="https://nikolasdehor.github.io/mcp-fiscal-brasil/">📚 Documentação</a> ·
   <a href="#-instalacao">Instalação</a> ·
   <a href="#-ferramentas-disponiveis">Ferramentas</a> ·
   <a href="#-demonstracao">Exemplos</a> ·

--- a/docs/agentic/compliance.md
+++ b/docs/agentic/compliance.md
@@ -1,0 +1,92 @@
+# analyze_cnpj_compliance
+
+Analise consolidada de compliance fiscal de um CNPJ.
+
+## Assinatura
+
+```python
+async def analyze_cnpj_compliance(cnpj: str) -> ComplianceReport
+```
+
+## O que faz
+
+Consulta **em paralelo**:
+
+1. Dados cadastrais (Receita Federal via BrasilAPI / ReceitaWS)
+2. Regime Simples Nacional
+3. Status MEI
+4. CNAE principal e secundarios
+
+Aplica heuristicas e retorna um relatorio unico com:
+
+- **`risco_geral`** (`baixo` / `medio` / `alto` / `critico`)
+- **`score`** (0-100, calibrado: 90 = excelente, 5 = critico)
+- **`achados`** detalhados por categoria
+- **`resumo_executivo`** em pt-BR para apresentar a humano
+- **`fontes_consultadas`** que responderam com sucesso
+
+## Schema de saida
+
+```python
+class ComplianceReport(BaseModel):
+    cnpj: str
+    razao_social: str
+    risco_geral: Literal["baixo", "medio", "alto", "critico"]
+    score: int  # 0-100
+    achados: list[ComplianceFinding]
+    resumo_executivo: str
+    fontes_consultadas: list[str]
+```
+
+## Tolerancia a falhas
+
+Se uma das fontes (Simples, MEI) estiver offline, a tool **nao falha**. So a fonte CNPJ e mandatoria (se ela falhar, a tool levanta `RuntimeError`). As demais sao usadas se disponiveis.
+
+Verifique `fontes_consultadas` para saber quais responderam.
+
+## Heuristica de risco
+
+| Sinal | Severidade |
+|-------|-----------|
+| Situacao `BAIXADA` ou `NULA` | critico |
+| Situacao `INAPTA` | alto |
+| Situacao `SUSPENSA` | medio |
+| Endereco incompleto | medio |
+| QSA nao disponivel | medio |
+| Tudo regular | baixo |
+
+Risco geral = severidade maxima dos achados.
+
+## Exemplos
+
+### CLI
+
+```bash
+mcp-fiscal compliance 12345678000190
+mcp-fiscal compliance 12345678000190 --json | jq '.score'
+```
+
+### REST API
+
+```bash
+curl http://localhost:8000/v1/agentic/compliance/12345678000190
+```
+
+### Python
+
+```python
+import asyncio
+from mcp_fiscal_brasil.agentic import analyze_cnpj_compliance
+
+async def main():
+    report = await analyze_cnpj_compliance("12345678000190")
+    print(report.resumo_executivo)
+    for achado in report.achados:
+        print(f"- [{achado.severidade}] {achado.titulo}")
+
+asyncio.run(main())
+```
+
+### Via agente IA
+
+> "Analise o compliance fiscal do CNPJ 12.345.678/0001-90 e me responda em portugues"

--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -1,0 +1,45 @@
+# Tools agenticas
+
+Tools de **alto nivel** desenhadas para uso por agentes de IA (Claude, GPT, Gemini). Cada tool combina multiplos clientes de baixo nivel em uma chamada com saida estruturada e rica em descricoes (otimizada para LLMs).
+
+## Disponiveis (v0.2.0)
+
+| Tool | O que faz |
+|------|-----------|
+| [`analyze_cnpj_compliance`](compliance.md) | Relatorio consolidado: CNPJ + Simples + MEI + CNAE, score 0-100, risco |
+| [`compare_tax_regimes`](regimes.md) | Comparativo MEI/Simples/Lucro Presumido/Lucro Real |
+| [`risk_score_supplier`](supplier.md) | Due diligence de fornecedor com recomendacao |
+| [`validate_nfe_full`](nfe.md) | NFe: parse XML + chave + situacao do emissor |
+| [`summarize_sped`](sped.md) | Sumario executivo de arquivo SPED |
+
+## Por que agentic
+
+Tools de baixo nivel (ex: `consultar_cnpj`, `validar_chave_nfe`) sao uteis, mas exigem que o agente saiba combinar varias chamadas para uma decisao. Tools agenticas resolvem isso:
+
+- Composem multiplos clientes em uma chamada
+- Retornam respostas com **score normalizado**, **risco classificado** e **resumo executivo**
+- Schema pydantic com `description` em cada campo (auto-explicativo para LLMs)
+- Capturam falhas parciais sem bloquear a analise (uma fonte offline nao quebra a tool)
+
+## Exemplo end-to-end
+
+Cenario: agente IA precisa decidir se contratar um fornecedor.
+
+**Sem agentic** (3+ chamadas):
+1. `consultar_cnpj(...)` -> dados cadastrais
+2. `consultar_simples_nacional(...)` -> regime
+3. `consultar_certidao_federal(...)` -> link
+4. agente combina manualmente, gera score, decide
+
+**Com agentic** (1 chamada):
+```python
+score = await risk_score_supplier("12345678000190", criterios_estritos=True)
+if score.recomendacao == "recusar":
+    return "Bloqueado: " + ", ".join(score.fatores)
+```
+
+Em ferramentas como Claude Desktop, o agente IA pode chamar diretamente:
+
+> "Faca due diligence no CNPJ 12.345.678/0001-90 com criterios estritos"
+
+E recebe a resposta consolidada em 1 turno.

--- a/docs/agentic/nfe.md
+++ b/docs/agentic/nfe.md
@@ -1,0 +1,68 @@
+# validate_nfe_full
+
+Validacao consolidada de NFe (XML + chave + situacao do emissor).
+
+## Assinatura
+
+```python
+async def validate_nfe_full(xml_path: str | Path) -> NFeValidationReport
+```
+
+## O que faz
+
+1. **Parse estrutural** do XML (lxml)
+2. **Validacao do digito verificador** da chave de acesso (modulo 11)
+3. **Consulta do CNPJ emissor** para confirmar situacao ativa
+
+Retorna relatorio com chave, validade, issues e resumo.
+
+## Schema de saida
+
+```python
+class NFeValidationReport(BaseModel):
+    chave_acesso: str
+    valida_estruturalmente: bool
+    chave_consistente: bool
+    emissor_ativo: bool | None  # None se nao foi possivel verificar
+    issues: list[NFeValidationIssue]
+    cnpj_emissor: str | None
+    cnpj_destinatario: str | None
+    valor_total: float | None
+    data_emissao: date | None
+    resumo: str
+```
+
+## Codigos de issue
+
+| Codigo | Severidade | Significado |
+|--------|------------|-------------|
+| `XML_PARSE_ERROR` | critico | XML mal-formado ou schema invalido |
+| `CHAVE_INVALIDA` | alto | DV da chave nao confere com conteudo |
+| `EMISSOR_INATIVO` | alto | CNPJ emissor nao esta `ativa` na Receita |
+| `CHAVE_VALIDACAO_FALHOU` | medio | Falha tecnica ao validar chave (rede etc) |
+
+## Exemplos
+
+### Via REST API
+
+```bash
+curl -X POST http://localhost:8000/v1/nfe/validate \
+  -H "Content-Type: application/json" \
+  -d '{"xml_path": "/var/notas/35240300623904000197550010000012341234567890.xml"}'
+```
+
+### Python
+
+```python
+from mcp_fiscal_brasil.agentic import validate_nfe_full
+
+report = await validate_nfe_full("/var/notas/nota.xml")
+if not report.valida_estruturalmente:
+    raise ValueError(f"NFe invalida: {report.resumo}")
+for issue in report.issues:
+    print(f"[{issue.severidade}] {issue.codigo}: {issue.descricao}")
+```
+
+### Via agente IA
+
+> "Valide a NFe em /var/notas/35240300623904000197550010000012341234567890.xml e me da o relatorio"

--- a/docs/agentic/regimes.md
+++ b/docs/agentic/regimes.md
@@ -1,0 +1,96 @@
+# compare_tax_regimes
+
+Comparativo entre regimes tributarios brasileiros (MEI, Simples, Lucro Presumido, Lucro Real).
+
+## Assinatura
+
+```python
+def compare_tax_regimes(
+    faturamento_anual: float,
+    setor: Literal["comercio", "servicos", "industria"],
+    folha_pagamento_anual: float | None = None,
+) -> TaxRegimeComparison
+```
+
+## O que faz
+
+Calcula **aliquota efetiva estimada** e **imposto anual estimado** para cada regime tributario aplicavel ao cenario, baseado em tabelas publicas vigentes (2025).
+
+Retorna o regime **mais economico** e a **economia anual vs pior opcao**.
+
+!!! warning "Estimativa, nao planejamento contabil"
+
+    Calculo simplificado baseado em premissas publicas. NAO substitui parecer de contador. Use para direcionamento em decisoes de planejamento, nao para apuracao final.
+
+## Heuristicas
+
+### MEI
+- Limite: R$ 81.000/ano
+- Aplicavel apenas a algumas atividades
+- Tributacao fixa mensal (~R$ 75-80)
+
+### Simples Nacional
+- Limite: R$ 4,8 milhoes/ano
+- Anexo conforme setor (comercio I, industria II, servicos III ou V)
+- **Fator R** (servicos): folha/faturamento >= 28% -> Anexo III (mais barato)
+
+### Lucro Presumido
+- Limite: R$ 78 milhoes/ano
+- Presuncao 8% (comercio/industria) ou 32% (servicos)
+- PIS/COFINS cumulativos (3,65%)
+
+### Lucro Real
+- Sem teto
+- IRPJ 15% + adicional 10% sobre lucro liquido
+- PIS/COFINS nao-cumulativos com creditos
+- Burocracia maior
+
+## Schema de saida
+
+```python
+class TaxRegimeComparison(BaseModel):
+    cenario_faturamento_anual: float
+    cenario_setor: Literal["comercio", "servicos", "industria"]
+    folha_pagamento_anual: float | None
+    opcoes: list[TaxRegimeOption]  # ordenadas: aplicaveis primeiro, do mais barato
+    melhor_opcao: str
+    economia_anual_vs_pior: float
+    observacoes: str
+
+class TaxRegimeOption(BaseModel):
+    regime: Literal["mei", "simples_nacional", "lucro_presumido", "lucro_real"]
+    aplicavel: bool
+    motivo_inaplicavel: str | None
+    aliquota_efetiva_estimada: float | None
+    imposto_anual_estimado: float | None
+    pros: list[str]
+    contras: list[str]
+```
+
+## Exemplos
+
+### Empresa de servicos pequena
+
+```bash
+mcp-fiscal regimes --faturamento 300000 --setor servicos --folha 120000 --json
+```
+
+Esperado: melhor opcao = `simples_nacional` (Anexo III pelo Fator R).
+
+### Industria de medio porte
+
+```bash
+mcp-fiscal regimes --faturamento 5000000 --setor industria --folha 1500000 --json
+```
+
+Esperado: Simples Nacional **nao aplicavel** (faturamento > R$ 4,8 mi). Melhor opcao tipicamente `lucro_presumido`.
+
+### Via REST API
+
+```bash
+curl "http://localhost:8000/v1/agentic/regimes?faturamento_anual=500000&setor=servicos&folha_pagamento_anual=180000"
+```
+
+### Via agente IA
+
+> "Sou prestador de servicos com faturamento de R$ 500 mil e folha de R$ 180 mil. Qual o melhor regime?"

--- a/docs/agentic/sped.md
+++ b/docs/agentic/sped.md
@@ -1,0 +1,64 @@
+# summarize_sped
+
+Sumario executivo de arquivo SPED (Fiscal, Contribuicoes, ECF ou ECD).
+
+## Assinatura
+
+```python
+async def summarize_sped(file_path: str | Path) -> SPEDSummary
+```
+
+## O que faz
+
+1. Le o arquivo (encoding `latin-1`, padrao SPED)
+2. Identifica tipo (EFD-ICMS-IPI, EFD-Contribuicoes, ECF, ECD)
+3. Extrai periodo (registro 0000)
+4. Extrai dados da empresa (CNPJ, razao social)
+5. Conta registros totais e por bloco
+6. Lista inconsistencias estruturais
+7. Produz resumo executivo em pt-BR
+
+## Schema de saida
+
+```python
+class SPEDSummary(BaseModel):
+    arquivo: str
+    tipo: Literal["fiscal", "contribuicoes", "ecf", "ecd"]
+    periodo_inicio: date | None
+    periodo_fim: date | None
+    total_registros: int
+    total_blocos: int
+    cnpj: str | None
+    razao_social: str | None
+    inconsistencias: list[str]
+    metricas_chave: dict[str, float]
+    resumo: str
+```
+
+## Exemplos
+
+### CLI
+
+```bash
+# Sumario rapido
+mcp-fiscal-api  # liga o servidor
+curl -X POST http://localhost:8000/v1/sped/summarize \
+  -H "Content-Type: application/json" \
+  -d '{"file_path": "/contabil/sped_fiscal_202412.txt"}'
+```
+
+### Python
+
+```python
+from mcp_fiscal_brasil.agentic import summarize_sped
+
+resumo = await summarize_sped("/contabil/sped_fiscal_202412.txt")
+print(resumo.resumo)
+print(f"Total: {resumo.total_registros} registros em {resumo.total_blocos} blocos")
+if resumo.inconsistencias:
+    print(f"Alertas: {len(resumo.inconsistencias)}")
+```
+
+### Via agente IA
+
+> "Analisa o arquivo SPED em /contabil/sped_fiscal_202412.txt e me da o sumario executivo"

--- a/docs/agentic/supplier.md
+++ b/docs/agentic/supplier.md
@@ -1,0 +1,75 @@
+# risk_score_supplier
+
+Score de risco para due diligence de fornecedor.
+
+## Assinatura
+
+```python
+async def risk_score_supplier(
+    cnpj: str,
+    criterios_estritos: bool = False,
+) -> SupplierRiskScore
+```
+
+## O que faz
+
+Baseia-se em [`analyze_cnpj_compliance`](compliance.md) e aplica ajustes mais conservadores para contexto de **contratacao**:
+
+- Achados com severidade `alto`/`critico` reduzem score em 15
+- Achados `medio` reduzem em 5
+- `criterios_estritos=True` reduz score em 10 (politicas anti-corrupcao)
+
+Retorna **recomendacao binaria/quaternaria** acionavel.
+
+## Schema de saida
+
+```python
+class SupplierRiskScore(BaseModel):
+    cnpj: str
+    razao_social: str
+    risco: Literal["baixo", "medio", "alto", "critico"]
+    score: int  # 0-100
+    fatores: list[str]  # positivos e negativos
+    recomendacao: Literal[
+        "aprovar",
+        "aprovar_com_ressalvas",
+        "investigar",
+        "recusar",
+    ]
+    data_analise: date
+```
+
+## Faixas de recomendacao
+
+| Score | Recomendacao |
+|-------|--------------|
+| 80-100 | `aprovar` |
+| 60-79 | `aprovar_com_ressalvas` |
+| 30-59 | `investigar` |
+| 0-29 | `recusar` |
+
+## Exemplos
+
+### CLI
+
+```bash
+mcp-fiscal supplier 12345678000190
+mcp-fiscal supplier 12345678000190 --estrito --json
+```
+
+### Python (integracao com cadastro de fornecedores)
+
+```python
+async def cadastrar_fornecedor(cnpj: str) -> bool:
+    score = await risk_score_supplier(cnpj, criterios_estritos=True)
+    if score.recomendacao == "recusar":
+        log.warning("supplier_rejected", cnpj=cnpj, fatores=score.fatores)
+        return False
+    if score.recomendacao == "investigar":
+        await notificar_compliance_team(cnpj, score)
+    return True
+```
+
+### Via agente IA
+
+> "Faz a due diligence completa do CNPJ 12.345.678/0001-90 com criterios estritos e me da a recomendacao"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,63 @@
+# Contribuir
+
+Contribuicoes sao bem-vindas! Algumas formas de ajudar:
+
+## Formas de contribuir
+
+- **Issues**: reporte bugs ou peca features em [github.com/nikolasdehor/mcp-fiscal-brasil/issues](https://github.com/nikolasdehor/mcp-fiscal-brasil/issues)
+- **Pull requests**: fork, branch, PR
+- **Documentacao**: melhorias na doc sao MUITO bem-vindas
+- **Casos de uso**: compartilhe como voce usa o `mcp-fiscal-brasil` em projetos reais
+
+## Setup de desenvolvimento
+
+```bash
+git clone https://github.com/nikolasdehor/mcp-fiscal-brasil
+cd mcp-fiscal-brasil
+
+# Instalar uv (https://docs.astral.sh/uv/)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Setup
+uv sync --all-extras
+```
+
+## Comandos uteis
+
+```bash
+# Testes
+uv run pytest
+
+# Lint + format
+uv run ruff check src/ tests/
+uv run ruff format src/ tests/
+
+# Type check
+uv run mypy --strict src/
+
+# Build
+uv build
+
+# Site de docs local
+uv run mkdocs serve
+```
+
+## Padroes
+
+- **Estilo**: PEP 8 + ruff format
+- **Tipos**: mypy --strict, type hints em todas as funcoes publicas
+- **Testes**: pytest, cobertura minima 80% em novo codigo
+- **Mensagens de commit**: imperativo curto, sem AI footers (`Co-Authored-By`, `Generated with Claude` etc)
+- **Portugues**: pt-BR com acentos corretos em strings/docs user-facing. Codigo e comentarios em ingles.
+
+## Estrutura de PR
+
+1. Branch a partir de `main`
+2. Commits pequenos e atomicos
+3. Testes para mudancas funcionais
+4. Atualize CHANGELOG.md
+5. PR com descricao clara do que muda e por que
+
+## Codigo de conduta
+
+Seja respeitoso. Foco no codigo, nao na pessoa. Sem toxicidade.

--- a/docs/getting-started/config.md
+++ b/docs/getting-started/config.md
@@ -1,0 +1,117 @@
+# Configuracao
+
+## Variaveis de ambiente
+
+Todas opcionais, com defaults razoaveis.
+
+| Variavel | Default | Descricao |
+|----------|---------|-----------|
+| `MCP_FISCAL_HTTP_TIMEOUT` | `30` | Timeout HTTP em segundos |
+| `MCP_FISCAL_MAX_RETRIES` | `3` | Maximo de retries por requisicao |
+| `MCP_FISCAL_CACHE_TTL` | `300` | TTL do cache em segundos |
+| `MCP_FISCAL_RATE_LIMIT` | `10` | Requests por segundo (por host) |
+| `MCP_FISCAL_CACHE_BACKEND` | `memory` | `memory`, `sqlite` ou `redis` |
+| `MCP_FISCAL_REDIS_URL` | - | URL do Redis (se `cache_backend=redis`) |
+| `MCP_FISCAL_LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+
+Exemplo `.env`:
+
+```bash
+MCP_FISCAL_HTTP_TIMEOUT=60
+MCP_FISCAL_CACHE_TTL=3600
+MCP_FISCAL_RATE_LIMIT=5
+MCP_FISCAL_LOG_LEVEL=DEBUG
+```
+
+## Cliente MCP
+
+### Claude Desktop
+
+Adicione em `claude_desktop_config.json`:
+
+=== "macOS / Linux"
+
+    Arquivo: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) ou `~/.config/Claude/claude_desktop_config.json` (Linux).
+
+    ```json
+    {
+      "mcpServers": {
+        "fiscal-brasil": {
+          "command": "mcp-fiscal-brasil",
+          "args": []
+        }
+      }
+    }
+    ```
+
+=== "Windows"
+
+    Arquivo: `%APPDATA%\Claude\claude_desktop_config.json`.
+
+    ```json
+    {
+      "mcpServers": {
+        "fiscal-brasil": {
+          "command": "mcp-fiscal-brasil.exe",
+          "args": []
+        }
+      }
+    }
+    ```
+
+Reinicie o Claude Desktop. O servidor aparece como `fiscal-brasil` com 20+ ferramentas.
+
+### Claude Code (CLI)
+
+```bash
+claude mcp add fiscal-brasil mcp-fiscal-brasil
+```
+
+### Cursor
+
+Adicione em Settings -> MCP Servers:
+
+```json
+{
+  "mcpServers": {
+    "fiscal-brasil": {
+      "command": "mcp-fiscal-brasil"
+    }
+  }
+}
+```
+
+### Outros clientes MCP
+
+Qualquer cliente compativel com MCP funciona. O servidor expoe via stdio por padrao. Para HTTP transport:
+
+```bash
+mcp-fiscal-brasil --transport http --port 8000
+```
+
+## Cache em producao
+
+Em producao, prefira `sqlite` ou `redis`:
+
+```bash
+MCP_FISCAL_CACHE_BACKEND=sqlite
+# armazena em ~/.cache/mcp-fiscal-brasil.db
+
+MCP_FISCAL_CACHE_BACKEND=redis
+MCP_FISCAL_REDIS_URL=redis://localhost:6379/0
+```
+
+## Logs estruturados
+
+Em producao, logs sao emitidos como JSON via `structlog`:
+
+```json
+{
+  "event": "cnpj_lookup_started",
+  "cnpj": "12345678000190",
+  "timestamp": "2026-05-20T10:30:00Z",
+  "level": "info"
+}
+```
+
+Ideal para parsing em Loki, Datadog, CloudWatch, etc.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,0 +1,77 @@
+# Instalacao
+
+## Pre-requisitos
+
+- **Python 3.10+** (verifique com `python --version`)
+- Conexao com internet (para consultar APIs publicas)
+
+## Metodos suportados
+
+=== "pipx (recomendado para CLI)"
+
+    ```bash
+    pipx install mcp-fiscal-brasil
+    ```
+
+    Isola o pacote em ambiente proprio. Apos instalar, `mcp-fiscal`, `mcp-fiscal-brasil` e `mcp-fiscal-api` ficam disponiveis no `PATH`.
+
+=== "uv tool (rapido)"
+
+    ```bash
+    uv tool install mcp-fiscal-brasil
+    ```
+
+    Mesmo resultado que pipx, com [`uv`](https://docs.astral.sh/uv/) (mais rapido).
+
+=== "pip (em um venv)"
+
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate  # Windows: .venv\Scripts\activate
+    pip install mcp-fiscal-brasil
+    ```
+
+=== "Docker"
+
+    ```bash
+    # Servidor MCP via stdio
+    docker run --rm -i ghcr.io/nikolasdehor/mcp-fiscal-brasil:0.2.0
+
+    # REST API + Web UI demo
+    docker run --rm -p 8000:8000 ghcr.io/nikolasdehor/mcp-fiscal-brasil:0.2.0 mcp-fiscal-api
+    ```
+
+=== "Como dependencia"
+
+    Em `pyproject.toml`:
+
+    ```toml
+    [project]
+    dependencies = [
+        "mcp-fiscal-brasil>=0.2.0",
+    ]
+    ```
+
+    Ou:
+
+    ```bash
+    uv add mcp-fiscal-brasil
+    pip install mcp-fiscal-brasil
+    ```
+
+## Verificar a instalacao
+
+```bash
+mcp-fiscal version
+# mcp-fiscal-brasil 0.2.0
+```
+
+```bash
+mcp-fiscal cnpj 00000000000191
+# (consulta dados publicos da empresa)
+```
+
+## Proximos passos
+
+- [Configuracao do cliente MCP](config.md)
+- [Quickstart com exemplos](quickstart.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,147 @@
+# Quickstart
+
+5 minutos para sentir o que o `mcp-fiscal-brasil` faz.
+
+## 1. Consulta CNPJ via CLI
+
+```bash
+mcp-fiscal cnpj 00000000000191
+```
+
+Saida:
+
+```
+cnpj: 00000000000191
+razao_social: BANCO DO BRASIL S.A.
+nome_fantasia: BB
+situacao_cadastral: ATIVA
+natureza_juridica: 2038
+porte: DEMAIS
+capital_social: ...
+endereco:
+  logradouro: SAUN QUADRA 5 LOTE B TORRES I, II E III
+  municipio: BRASILIA
+  uf: DF
+  cep: 70040912
+atividade_principal:
+  codigo: 6422100
+  descricao: Bancos multiplos, com carteira comercial
+origem: BrasilAPI
+```
+
+## 2. Analise de compliance consolidada
+
+Combina CNPJ + Simples + MEI + CNAE em uma chamada:
+
+```bash
+mcp-fiscal compliance 00000000000191
+```
+
+Saida tipica:
+
+```
+cnpj: 00000000000191
+razao_social: BANCO DO BRASIL S.A.
+risco_geral: baixo
+score: 90
+achados:
+  - categoria: atividade
+    severidade: baixo
+    titulo: CNAE principal 6422100
+    detalhe: Bancos multiplos, com carteira comercial
+resumo_executivo: CNPJ 00000000000191 (BANCO DO BRASIL S.A.) apresenta risco baixo (score 90/100)...
+fontes_consultadas:
+  - BrasilAPI
+  - Simples Nacional
+```
+
+## 3. Compare regimes tributarios
+
+Cenario: empresa de servicos, faturamento R$ 500 mil/ano, folha R$ 180 mil.
+
+```bash
+mcp-fiscal regimes --faturamento 500000 --setor servicos --folha 180000
+```
+
+Saida:
+
+```
+cenario_faturamento_anual: 500000
+cenario_setor: servicos
+folha_pagamento_anual: 180000
+opcoes:
+  - regime: simples_nacional
+    aplicavel: True
+    aliquota_efetiva_estimada: 16.0
+    imposto_anual_estimado: 80000
+  - regime: lucro_presumido
+    aplicavel: True
+    aliquota_efetiva_estimada: 19.8
+    imposto_anual_estimado: 99000
+melhor_opcao: simples_nacional
+economia_anual_vs_pior: ...
+```
+
+## 4. REST API + Web UI demo
+
+```bash
+mcp-fiscal-api
+# Servidor em http://localhost:8000
+```
+
+Abra no navegador:
+
+- **`/`** - Web UI com 3 demos interativas
+- **`/docs`** - OpenAPI / Swagger
+- **`/v1/cnpj/00000000000191`** - JSON via HTTP
+
+## 5. Como SDK Python
+
+```python
+import asyncio
+from mcp_fiscal_brasil.agentic import (
+    analyze_cnpj_compliance,
+    compare_tax_regimes,
+    risk_score_supplier,
+)
+
+
+async def main():
+    # Compliance
+    report = await analyze_cnpj_compliance("00000000000191")
+    print(f"Risco: {report.risco_geral} (score {report.score}/100)")
+
+    # Due diligence de fornecedor
+    score = await risk_score_supplier("00000000000191", criterios_estritos=True)
+    print(f"Recomendacao: {score.recomendacao}")
+
+    # Planejamento tributario
+    plano = compare_tax_regimes(
+        faturamento_anual=500_000,
+        setor="servicos",
+        folha_pagamento_anual=180_000,
+    )
+    print(f"Melhor regime: {plano.melhor_opcao}")
+    print(f"Economia anual: R$ {plano.economia_anual_vs_pior:,.2f}")
+
+
+asyncio.run(main())
+```
+
+## 6. Com agentes IA (Claude, GPT, Gemini)
+
+Apos configurar o servidor MCP no seu cliente ([config](config.md)), basta perguntar em linguagem natural:
+
+> "Consulte o CNPJ 00.000.000/0001-91 e me da uma analise de compliance"
+>
+> "A empresa X esta apta a entrar no Simples Nacional?"
+>
+> "Compare os regimes tributarios para um servico com R$ 500 mil de faturamento e R$ 180 mil de folha"
+
+O Claude/GPT/Gemini chama as tools certas e responde em pt-BR.
+
+## Proximos passos
+
+- [Tools agenticas detalhadas](../agentic/index.md)
+- [REST API reference](../interfaces/rest-api.md)
+- [Casos de uso reais](../use-cases/due-diligence.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,99 @@
+# MCP Fiscal Brasil
+
+Servidor MCP, CLI, REST API e SDK para o sistema fiscal brasileiro.
+
+[![PyPI](https://img.shields.io/pypi/v/mcp-fiscal-brasil?color=009c3b&label=PyPI)](https://pypi.org/project/mcp-fiscal-brasil/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-002776?logo=python&logoColor=white)](https://www.python.org/)
+[![MCP](https://img.shields.io/badge/MCP-compativel-7c3aed)](https://modelcontextprotocol.io)
+[![Licenca MIT](https://img.shields.io/badge/licenca-MIT-FFDF00?labelColor=002776)](https://github.com/nikolasdehor/mcp-fiscal-brasil/blob/main/LICENSE)
+
+## O que e
+
+O `mcp-fiscal-brasil` integra dados fiscais brasileiros (CNPJ, NFe, SPED, Simples Nacional, CNAE, certidoes e mais) em **quatro interfaces** complementares:
+
+```mermaid
+flowchart LR
+    A[Sua aplicacao ou agente IA] -->|MCP| M[Servidor MCP]
+    A -->|HTTP| R[REST API]
+    A -->|stdin/stdout| C[CLI]
+    A -->|import| S[SDK Python]
+    M --> Core[Core fiscal]
+    R --> Core
+    C --> Core
+    S --> Core
+    Core --> APIs[BrasilAPI / ReceitaWS / IBGE / SEFAZ]
+```
+
+## Por que existe
+
+O Brasil tem o sistema fiscal mais complexo do mundo: 27 SEFAZs, NFe + NFSe + SPED + eSocial, cada municipio com seu portal proprio. Integrar IA com dados fiscais brasileiros antes desse projeto significava semanas de codigo de cola.
+
+Com o `mcp-fiscal-brasil`, **uma linha de codigo** consulta CNPJ, valida NFe, analisa compliance, compara regimes tributarios.
+
+## Recursos chave (v0.2.0)
+
+=== "Tools agenticas"
+
+    Combinacoes pensadas para uso por agentes de IA:
+
+    - `analyze_cnpj_compliance` - relatorio consolidado com score 0-100
+    - `compare_tax_regimes` - MEI vs Simples vs Lucro Presumido vs Real
+    - `risk_score_supplier` - due diligence com recomendacao acionavel
+    - `validate_nfe_full` - parse XML + chave + situacao do emissor
+    - `summarize_sped` - sumario executivo de arquivo SPED
+
+=== "Multiplas interfaces"
+
+    Escolha como integrar:
+
+    - **MCP Server**: Claude Desktop, Cursor, qualquer cliente MCP
+    - **CLI**: `mcp-fiscal cnpj 12345678000190` no terminal
+    - **REST API**: FastAPI com OpenAPI docs
+    - **Web UI**: pagina htmx 2.0 servida pela API
+    - **npm wrapper**: usar em apps Node.js/TypeScript
+
+=== "Production-grade"
+
+    Pensado para ambientes serios:
+
+    - HTTP retry exponencial (`tenacity`)
+    - Cache pluggavel (memory / redis / sqlite)
+    - Rate-limit per-host
+    - Logs estruturados JSON (`structlog`)
+    - Strict typing com `mypy --strict`
+
+## Quick start
+
+```bash
+# Instalar
+pipx install mcp-fiscal-brasil
+# ou
+uv tool install mcp-fiscal-brasil
+
+# CLI
+mcp-fiscal cnpj 12345678000190
+mcp-fiscal compliance 12345678000190
+mcp-fiscal regimes --faturamento 500000 --setor servicos --folha 180000
+
+# REST API + Web UI demo
+mcp-fiscal-api  # http://localhost:8000
+```
+
+```python
+# SDK Python
+import asyncio
+from mcp_fiscal_brasil.agentic import analyze_cnpj_compliance
+
+async def main():
+    report = await analyze_cnpj_compliance("12345678000190")
+    print(f"Risco: {report.risco_geral} (score {report.score}/100)")
+    print(report.resumo_executivo)
+
+asyncio.run(main())
+```
+
+## Onde ir agora
+
+[:material-rocket: Comece pelo guia rapido](getting-started/quickstart.md){ .md-button .md-button--primary }
+[:material-tools: Explore as tools agenticas](agentic/index.md){ .md-button }
+[:material-github: Ver no GitHub](https://github.com/nikolasdehor/mcp-fiscal-brasil){ .md-button }

--- a/docs/interfaces/cli.md
+++ b/docs/interfaces/cli.md
@@ -1,0 +1,60 @@
+# CLI
+
+CLI standalone para uso em terminal e scripts shell.
+
+## Instalacao
+
+```bash
+pipx install mcp-fiscal-brasil
+# binarios: mcp-fiscal, mcp-fiscal-brasil, mcp-fiscal-api
+```
+
+## Comandos
+
+| Comando | Descricao |
+|---------|-----------|
+| `mcp-fiscal cnpj <numero>` | Consulta dados cadastrais de CNPJ |
+| `mcp-fiscal cpf <numero>` | Valida CPF (offline) |
+| `mcp-fiscal cep <numero>` | Consulta endereco por CEP |
+| `mcp-fiscal simples <cnpj>` | Situacao no Simples Nacional |
+| `mcp-fiscal municipio <codigo_ibge>` | Dados de municipio por codigo IBGE |
+| `mcp-fiscal compliance <cnpj>` | Analise consolidada de compliance |
+| `mcp-fiscal supplier <cnpj>` | Score de risco de fornecedor |
+| `mcp-fiscal regimes ...` | Comparativo de regimes tributarios |
+| `mcp-fiscal version` | Versao do pacote |
+
+## Flag `--json`
+
+Toda saida pode vir como JSON puro para uso programatico:
+
+```bash
+mcp-fiscal cnpj 12345678000190 --json | jq '.razao_social'
+mcp-fiscal compliance 12345678000190 --json > report.json
+```
+
+## Exemplos
+
+### Pipeline shell
+
+```bash
+# Validar lista de CNPJs em massa
+for cnpj in $(cat cnpjs.txt); do
+  mcp-fiscal compliance "$cnpj" --json | jq '{cnpj, risco_geral, score}'
+done | jq -s '.'
+```
+
+### Planejamento tributario rapido
+
+```bash
+mcp-fiscal regimes \
+  --faturamento 500000 \
+  --setor servicos \
+  --folha 180000 \
+  --json | jq '.melhor_opcao, .economia_anual_vs_pior'
+```
+
+### Due diligence com criterios estritos
+
+```bash
+mcp-fiscal supplier 12345678000190 --estrito --json
+```

--- a/docs/interfaces/mcp.md
+++ b/docs/interfaces/mcp.md
@@ -1,0 +1,42 @@
+# Servidor MCP
+
+O servidor MCP (Model Context Protocol) e a interface canonica para integrar com agentes IA (Claude, Cursor, qualquer cliente MCP).
+
+## Executar
+
+```bash
+# stdio (padrao para clientes MCP)
+mcp-fiscal-brasil
+
+# HTTP
+mcp-fiscal-brasil --transport http --port 8000
+
+# SSE (deprecated mas ainda suportado)
+mcp-fiscal-brasil --transport sse
+```
+
+## Ferramentas registradas (20+)
+
+| Categoria | Ferramentas |
+|-----------|-------------|
+| CNPJ | `consultar_cnpj`, `listar_cnpjs_por_nome` |
+| CPF | `validar_cpf` |
+| NFe | `consultar_nfe`, `validar_chave_nfe`, `consultar_status_sefaz` |
+| NFSe | `consultar_nfse` |
+| SPED | `analisar_sped`, `listar_registros_sped` |
+| eSocial | `listar_eventos_esocial`, `validar_evento_esocial` |
+| Certidoes | `consultar_certidao_federal`, `consultar_certidao_fgts` |
+| Simples | `consultar_simples_nacional` |
+| **Agentic** | `analyze_cnpj_compliance`, `compare_tax_regimes`, `risk_score_supplier`, `validate_nfe_full`, `summarize_sped` |
+
+## Configuracao do cliente
+
+Veja [Configuracao](../getting-started/config.md#cliente-mcp) para exemplos de Claude Desktop, Claude Code, Cursor.
+
+## Exemplos de uso
+
+Apos configurar o servidor no cliente, pergunte em linguagem natural:
+
+> "Consulte o CNPJ 12.345.678/0001-90 e me da o relatorio de compliance completo"
+
+O agente IA vai chamar `analyze_cnpj_compliance` automaticamente.

--- a/docs/interfaces/nodejs.md
+++ b/docs/interfaces/nodejs.md
@@ -1,0 +1,70 @@
+# Node.js (npm wrapper)
+
+Pacote npm `mcp-fiscal-brasil` que envelopa o CLI Python para uso em apps JavaScript/TypeScript.
+
+## Pre-requisito
+
+O CLI Python precisa estar instalado no `PATH`:
+
+```bash
+pipx install mcp-fiscal-brasil
+mcp-fiscal --help  # deve responder
+```
+
+## Instalacao
+
+```bash
+npm install mcp-fiscal-brasil
+# ou
+pnpm add mcp-fiscal-brasil
+# ou
+yarn add mcp-fiscal-brasil
+```
+
+## Uso programatico
+
+```typescript
+import {
+  lookupCNPJ,
+  analyzeCompliance,
+  compareRegimes,
+  scoreSupplier,
+} from "mcp-fiscal-brasil";
+
+// CNPJ lookup
+const empresa = await lookupCNPJ("12345678000190");
+console.log(empresa.razao_social);
+
+// Compliance
+const report = await analyzeCompliance("12345678000190");
+console.log(`Risco: ${report.risco_geral} (score ${report.score}/100)`);
+
+// Due diligence
+const score = await scoreSupplier("12345678000190", { estrito: true });
+console.log(score.recomendacao);  // "aprovar" | "investigar" | etc
+
+// Planejamento tributario
+const regimes = await compareRegimes({
+  faturamento: 500_000,
+  setor: "servicos",
+  folha: 180_000,
+});
+console.log(regimes.melhor_opcao);
+```
+
+## CLI passthrough
+
+```bash
+npx mcp-fiscal cnpj 12345678000190
+npx mcp-fiscal regimes --faturamento 500000 --setor servicos
+```
+
+## Trade-offs
+
+Como o wrapper spawna o CLI Python via subprocess:
+
+- **Overhead**: 50-150ms por chamada
+- **Pre-requisito**: Python instalado
+- **Beneficio**: zero drift entre ecossistemas Python e Node
+
+Para apps Node de alto throughput, considere usar a [REST API](rest-api.md) em vez do wrapper.

--- a/docs/interfaces/rest-api.md
+++ b/docs/interfaces/rest-api.md
@@ -1,0 +1,91 @@
+# REST API
+
+API HTTP via FastAPI. Util para integracoes que nao falam MCP (frontends, no-code, microservicos legados).
+
+## Executar
+
+```bash
+mcp-fiscal-api
+# http://localhost:8000
+```
+
+Por padrao escuta em `127.0.0.1:8000`. Para producao:
+
+```bash
+HOST=0.0.0.0 PORT=8080 mcp-fiscal-api
+```
+
+Ou direto via uvicorn:
+
+```bash
+uvicorn mcp_fiscal_brasil.api:app --host 0.0.0.0 --port 8080 --workers 4
+```
+
+## OpenAPI docs
+
+- Swagger: `http://localhost:8000/docs`
+- ReDoc: `http://localhost:8000/redoc`
+- JSON spec: `http://localhost:8000/openapi.json`
+
+## Endpoints
+
+### Meta
+
+- `GET /health` - status do servico
+
+### Modulos
+
+- `GET /v1/cnpj/{cnpj}` - dados cadastrais
+- `GET /v1/cpf/{cpf}` - validacao de CPF
+- `GET /v1/cep/{cep}` - endereco por CEP
+- `GET /v1/simples/{cnpj}` - Simples Nacional
+- `GET /v1/ibge/municipio/{codigo}` - municipio IBGE
+- `GET /v1/nfe/chave/{chave}` - valida chave NFe
+
+### Agentic
+
+- `GET /v1/agentic/compliance/{cnpj}` - relatorio consolidado
+- `GET /v1/agentic/supplier/{cnpj}` - due diligence
+- `GET /v1/agentic/regimes` - comparativo de regimes
+- `POST /v1/nfe/validate` - validacao consolidada NFe (XML)
+- `POST /v1/sped/summarize` - sumario executivo SPED
+
+## Web UI
+
+A rota `/` serve uma pagina htmx 2.0 com tres demos interativas (CNPJ lookup, compliance, comparativo de regimes). Veja [Web UI](web-ui.md).
+
+## Producao
+
+### Docker
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e MCP_FISCAL_CACHE_BACKEND=sqlite \
+  -e MCP_FISCAL_RATE_LIMIT=20 \
+  ghcr.io/nikolasdehor/mcp-fiscal-brasil:0.2.0 \
+  mcp-fiscal-api
+```
+
+### Compose com Redis
+
+Veja `docker-compose.yml` no repo. Para habilitar Redis, descomente o servico `redis` e mude:
+
+```yaml
+environment:
+  MCP_FISCAL_CACHE_BACKEND: redis
+  MCP_FISCAL_REDIS_URL: redis://redis:6379/0
+```
+
+### Atras de proxy reverso (Nginx)
+
+```nginx
+location /api/fiscal/ {
+    proxy_pass http://localhost:8000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+```
+
+## Autenticacao
+
+A v0.2.0 nao implementa autenticacao na API. **Nao exponha publicamente sem layer de auth** (proxy com auth basica, OAuth, ou API gateway). Para uso interno na sua rede, esta seguro.

--- a/docs/interfaces/web-ui.md
+++ b/docs/interfaces/web-ui.md
@@ -1,0 +1,36 @@
+# Web UI demo
+
+A rota `/` da REST API serve uma pagina demo interativa construida com htmx 2.0.
+
+## Acesso
+
+```bash
+mcp-fiscal-api
+# Abrir http://localhost:8000
+```
+
+## Demos disponiveis
+
+### Consulta de CNPJ
+
+Input: CNPJ com ou sem formatacao. Output: dados cadastrais completos.
+
+### Compliance consolidado
+
+Input: CNPJ. Output: relatorio com score 0-100, risco classificado e achados.
+
+### Comparativo de regimes tributarios
+
+Inputs: faturamento, setor, folha (opcional). Output: comparativo MEI/Simples/LP/LR com melhor opcao e economia.
+
+## Stack
+
+- **htmx 2.0** - reatividade sem JS bundle
+- **Tailwind-like inline CSS** - dark mode nativo
+- **Sem build step** - HTML servido direto pelo FastAPI
+
+## Personalizar
+
+A pagina e definida em `src/mcp_fiscal_brasil/api.py` como string `_DEMO_HTML`. Para customizar, edite la e reinicie o servidor.
+
+Para uma SPA mais completa, considere construir um frontend separado consumindo a [REST API](rest-api.md).

--- a/docs/modules/cep.md
+++ b/docs/modules/cep.md
@@ -1,0 +1,20 @@
+# Modulo CEP
+
+Lookup de enderecos por CEP.
+
+## Uso
+
+```python
+from mcp_fiscal_brasil.cep.client import CEPClient
+
+client = CEPClient()
+endereco = await client.get_address("74000000")
+print(f"{endereco.logradouro}, {endereco.bairro} - {endereco.municipio}/{endereco.uf}")
+```
+
+## Fontes
+
+- **BrasilAPI** (preferencial)
+- **ViaCEP** (fallback)
+
+Ambas sao publicas e gratuitas, sem rate limit estrito.

--- a/docs/modules/cnae.md
+++ b/docs/modules/cnae.md
@@ -1,0 +1,33 @@
+# Modulo CNAE
+
+Classificacao Nacional de Atividades Economicas.
+
+## Uso
+
+```python
+from mcp_fiscal_brasil.cnae.client import CNAEClient
+
+client = CNAEClient()
+atividades = await client.search("desenvolvimento de software")
+for a in atividades:
+    print(a.codigo, a.descricao)
+```
+
+## Schema
+
+```python
+class CNAEActivity(BaseModel):
+    codigo: str
+    descricao: str
+
+class CNAEClass(BaseModel):
+    classe: str
+    descricao: str
+    atividades: list[CNAEActivity]
+```
+
+## Casos de uso
+
+- Validar compatibilidade entre atividade economica e operacao
+- Sugerir CNAE para novos cadastros
+- Mapear empresa -> setor para analise de carteira

--- a/docs/modules/cnpj.md
+++ b/docs/modules/cnpj.md
@@ -1,0 +1,47 @@
+# Modulo CNPJ
+
+Consulta de dados cadastrais de empresas via BrasilAPI (preferencial) com fallback para ReceitaWS.
+
+## API publica
+
+```python
+from mcp_fiscal_brasil.cnpj.client import CNPJClient
+
+client = CNPJClient()
+empresa = await client.consultar("12345678000190")
+print(empresa.razao_social)
+```
+
+## Schema
+
+```python
+class CNPJResponse(BaseModel):
+    cnpj: str
+    razao_social: str
+    nome_fantasia: str | None
+    situacao_cadastral: str
+    natureza_juridica: str
+    porte: str | None
+    capital_social: float | None
+    data_abertura: date | None
+    atividade_principal: AtividadeCNAE | None
+    atividades_secundarias: list[AtividadeCNAE]
+    endereco: Endereco
+    telefone: str | None
+    email: str | None
+    qsa: list[QSASocio]
+    origem: str  # "BrasilAPI" ou "ReceitaWS"
+```
+
+## Tools MCP
+
+- `consultar_cnpj(cnpj: str)` - dados completos
+- `listar_cnpjs_por_nome(nome, uf?)` - busca por nome (limitada)
+
+## Fontes
+
+- **BrasilAPI**: https://brasilapi.com.br/ (preferencial)
+- **ReceitaWS**: https://receitaws.com.br/ (fallback)
+- Rate limit publico: 3 req/min por IP em ambos (~)
+
+Habilite cache em producao para nao bater no rate limit.

--- a/docs/modules/cpf.md
+++ b/docs/modules/cpf.md
@@ -1,0 +1,28 @@
+# Modulo CPF
+
+Validacao **algoritmica offline** do digito verificador do CPF.
+
+A Receita Federal nao expoe API publica para consulta de CPF (dados pessoais). Esse modulo so verifica o calculo matematico do DV.
+
+## Uso
+
+```python
+from mcp_fiscal_brasil.cpf.tools import validar_cpf_tool
+
+resultado = await validar_cpf_tool("123.456.789-09")
+print(resultado.valido)  # True/False
+```
+
+## Tool MCP
+
+- `validar_cpf(cpf: str)` - validacao offline do DV
+
+## Limitacoes
+
+Nao consulta:
+
+- Nome titular
+- Situacao cadastral (regular/pendente/cancelada)
+- Outras informacoes pessoais
+
+Para esses dados, e necessario contrato com SERPRO Datavalid ou Caixa.

--- a/docs/modules/ibge.md
+++ b/docs/modules/ibge.md
@@ -1,0 +1,29 @@
+# Modulo IBGE
+
+Dados geograficos: municipios, UFs e codigos IBGE.
+
+## Uso
+
+```python
+from mcp_fiscal_brasil.ibge.client import IBGEClient
+
+client = IBGEClient()
+
+# Listar UFs
+ufs = await client.get_states()
+
+# Detalhes de uma UF
+go = await client.get_state("GO")
+
+# Listar municipios de GO
+municipios_go = await client.get_municipalities("GO")
+
+# Municipio por codigo IBGE
+goiania = await client.get_municipality(5208707)
+```
+
+## Fonte
+
+API publica do IBGE: https://servicodados.ibge.gov.br/api/v1/localidades/
+
+Sem rate limit conhecido, mas use cache para reduzir latencia (default TTL 5min).

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -1,0 +1,35 @@
+# Modulos
+
+Cada fonte de dado fiscal e um modulo Python em `src/mcp_fiscal_brasil/`.
+
+## Disponiveis (v0.2.0)
+
+| Modulo | Fonte | Tipo |
+|--------|-------|------|
+| [cnpj](cnpj.md) | BrasilAPI, ReceitaWS | Dados cadastrais |
+| [cpf](cpf.md) | Algoritmico | Validacao offline |
+| [cep](cep.md) | BrasilAPI, ViaCEP | Enderecos |
+| [nfe](nfe.md) | SEFAZ, parse XML | Notas fiscais eletronicas |
+| [nfse](#) | Portais municipais | Servicos eletronicos |
+| [sped](sped.md) | Parse local | Escrituracao digital |
+| [esocial](#) | Validacao | Eventos eSocial |
+| [simples](simples.md) | API Receita | Regime Simples Nacional |
+| [mei](#) | API Receita | Microempreendedor |
+| [cnae](cnae.md) | Tabela local + API | Atividades economicas |
+| [ibge](ibge.md) | API IBGE | Municipios, UFs |
+| [empresa](#) | Consolidado | Dados unificados |
+| [certidoes](#) | URLs portais | Certidoes negativas |
+
+## Convencao
+
+Cada modulo segue o mesmo padrao:
+
+```
+src/mcp_fiscal_brasil/<modulo>/
+├── __init__.py    # exports publicos
+├── client.py      # cliente assincrono
+├── schemas.py     # modelos pydantic
+└── tools.py       # tools MCP (quando aplicavel)
+```
+
+Para detalhes da arquitetura interna, veja o codigo no [GitHub](https://github.com/nikolasdehor/mcp-fiscal-brasil/tree/main/src/mcp_fiscal_brasil).

--- a/docs/modules/nfe.md
+++ b/docs/modules/nfe.md
@@ -1,0 +1,30 @@
+# Modulo NFe
+
+Notas Fiscais Eletronicas: consulta, validacao de chave, parse de XML.
+
+## Tools MCP
+
+- `consultar_nfe(chave_acesso)` - dados da NFe pela chave de 44 digitos
+- `validar_chave_nfe(chave_acesso)` - validacao do DV (modulo 11)
+- `consultar_status_sefaz(uf)` - status do webservice SEFAZ por UF
+
+## Parser XML
+
+```python
+from mcp_fiscal_brasil.nfe.xml_parser import parse_nfe_xml
+
+with open("nota.xml", "rb") as f:
+    nfe = parse_nfe_xml(f.read(), chave="")
+print(nfe.emitente.razao_social)
+print(nfe.totais.valor_nota)
+```
+
+## Tool agentic
+
+Para validacao consolidada (XML + chave + emissor), use [`validate_nfe_full`](../agentic/nfe.md).
+
+## Compatibilidade
+
+- Layout: NFe 4.00 (atual desde 2018)
+- Namespaces: `http://www.portalfiscal.inf.br/nfe` (com fallback para sem namespace)
+- Mensagens SEFAZ: padrao nacional + Portal Nacional NFe

--- a/docs/modules/simples.md
+++ b/docs/modules/simples.md
@@ -1,0 +1,29 @@
+# Modulo Simples Nacional
+
+Consulta de regime tributario Simples Nacional via API publica da Receita.
+
+## Uso
+
+```python
+from mcp_fiscal_brasil.simples.client import SimplesClient
+
+client = SimplesClient()
+status = await client.get_simples_status("12345678000190")
+print(status.optante)        # True/False
+print(status.data_opcao)     # date | None
+print(status.data_exclusao)  # date | None
+```
+
+## Tool MCP
+
+- `consultar_simples_nacional(cnpj)` - dados completos
+
+## Limitacoes
+
+A API publica retorna apenas:
+
+- Optante (sim/nao)
+- Datas de opcao / exclusao
+- Modalidade (MEI ou Simples)
+
+**Nao retorna**: anexo, faixa atual, valor recolhido. Para isso, e necessario acesso autenticado ao Portal do Simples Nacional.

--- a/docs/modules/sped.md
+++ b/docs/modules/sped.md
@@ -1,0 +1,44 @@
+# Modulo SPED
+
+Parse e analise de arquivos SPED (Sistema Publico de Escrituracao Digital).
+
+## Tipos suportados
+
+- **EFD-ICMS-IPI** (SPED Fiscal)
+- **EFD-Contribuicoes** (PIS/COFINS)
+- **ECD** (Escrituracao Contabil Digital)
+- **ECF** (Escrituracao Contabil Fiscal)
+
+## Uso
+
+```python
+from mcp_fiscal_brasil.sped.tools import analisar_sped, listar_registros_sped
+
+with open("sped_fiscal.txt", encoding="latin-1") as f:
+    conteudo = f.read()
+
+analise = await analisar_sped(conteudo, "sped_fiscal.txt")
+print(f"Tipo: {analise.tipo_sped}")
+print(f"Periodo: {analise.resumo.periodo_inicial} - {analise.resumo.periodo_final}")
+print(f"Total: {analise.resumo.total_registros}")
+
+# Listar todos os registros C100 (documentos fiscais)
+docs = await listar_registros_sped(conteudo, "C100")
+```
+
+## Tools MCP
+
+- `analisar_sped(conteudo, nome_arquivo?)` - parse e sumario
+- `listar_registros_sped(conteudo, tipo_registro)` - filtra por tipo
+
+## Tool agentic
+
+Para sumario executivo de alto nivel, use [`summarize_sped`](../agentic/sped.md).
+
+## Encoding
+
+Arquivos SPED usam `latin-1`. Carregue assim:
+
+```python
+content = path.read_text(encoding="latin-1")
+```

--- a/docs/use-cases/due-diligence.md
+++ b/docs/use-cases/due-diligence.md
@@ -1,0 +1,114 @@
+# Due diligence de fornecedores
+
+Como usar o `mcp-fiscal-brasil` para automatizar verificacao de fornecedores em larga escala.
+
+## Cenario
+
+Sua empresa cadastra 100+ fornecedores por mes. Cada cadastro exige:
+
+1. Consultar CNPJ na Receita
+2. Verificar regime tributario
+3. Conferir situacao em certidoes (CND, FGTS, CNDT)
+4. Decidir aprovar / pedir documentos / recusar
+
+Sem automacao, isso e 30 minutos por fornecedor, feito por uma pessoa do compliance.
+
+Com o `mcp-fiscal`, e uma chamada:
+
+```python
+score = await risk_score_supplier(cnpj, criterios_estritos=True)
+```
+
+## Fluxo recomendado
+
+```mermaid
+flowchart TD
+    A[Cadastro de fornecedor] --> B[Validacao basica<br/>CNPJ formato + DV]
+    B --> C[risk_score_supplier]
+    C --> D{Recomendacao}
+    D -->|aprovar| E[Cadastro automatico]
+    D -->|aprovar_com_ressalvas| F[Cadastro com flag<br/>+ notificacao]
+    D -->|investigar| G[Fila de revisao manual<br/>compliance team]
+    D -->|recusar| H[Bloqueio<br/>+ log estruturado]
+```
+
+## Implementacao em Python
+
+```python
+from mcp_fiscal_brasil.agentic import risk_score_supplier
+import structlog
+
+log = structlog.get_logger()
+
+
+async def processar_cadastro_fornecedor(cnpj: str, contratante: dict) -> dict:
+    """Decide se cadastra um fornecedor."""
+    criterios_estritos = contratante.get("politica_anti_corrupcao", False)
+
+    score = await risk_score_supplier(cnpj, criterios_estritos=criterios_estritos)
+
+    log.info(
+        "supplier_evaluated",
+        cnpj=cnpj,
+        score=score.score,
+        recomendacao=score.recomendacao,
+        contratante=contratante["id"],
+    )
+
+    if score.recomendacao == "recusar":
+        return {"status": "bloqueado", "motivos": score.fatores}
+
+    if score.recomendacao == "investigar":
+        await enfileirar_revisao_manual(cnpj, score)
+        return {"status": "pendente_revisao"}
+
+    if score.recomendacao == "aprovar_com_ressalvas":
+        await notificar_compliance(cnpj, score)
+        return {"status": "aprovado", "flag": "ressalvas"}
+
+    return {"status": "aprovado"}
+```
+
+## Batch processing
+
+```python
+import asyncio
+
+async def avaliar_em_massa(cnpjs: list[str]) -> dict[str, str]:
+    """Avalia varios CNPJs em paralelo, com limite de concorrencia."""
+    sem = asyncio.Semaphore(10)  # max 10 simultaneos
+
+    async def _avaliar_um(cnpj: str) -> tuple[str, str]:
+        async with sem:
+            score = await risk_score_supplier(cnpj, criterios_estritos=True)
+            return cnpj, score.recomendacao
+
+    resultados = await asyncio.gather(*(_avaliar_um(c) for c in cnpjs))
+    return dict(resultados)
+```
+
+## Auditoria
+
+O score inclui `fatores` (lista de strings) que explicam **porque** a recomendacao foi essa. Armazene-os no log de auditoria:
+
+```python
+log.info(
+    "supplier_evaluation",
+    cnpj=score.cnpj,
+    razao_social=score.razao_social,
+    score=score.score,
+    risco=score.risco,
+    recomendacao=score.recomendacao,
+    fatores=score.fatores,
+    data_analise=score.data_analise.isoformat(),
+)
+```
+
+Audit trail completo em JSON estruturado, pronto pra Loki / CloudWatch / Datadog.
+
+## Tradeoffs e cuidados
+
+- **Cache**: ative cache (`MCP_FISCAL_CACHE_TTL=3600`) para nao repetir consultas dentro de 1 hora
+- **Rate limit**: APIs publicas tem limites. Default e conservador, mas se rodar muitos batches, monitore
+- **Falsos positivos**: empresas recem-cadastradas as vezes tem `endereco_incompleto`. Combine com regras de negocio especificas
+- **Renovacao**: cadastros periodicos (anual / semestral) garantem que mudancas na situacao sejam capturadas

--- a/docs/use-cases/supplier-validation.md
+++ b/docs/use-cases/supplier-validation.md
@@ -1,0 +1,114 @@
+# Validacao de fornecedor no ERP
+
+Integracao com sistemas ERP para validar fornecedores antes de emissao de NFe.
+
+## Cenario
+
+Antes de emitir NFe contra um CNPJ destinatario, voce quer confirmar que:
+
+1. CNPJ existe e esta ativo
+2. Empresa nao foi baixada / suspensa
+3. Endereco bate com o cadastro
+4. Atividade (CNAE) e compativel com a operacao
+
+## Pre-emissao via webhook
+
+```python
+from fastapi import FastAPI, HTTPException
+from mcp_fiscal_brasil.agentic import analyze_cnpj_compliance
+
+app = FastAPI()
+
+@app.post("/erp/pre-emissao-nfe")
+async def validar_destinatario(payload: dict) -> dict:
+    cnpj_destinatario = payload["cnpj_destinatario"]
+    report = await analyze_cnpj_compliance(cnpj_destinatario)
+
+    if report.risco_geral == "critico":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "blocked": True,
+                "reason": report.resumo_executivo,
+                "achados": [a.titulo for a in report.achados],
+            },
+        )
+
+    return {
+        "allowed": True,
+        "score": report.score,
+        "risco": report.risco_geral,
+    }
+```
+
+## Conciliacao em lote (mensal)
+
+```python
+import asyncio
+from datetime import datetime
+
+async def reconciliacao_fornecedores(cnpjs_ativos: list[str]) -> dict:
+    """Roda 1x por mes para reavaliar fornecedores ativos."""
+    sem = asyncio.Semaphore(20)
+
+    async def _avaliar(cnpj: str):
+        async with sem:
+            try:
+                report = await analyze_cnpj_compliance(cnpj)
+                return cnpj, report
+            except Exception as e:
+                return cnpj, {"error": str(e)}
+
+    resultados = await asyncio.gather(*(_avaliar(c) for c in cnpjs_ativos))
+
+    alertas = [
+        (cnpj, r) for cnpj, r in resultados
+        if hasattr(r, "risco_geral") and r.risco_geral in ("alto", "critico")
+    ]
+
+    if alertas:
+        await notificar_compliance_team(alertas)
+
+    return {
+        "data": datetime.now().isoformat(),
+        "total": len(cnpjs_ativos),
+        "alertas": len(alertas),
+    }
+```
+
+## Renovacao automatica de certidoes
+
+```python
+from mcp_fiscal_brasil.certidoes.tools import (
+    consultar_certidao_federal,
+    consultar_certidao_fgts,
+)
+
+async def renovar_certidoes(cnpj: str) -> dict:
+    """Obtem URLs atualizadas de certidoes negativas."""
+    federal = await consultar_certidao_federal(cnpj)
+    fgts = await consultar_certidao_fgts(cnpj)
+    return {"federal": federal, "fgts": fgts}
+```
+
+!!! note "Sobre certidoes"
+
+    O `mcp-fiscal-brasil` retorna **URLs para emissao** das certidoes (CND, FGTS, CNDT). A emissao em si requer captcha / login no portal correspondente - nao automatizamos isso por questoes legais e de tos. Use os URLs para guiar o usuario / contador.
+
+## Logs estruturados
+
+```python
+import structlog
+
+log = structlog.get_logger()
+
+log.info(
+    "pre_emission_validation",
+    cnpj_destinatario=cnpj,
+    score=report.score,
+    risco=report.risco_geral,
+    decision="allowed" if report.risco_geral != "critico" else "blocked",
+)
+```
+
+Ideal para BI: tracker de "quantos cadastros foram bloqueados", "qual a media de score por mes", etc.

--- a/docs/use-cases/tax-planning.md
+++ b/docs/use-cases/tax-planning.md
@@ -1,0 +1,104 @@
+# Planejamento tributario
+
+Como usar o `mcp-fiscal` para sugerir regime tributario a clientes ou para decisoes internas de planejamento.
+
+## Cenario
+
+Cliente / equipe pergunta: "Qual o melhor regime para meu cenario?". Tradicionalmente: pegar planilhas, calcular para cada regime, comparar. Tempo: 30-60 minutos.
+
+Com `compare_tax_regimes`:
+
+```python
+plano = compare_tax_regimes(
+    faturamento_anual=500_000,
+    setor="servicos",
+    folha_pagamento_anual=180_000,
+)
+```
+
+Resposta em milissegundos com aliquota efetiva e imposto estimado por regime.
+
+## Exemplo: assistente de planejamento
+
+```python
+from mcp_fiscal_brasil.agentic import compare_tax_regimes
+
+def sugerir_regime(cenario: dict) -> dict:
+    """Sugere regime tributario com base no cenario do cliente."""
+    plano = compare_tax_regimes(
+        faturamento_anual=cenario["faturamento"],
+        setor=cenario["setor"],
+        folha_pagamento_anual=cenario.get("folha"),
+    )
+
+    return {
+        "recomendacao": plano.melhor_opcao,
+        "economia_anual": plano.economia_anual_vs_pior,
+        "ranking": [
+            {
+                "regime": o.regime,
+                "imposto_anual": o.imposto_anual_estimado,
+                "aplicavel": o.aplicavel,
+            }
+            for o in plano.opcoes
+        ],
+        "observacoes": plano.observacoes,
+    }
+```
+
+## Cenarios comuns
+
+### MEI vs Simples (microempresa de servicos)
+
+```bash
+mcp-fiscal regimes --faturamento 60000 --setor servicos --json
+mcp-fiscal regimes --faturamento 100000 --setor servicos --json
+```
+
+Esperado: para faturamento <= R$ 81 mil, MEI tende a ser melhor (se a atividade for permitida). Acima disso, Simples.
+
+### Fator R em servicos
+
+```bash
+# Folha alta -> Anexo III
+mcp-fiscal regimes --faturamento 500000 --setor servicos --folha 200000
+
+# Folha baixa -> Anexo V (mais caro)
+mcp-fiscal regimes --faturamento 500000 --setor servicos --folha 30000
+```
+
+A diferenca de aliquota pode passar de 5pp.
+
+### Industria grande (sem Simples)
+
+```bash
+mcp-fiscal regimes --faturamento 10000000 --setor industria --json
+```
+
+Simples saira como `aplicavel=false`. Comparativo entre Lucro Presumido e Lucro Real.
+
+## Integracao com SaaS contabil
+
+```python
+from fastapi import FastAPI
+from mcp_fiscal_brasil.agentic import compare_tax_regimes
+
+app = FastAPI()
+
+@app.post("/api/planejamento-tributario")
+async def planejamento(payload: dict) -> dict:
+    plano = compare_tax_regimes(
+        faturamento_anual=payload["faturamento"],
+        setor=payload["setor"],
+        folha_pagamento_anual=payload.get("folha"),
+    )
+    return plano.model_dump(mode="json", exclude_none=True)
+```
+
+## Limitacoes
+
+- Calculo simplificado, **NAO substitui parecer contabil**
+- Nao considera beneficios estaduais (ProEmprego, regimes especiais)
+- ICMS usado e media nacional (12%) - na pratica varia 4-25% por UF
+- ISS usado e media (5%) - varia 2-5% por municipio
+- Aliquotas atualizadas em 2025; revisar a cada reforma tributaria

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,122 @@
+site_name: MCP Fiscal Brasil
+site_description: Servidor MCP, CLI e REST API para o sistema fiscal brasileiro (CNPJ, NFe, SPED, Simples Nacional, compliance).
+site_url: https://nikolasdehor.github.io/mcp-fiscal-brasil/
+site_author: Nikolas de Hor
+repo_url: https://github.com/nikolasdehor/mcp-fiscal-brasil
+repo_name: nikolasdehor/mcp-fiscal-brasil
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: pt-BR
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      accent: yellow
+      toggle:
+        icon: material/weather-night
+        name: Modo escuro
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: green
+      accent: yellow
+      toggle:
+        icon: material/weather-sunny
+        name: Modo claro
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.tracking
+    - navigation.indexes
+    - search.highlight
+    - search.suggest
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - content.tabs.link
+  icon:
+    repo: fontawesome/brands/github
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/nikolasdehor
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/in/nikolasdehor
+  generator: false
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path: [".", "docs"]
+      check_paths: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - search:
+      lang: pt
+  - mermaid2
+
+nav:
+  - Inicio: index.md
+  - Comece aqui:
+      - Instalacao: getting-started/install.md
+      - Configuracao: getting-started/config.md
+      - Primeiro uso: getting-started/quickstart.md
+  - Interfaces:
+      - MCP Server: interfaces/mcp.md
+      - CLI: interfaces/cli.md
+      - REST API: interfaces/rest-api.md
+      - Web UI: interfaces/web-ui.md
+      - Node.js: interfaces/nodejs.md
+  - Modulos:
+      - Visao geral: modules/index.md
+      - CNPJ: modules/cnpj.md
+      - CPF: modules/cpf.md
+      - NFe: modules/nfe.md
+      - SPED: modules/sped.md
+      - Simples Nacional: modules/simples.md
+      - CNAE: modules/cnae.md
+      - IBGE: modules/ibge.md
+      - CEP: modules/cep.md
+  - Tools agenticas:
+      - Visao geral: agentic/index.md
+      - Analise de compliance: agentic/compliance.md
+      - Comparativo de regimes: agentic/regimes.md
+      - Score de fornecedor: agentic/supplier.md
+      - Validacao de NFe: agentic/nfe.md
+      - Sumario de SPED: agentic/sped.md
+  - Casos de uso:
+      - Due diligence: use-cases/due-diligence.md
+      - Planejamento tributario: use-cases/tax-planning.md
+      - Validacao de fornecedor: use-cases/supplier-validation.md
+  - Contribuir: contributing.md
+  - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ testpaths = ["tests"]
 [dependency-groups]
 dev = [
     "httpx>=0.28.1",
+    "mkdocs-material>=9.7.6",
+    "mkdocs-mermaid2-plugin>=1.2.3",
+    "pymdown-extensions>=10.21.3",
     "pytest-cov>=7.1.0",
     "types-cachetools>=7.0.0.20260518",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -95,12 +104,38 @@ wheels = [
 ]
 
 [[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
@@ -239,6 +274,111 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -494,6 +634,15 @@ wheels = [
 ]
 
 [[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -573,6 +722,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -703,6 +864,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
 ]
 
 [[package]]
@@ -983,6 +1169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -992,6 +1187,91 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1051,6 +1331,9 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-mermaid2-plugin" },
+    { name = "pymdown-extensions" },
     { name = "pytest-cov" },
     { name = "types-cachetools" },
 ]
@@ -1081,6 +1364,9 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
+    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
+    { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260518" },
 ]
@@ -1092,6 +1378,101 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-mermaid2-plugin"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsbeautifier" },
+    { name = "mkdocs" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
 ]
 
 [[package]]
@@ -1199,6 +1580,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
 ]
 
 [[package]]
@@ -1466,6 +1856,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1659,6 +2062,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1670,6 +2085,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1859,6 +2289,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1874,6 +2313,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]
@@ -2032,6 +2480,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2059,6 +2516,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Resumo

Adiciona site de documentacao do mcp-fiscal-brasil com mkdocs-material, deploy automatico em GitHub Pages a cada push em `main`.

## URL pos-merge

https://nikolasdehor.github.io/mcp-fiscal-brasil/

## Estrutura

- **Inicio**: visao geral + quick start + recursos chave
- **Comece aqui**: install, config (Claude Desktop/Code/Cursor), quickstart
- **Interfaces**: MCP, CLI, REST API, Web UI, Node.js
- **Modulos**: stubs por modulo (CNPJ, CPF, NFe, SPED, Simples, CNAE, IBGE, CEP)
- **Tools agenticas**: 5 paginas detalhadas (compliance, regimes, supplier, NFe, SPED)
- **Casos de uso**: due diligence, planejamento tributario, validacao de fornecedor
- **Contribuir + Changelog**

## Recursos do site

- Tema verde/amarelo (cores BR)
- Modo claro/escuro com toggle
- Busca em pt-BR
- Diagramas Mermaid
- Code copy buttons
- Edit-on-GitHub links

## Workflow

`.github/workflows/docs.yml` constroi com `mkdocs build --strict` e deploya em Pages. Trigger: push em `main` que toque `docs/`, `mkdocs.yml` ou `CHANGELOG.md`. Tambem `workflow_dispatch` manual.

## Pre-merge

Apos merge, voce precisa habilitar GitHub Pages em **Settings -> Pages -> Source: GitHub Actions** (1x). Depois o deploy roda automatico.