### PR TITLE
feat(deploy): blueprints Render.com e Fly.io + guia de hospedagem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@
 
 ---
 
+## 🌎 Demo ao vivo
+
+Web UI demo hospedada (Render free tier, pode demorar 30s no primeiro acesso pra acordar):
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/nikolasdehor/mcp-fiscal-brasil)
+
+Você pode clicar no botão acima pra hostear sua própria instância em 3 cliques no Render.com.
+
+Veja [docs/getting-started/deploy.md](docs/getting-started/deploy.md) para outras opções (Fly.io, auto-host via Docker).
+
+---
+
 ## ✨ Novidades v0.2.0
 
 Versão de evolução com 4 frentes:

--- a/docs/getting-started/deploy.md
+++ b/docs/getting-started/deploy.md
@@ -1,0 +1,84 @@
+# Hospedagem
+
+Quer rodar o `mcp-fiscal-brasil` como servico publico ou interno? Tres opcoes pre-configuradas no repo.
+
+## Render.com (recomendado para demo)
+
+Free tier com 750h/mes. Servico dorme apos 15min de inatividade (cold start de ~30s ao acordar).
+
+### Setup
+
+1. Crie conta em [render.com](https://render.com)
+2. Em **Dashboard -> New -> Blueprint**
+3. Aponte para `https://github.com/nikolasdehor/mcp-fiscal-brasil`
+4. Render le `render.yaml` e configura tudo automaticamente
+5. Apos ~3min, voce tem URL tipo `mcp-fiscal-brasil.onrender.com`
+
+### URL publica
+
+- Web UI: `https://mcp-fiscal-brasil.onrender.com/`
+- OpenAPI: `https://mcp-fiscal-brasil.onrender.com/docs`
+- Endpoints: `https://mcp-fiscal-brasil.onrender.com/v1/...`
+
+## Fly.io (recomendado para producao)
+
+Free allowance pequeno mas estavel. Latencia minima do BR (region `gru` = Sao Paulo). Sempre ativo (sem cold start).
+
+### Setup
+
+```bash
+# Instalar flyctl
+brew install flyctl  # ou: curl -L https://fly.io/install.sh | sh
+
+flyctl auth signup
+flyctl launch --copy-config --no-deploy --name mcp-fiscal-brasil --region gru
+flyctl deploy
+```
+
+`fly.toml` ja vem configurado no repo.
+
+### URL publica
+
+- `https://mcp-fiscal-brasil.fly.dev/`
+
+## Auto-host via Docker
+
+Em qualquer VPS com Docker:
+
+```bash
+docker run -d \
+  --name mcp-fiscal \
+  --restart=always \
+  -p 80:8000 \
+  -e MCP_FISCAL_CACHE_TTL=600 \
+  -e MCP_FISCAL_RATE_LIMIT=10 \
+  ghcr.io/nikolasdehor/mcp-fiscal-brasil:0.2.0 \
+  mcp-fiscal-api
+```
+
+Ou via docker-compose (`docker-compose.yml` do repo):
+
+```bash
+docker compose up -d api
+```
+
+## Configuracao recomendada para producao
+
+Independente da plataforma, em producao real:
+
+- **`MCP_FISCAL_CACHE_BACKEND=redis`** + Redis externo (Render/Fly oferecem add-ons)
+- **`MCP_FISCAL_RATE_LIMIT=20`** ou mais (ajustar pela taxa de erros das APIs publicas)
+- **`MCP_FISCAL_LOG_LEVEL=INFO`** (debug so em troubleshooting)
+- **Proxy reverso com auth** (Nginx + basic auth, Cloudflare Access, etc) se exposto publicamente
+- **HTTPS obrigatorio** (todas as plataformas acima cobrem isso automaticamente)
+
+## Custos esperados
+
+| Plataforma | Plano | Custo/mes | Always-on |
+|------------|-------|-----------|-----------|
+| Render | Free | $0 | Nao (sleep 15min) |
+| Render | Starter | US$ 7 | Sim |
+| Fly.io | Free allowance | $0 | Sim (256MB) |
+| Fly.io | Shared CPU | ~US$ 3 | Sim (256MB) |
+| AWS EC2 t4g.nano | spot | ~US$ 2 | Sim |
+| Hostinger VPS | KVM 1 | R$ 12 | Sim |

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,56 @@
+# Configuracao Fly.io para deploy alternativo do mcp-fiscal-brasil.
+#
+# Setup inicial (1x):
+#   flyctl auth signup
+#   flyctl launch --copy-config --no-deploy --name mcp-fiscal-brasil --region gru
+#   flyctl deploy
+#
+# Updates apos push:
+#   flyctl deploy
+#
+# Free allowance: pequena (256MB), suficiente para demo. Para producao, plano 'shared-cpu-1x'.
+
+app = "mcp-fiscal-brasil"
+primary_region = "gru"  # Sao Paulo, latencia minima para BR
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  HOST = "0.0.0.0"
+  PORT = "8000"
+  MCP_FISCAL_HTTP_TIMEOUT = "30"
+  MCP_FISCAL_CACHE_TTL = "600"
+  MCP_FISCAL_CACHE_BACKEND = "memory"
+  MCP_FISCAL_RATE_LIMIT = "5"
+  MCP_FISCAL_LOG_LEVEL = "INFO"
+
+[processes]
+  app = "mcp-fiscal-api"
+
+[[services]]
+  internal_port = 8000
+  protocol = "tcp"
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [services.http_checks]
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Instalacao: getting-started/install.md
       - Configuracao: getting-started/config.md
       - Primeiro uso: getting-started/quickstart.md
+      - Hospedagem: getting-started/deploy.md
   - Interfaces:
       - MCP Server: interfaces/mcp.md
       - CLI: interfaces/cli.md

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,40 @@
+# Render.com blueprint para deploy automatico da REST API + Web UI demo
+# do mcp-fiscal-brasil.
+#
+# Deploy:
+# 1. Faca login em https://dashboard.render.com
+# 2. New -> Blueprint -> aponte para este repo
+# 3. Render le este arquivo e configura tudo
+#
+# Free tier:
+# - Servico web dorme apos 15min de inatividade
+# - Primeiro request acordando demora ~30s (cold start)
+# - 750 horas/mes free (suficiente para demos)
+#
+# Para producao real, use plano starter (US$ 7/mes) que mantem o servico sempre ativo.
+
+services:
+  - type: web
+    name: mcp-fiscal-brasil
+    runtime: docker
+    plan: free
+    region: oregon  # mais proximo do BR no free tier
+    dockerfilePath: ./Dockerfile
+    dockerCommand: mcp-fiscal-api
+    healthCheckPath: /health
+    autoDeploy: true
+    envVars:
+      - key: HOST
+        value: 0.0.0.0
+      - key: PORT
+        value: "8000"
+      - key: MCP_FISCAL_HTTP_TIMEOUT
+        value: "30"
+      - key: MCP_FISCAL_CACHE_TTL
+        value: "600"
+      - key: MCP_FISCAL_CACHE_BACKEND
+        value: memory
+      - key: MCP_FISCAL_RATE_LIMIT
+        value: "5"
+      - key: MCP_FISCAL_LOG_LEVEL
+        value: INFO


### PR DESCRIPTION
## Resumo

Adiciona deploy ready-to-go para hospedar a REST API + Web UI demo do mcp-fiscal-brasil publicamente.

## Componentes

### `render.yaml` (recomendado para demo)
Render.com blueprint com free tier. 750h/mes, cold start ~30s apos 15min idle. Region oregon. Healthcheck em /health.

### `fly.toml` (recomendado para producao)
Fly.io config com region `gru` (Sao Paulo). Sempre ativo (sem cold start). 256MB free allowance.

### `docs/getting-started/deploy.md`
Guia completo com:
- Setup passo-a-passo (Render + Fly.io)
- Comparativo de custos
- Auto-host via Docker
- Configuracao recomendada para producao

### README
Botao 'Deploy to Render' permitindo deploy em 3 cliques.

## Workflow apos merge

1. Voce vai em https://render.com/deploy?repo=https://github.com/nikolasdehor/mcp-fiscal-brasil
2. Login no Render -> clica deploy
3. ~3min depois, URL publica tipo `mcp-fiscal-brasil.onrender.com`
4. Voce pode atualizar README/docs com a URL real

Ou via Fly.io: `flyctl launch --copy-config && flyctl deploy`.