### PR TITLE
fix: description do server.json no limite do MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nikolasdehor/mcp-fiscal-brasil",
   "title": "MCP Fiscal Brasil",
-  "description": "Servidor MCP para integrar IAs com o sistema fiscal brasileiro. Consulte CNPJ, NFe, NFSe, SPED, eSocial e mais via linguagem natural.",
+  "description": "Servidor MCP para integrar IAs com o sistema fiscal brasileiro: CNPJ, NFe, NFSe, SPED, eSocial.",
   "version": "0.2.1",
   "repository": {
     "url": "https://github.com/nikolasdehor/mcp-fiscal-brasil",


### PR DESCRIPTION
## O que muda

- Encurta a `description` do `server.json` para respeitar o limite de 100 caracteres do MCP Registry.
- Correcao de sincronizacao: o campo publicado no registry ja estava correto, agora o repo bate com ele.

## Como testar

- Verificar que `server.json` tem `description` com 100 chars ou menos.
- Confirmar que `npm run build` passa sem erros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refinada a descrição de configuração do servidor para refletir com mais precisão as funcionalidades específicas suportadas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolasdehor/mcp-fiscal-brasil/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->