### PR TITLE
chore: corrige config do CodeRabbit (tools dentro de reviews)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -57,19 +57,19 @@ reviews:
     - "!uv.lock"
     - "!.coderabbit.yaml"
 
-tools:
-  ruff:
-    enabled: true
-  flake8:
-    enabled: true
-  semgrep:
-    enabled: true
-  gitleaks:
-    enabled: true
-  presidio:
-    enabled: true
-  markdownlint:
-    enabled: true
+  tools:
+    ruff:
+      enabled: true
+    flake8:
+      enabled: true
+    semgrep:
+      enabled: true
+    gitleaks:
+      enabled: true
+    presidio:
+      enabled: true
+    markdownlint:
+      enabled: true
 
 knowledge_base:
   web_search:


### PR DESCRIPTION
Move o bloco `tools` para dentro de `reviews`, corrigindo a posicao incorreta que gerava propriedades nao reconhecidas pelo CodeRabbit.

**Mudanca**: `tools` estava no nivel raiz do YAML, agora esta corretamente aninhado dentro de `reviews`.