### PR TITLE
chore: add release metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release de consolidação dos fluxos agenticos fiscais e da publicação do paco
 ## [0.2.1] - 2026-05-29
 
 ### Changed
+
 - Ajuste de consistência de release metadata entre `pyproject.toml`, `server.json` e `npm-wrapper/package.json` (todos com versão `0.2.1`).
 - Corrigida a documentação de histórico de releases para incluir uma entrada de `0.2.1` com foco em alinhamento de versionamento e integridade de artefatos.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Release de consolidação dos fluxos agenticos fiscais e da publicação do paco
 - Validação de entradas NFSe e padronização do campo `numero`.
 - Processamento em lote com concorrência controlada, limite de lote e logs estruturados de falha.
 
+## [0.2.1] - 2026-05-29
+
+### Changed
+- Ajuste de consistência de release metadata entre `pyproject.toml`, `server.json` e `npm-wrapper/package.json` (todos com versão `0.2.1`).
+- Corrigida a documentação de histórico de releases para incluir uma entrada de `0.2.1` com foco em alinhamento de versionamento e integridade de artefatos.
+
 ## [0.2.0] - 2026-05-20
 
 Release focada em produzir o MCP fiscal brasileiro mais completo do mercado.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev install test lint format typecheck build serve clean
+.PHONY: dev install test lint format typecheck build serve check check-release-metadata clean
 
 # Instala dependencias de desenvolvimento
 dev:
@@ -32,6 +32,10 @@ typecheck:
 
 # Lint + typecheck
 check: lint typecheck
+
+# Valida metadados de release/versionamento
+check-release-metadata:
+	@python scripts/check_release_metadata.py
 
 # Build do pacote
 build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "ruff>=0.4.0",
     "mypy>=1.10",
     "pre-commit>=3.7",
+    "tomli>=2.0.1; python_version < '3.11'",
 ]
 
 [project.scripts]

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+try:
+    import tomllib  # py311+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+
+def main() -> int:
+    root = pathlib.Path.cwd()
+
+    with (root / "pyproject.toml").open("rb") as fp:
+        project_data = tomllib.load(fp)
+
+    with (root / "server.json").open("r", encoding="utf-8") as fp:
+        server_data = json.load(fp)
+
+    with (root / "npm-wrapper" / "package.json").open("r", encoding="utf-8") as fp:
+        npm_data = json.load(fp)
+
+    with (root / "CHANGELOG.md").open("r", encoding="utf-8") as fp:
+        changelog = fp.read()
+
+    versions = {
+        "pyproject.toml": project_data["project"]["version"],
+        "server.json": server_data["version"],
+        "npm-wrapper/package.json": npm_data["version"],
+    }
+
+    unique_versions = set(versions.values())
+    release_version = project_data["project"]["version"]
+
+    if len(unique_versions) != 1:
+        print("FALHA: versões inconsistentes nos metadados.")
+        for file_path, version in versions.items():
+            print(f"  {file_path}: {version}")
+        return 1
+
+    if f"## [{release_version}]" not in changelog:
+        print(f"FALHA: seção ## [{release_version}] não encontrada no CHANGELOG.md.")
+        return 1
+
+    print(f"OK: release metadata consistente ({release_version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -11,7 +11,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 
 def main() -> int:
-    root = pathlib.Path.cwd()
+    root = pathlib.Path(__file__).resolve().parents[1]
 
     with (root / "pyproject.toml").open("rb") as fp:
         project_data = tomllib.load(fp)
@@ -30,6 +30,15 @@ def main() -> int:
         "server.json": server_data["version"],
         "npm-wrapper/package.json": npm_data["version"],
     }
+
+    for idx, package_data in enumerate(server_data.get("packages", [])):
+        package_version = package_data.get("version")
+        package_name = package_data.get("identifier", f"package-{idx}")
+        package_path = f"server.json.packages[{idx}] ({package_name})"
+        if package_version is None:
+            print(f"FALHA: {package_path} não declara version.")
+            return 1
+        versions[f"{package_path}.version"] = package_version
 
     unique_versions = set(versions.values())
     release_version = project_data["project"]["version"]


### PR DESCRIPTION
## Summary
- Adds a reusable `make check-release-metadata` validation for release metadata consistency.
- Adds `scripts/check_release_metadata.py` to compare `pyproject.toml`, `server.json`, and `npm-wrapper/package.json` versions and verify the current version has a changelog entry.
- Adds the missing historical `0.2.1` changelog entry and Python 3.10-compatible `tomli` dev fallback.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 make check-release-metadata`
- `PYTHONDONTWRITEBYTECODE=1 python scripts/check_release_metadata.py`

## Gate
- No merge/release requested here. Merge still requires current CI plus review-gate triage for automated and human findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Histórico de releases atualizado e documentado para a versão 0.2.1.
  * Adicionada validação automática de consistência de versionamento entre artefatos de release.
  * Incluído alvo de build para executar a verificação de metadados de release.
  * Adicionada dependência de desenvolvimento para suporte a parsing TOML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->