### PR TITLE
docs: README com uvx e snippets de instalacao para clientes MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ mcp-name: io.github.dehor-labs/mcp-fiscal-brasil
 </p>
 
 <p align="center">
-  <strong>A camada open source para agentes de IA trabalharem com compliance fiscal brasileiro</strong>
+  <strong>Zero API key. Zero cadastro. 100% open source.</strong><br>
+  A camada open source para agentes de IA trabalharem com compliance fiscal brasileiro.
 </p>
 
 <p align="center">
@@ -198,36 +199,19 @@ Requerem APIs pagas ou têm cobertura limitada.
 
 ## 🚀 Instalação
 
-Três linhas para começar:
+A forma mais simples, sem instalar nada permanentemente:
 
 ```bash
-pip install mcp-fiscal-brasil
-claude mcp add fiscal-brasil -- mcp-fiscal-brasil
-# Pronto! Pergunte ao Claude sobre qualquer empresa brasileira.
+uvx mcp-fiscal-brasil
 ```
 
-```python
-# Ou use como biblioteca Python:
-from mcp_fiscal_brasil import FiscalBrasil
-```
-
-### Via uv (recomendado)
-
-```bash
-uv add mcp-fiscal-brasil
-```
-
-### A partir do código-fonte
-
-```bash
-git clone https://github.com/DeHor-Labs/mcp-fiscal-brasil.git
-cd mcp-fiscal-brasil
-pip install -e .
-```
+> **O que é `uvx`?** É o gerenciador de ferramentas do [uv](https://docs.astral.sh/uv/), que baixa e executa pacotes Python em ambiente isolado, sem poluir seu sistema. Se ainda não tem o uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 ---
 
-## ⚙️ Configuração Detalhada
+## ⚙️ Configuração por Cliente MCP
+
+Cole o trecho abaixo no arquivo de configuração do seu cliente. **Nenhuma chave de API é necessária.**
 
 ### Claude Desktop
 
@@ -237,7 +221,8 @@ Edite `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) 
 {
   "mcpServers": {
     "fiscal-brasil": {
-      "command": "mcp-fiscal-brasil"
+      "command": "uvx",
+      "args": ["mcp-fiscal-brasil"]
     }
   }
 }
@@ -248,18 +233,19 @@ Reinicie o Claude Desktop. As ferramentas fiscais e agênticas aparecem automati
 ### Claude Code (CLI)
 
 ```bash
-claude mcp add fiscal-brasil -- mcp-fiscal-brasil
+claude mcp add fiscal-brasil -- uvx mcp-fiscal-brasil
 ```
 
-### Cursor
+### Cursor / `.mcp.json`
 
-Adicione ao `.cursor/mcp.json` do projeto:
+Crie ou edite `.cursor/mcp.json` (ou `.mcp.json` na raiz do projeto):
 
 ```json
 {
   "mcpServers": {
     "fiscal-brasil": {
-      "command": "mcp-fiscal-brasil"
+      "command": "uvx",
+      "args": ["mcp-fiscal-brasil"]
     }
   }
 }
@@ -273,7 +259,8 @@ Adicione ao `settings.json`:
 {
   "continue.mcpServers": {
     "fiscal-brasil": {
-      "command": "mcp-fiscal-brasil"
+      "command": "uvx",
+      "args": ["mcp-fiscal-brasil"]
     }
   }
 }
@@ -285,6 +272,30 @@ Adicione ao `settings.json`:
 docker run --rm -i \
   -e MCP_FISCAL_LOG_LEVEL=INFO \
   ghcr.io/dehor-labs/mcp-fiscal-brasil:latest
+```
+
+---
+
+## 🛠 Instalação permanente (alternativa)
+
+Prefere instalar uma vez e manter no PATH?
+
+```bash
+# via pip
+pip install mcp-fiscal-brasil
+
+# via uv (recomendado para projetos Python)
+uv add mcp-fiscal-brasil
+```
+
+Após a instalação, os snippets JSON acima funcionam com `"command": "mcp-fiscal-brasil"` (sem o `uvx`).
+
+### A partir do código-fonte
+
+```bash
+git clone https://github.com/DeHor-Labs/mcp-fiscal-brasil.git
+cd mcp-fiscal-brasil
+pip install -e .
 ```
 
 ---


### PR DESCRIPTION
## O que mudou

A secao de instalacao do README foi refatorada para refletir a forma mais simples e recomendada de usar o servidor MCP: via `uvx`, sem instalacao permanente.

### Mudancas principais

- **Diferencial no topo**: linha "Zero API key. Zero cadastro. 100% open source." adicionada logo abaixo do subtitulo, tornando o valor do projeto imediatamente claro para quem chega do PyPI, Smithery ou pesquisa no GitHub
- **Instrucao primaria via `uvx`**: `uvx mcp-fiscal-brasil` e agora a primeira instrucao de instalacao, com explicacao rapida do que e o uv e como instalar caso necessario
- **Snippets JSON prontos por cliente MCP**: blocos de configuracao completos para copiar e colar direto em Claude Desktop, Claude Code, Cursor e VS Code + Continue, todos usando `uvx` para zero configuracao de ambiente
- **pip e uv add como alternativa secundaria**: mantidos em secao propria "Instalacao permanente" para quem prefere ter o pacote instalado globalmente

### Por que isso importa

O maior atrito na adocao de servidores MCP e saber exatamente o que colar no arquivo de configuracao. Com os snippets prontos por cliente, o tempo de "instalar e usar" cai de minutos para segundos.

## Tipo de mudanca

- [x] Documentacao (sem mudanca de codigo)

## Checklist

- [x] Apenas README.md alterado
- [x] Nenhuma chave de API necessaria para usar o servidor (confirmado)
- [x] Snippets testados manualmente para formato JSON valido

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Apresentação do projeto renovada no banner.
  * Instalação simplificada destacando fluxo sem instalação permanente via `uvx mcp-fiscal-brasil`.
  * Instruções de configuração para clientes MCP (Claude Desktop, Cursor, VS Code) atualizadas com suporte a `uvx`.
  * Nova seção de instalação permanente com alternativas via `pip install` e `uv add`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->