### PR TITLE
feat: Reforma Tributaria 2026 - IBS/CBS/IS na NF-e, CNPJ alfanumerico, NFS-e Nacional

### DIFF
--- a/docs/gen_api_pages.py
+++ b/docs/gen_api_pages.py
@@ -87,9 +87,7 @@ for module in MODULES_TO_DOCUMENT:
         fd.write("        - '!^_'\n")  # esconde _privates
         fd.write("      heading_level: 2\n")
 
-    nav[(module,)] = (
-        f"{module}/index.md" if module_path.is_dir() else f"{module}.md"
-    )
+    nav[(module,)] = f"{module}/index.md" if module_path.is_dir() else f"{module}.md"
 
 
 with mkdocs_gen_files.open(REFERENCE_ROOT / "SUMMARY.md", "w") as fd:

--- a/examples/cnpj_lookup.py
+++ b/examples/cnpj_lookup.py
@@ -98,4 +98,3 @@ async def main() -> None:
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/src/mcp_fiscal_brasil/nfe/schemas.py
+++ b/src/mcp_fiscal_brasil/nfe/schemas.py
@@ -37,6 +37,15 @@ class ItemNFe(BaseModel):
     valor_pis: float | None = None
     aliquota_cofins: float | None = None
     valor_cofins: float | None = None
+    # Campos Reforma Tributária (NT 2025.002) - opcionais para retrocompatibilidade
+    aliquota_ibs_uf: float | None = None
+    valor_ibs_uf: float | None = None
+    aliquota_ibs_mun: float | None = None
+    valor_ibs_mun: float | None = None
+    aliquota_cbs: float | None = None
+    valor_cbs: float | None = None
+    aliquota_is: float | None = None
+    valor_is: float | None = None
 
 
 class TotaisNFe(BaseModel):
@@ -58,6 +67,17 @@ class TotaisNFe(BaseModel):
     valor_nota: float | None = None
 
 
+class TotaisReformaNFe(BaseModel):
+    """Totais dos tributos da Reforma Tributária na NF-e (NT 2025.002 - Grupo W03/IBSCBSTot)."""
+
+    base_calculo_ibscbs: float | None = None
+    valor_ibs_uf: float | None = None
+    valor_ibs_mun: float | None = None
+    valor_ibs: float | None = None
+    valor_cbs: float | None = None
+    valor_is: float | None = None
+
+
 class NFeResponse(BaseResponse):
     """Dados de uma NFe consultada."""
 
@@ -74,6 +94,7 @@ class NFeResponse(BaseResponse):
     finalidade: str | None = None
     itens: list[ItemNFe] = Field(default_factory=list)
     totais: TotaisNFe | None = None
+    totais_reforma: TotaisReformaNFe | None = None
     protocolo_autorizacao: str | None = None
     data_autorizacao: datetime | None = None
     situacao: str | None = None

--- a/src/mcp_fiscal_brasil/nfe/xml_parser.py
+++ b/src/mcp_fiscal_brasil/nfe/xml_parser.py
@@ -110,16 +110,20 @@ def _parse_item(det: etree._Element, ns: dict[str, str]) -> ItemNFe:
         # Simples/MEI em 04/01/2027.
         ibscbs_el = _find_any(imposto, "nfe:IBSCBS", "IBSCBS", ns)
         if ibscbs_el is not None:
-            # NT v1.40 usa tanto IBSUF quanto gIBSUF - aceita ambas as variantes
-            ibsuf_el = _find_any(ibscbs_el, "nfe:gIBSUF", "gIBSUF", ns) or _find_any(
-                ibscbs_el, "nfe:IBSUF", "IBSUF", ns
+            # NT v1.40 usa tanto IBSUF quanto gIBSUF - aceita ambas as variantes.
+            # Usa is not None explícito pra evitar FutureWarning do lxml (truth-testing).
+            _ibsuf_g = _find_any(ibscbs_el, "nfe:gIBSUF", "gIBSUF", ns)
+            ibsuf_el = (
+                _ibsuf_g if _ibsuf_g is not None else _find_any(ibscbs_el, "nfe:IBSUF", "IBSUF", ns)
             )
-            ibsmun_el = _find_any(ibscbs_el, "nfe:gIBSMun", "gIBSMun", ns) or _find_any(
-                ibscbs_el, "nfe:IBSMun", "IBSMun", ns
+            _ibsmun_g = _find_any(ibscbs_el, "nfe:gIBSMun", "gIBSMun", ns)
+            ibsmun_el = (
+                _ibsmun_g
+                if _ibsmun_g is not None
+                else _find_any(ibscbs_el, "nfe:IBSMun", "IBSMun", ns)
             )
-            cbs_el = _find_any(ibscbs_el, "nfe:gCBS", "gCBS", ns) or _find_any(
-                ibscbs_el, "nfe:CBS", "CBS", ns
-            )
+            _cbs_g = _find_any(ibscbs_el, "nfe:gCBS", "gCBS", ns)
+            cbs_el = _cbs_g if _cbs_g is not None else _find_any(ibscbs_el, "nfe:CBS", "CBS", ns)
 
         # IS (Imposto Seletivo) é IRMÃO de IBSCBS em det/imposto/IS per NT 2025.002.
         # Como fallback, busca também dentro de IBSCBS para compatibilidade

--- a/src/mcp_fiscal_brasil/nfe/xml_parser.py
+++ b/src/mcp_fiscal_brasil/nfe/xml_parser.py
@@ -6,7 +6,7 @@ from typing import cast
 from lxml import etree
 
 from ..shared.xml_utils import NS_NFE, parse_xml, xpath_text
-from .schemas import EnderecoNFe, ItemNFe, NFeResponse, TotaisNFe
+from .schemas import EnderecoNFe, ItemNFe, NFeResponse, TotaisNFe, TotaisReformaNFe
 
 
 def _find_any(
@@ -94,10 +94,24 @@ def _parse_item(det: etree._Element, ns: dict[str, str]) -> ItemNFe:
     imposto = _find_any(det, "nfe:imposto", "imposto", ns)
 
     icms_el = None
+    ibscbs_el = None
+    ibsuf_el = None
+    ibsmun_el = None
+    cbs_el = None
+    is_el = None
+
     if imposto is not None:
         icms_group = _find_any(imposto, "nfe:ICMS", "ICMS", ns)
         if icms_group is not None and len(icms_group):
             icms_el = icms_group[0]  # ICMS00, ICMS10, etc.
+
+        # Campos Reforma Tributária (NT 2025.002) - opcionais
+        ibscbs_el = _find_any(imposto, "nfe:IBSCBS", "IBSCBS", ns)
+        if ibscbs_el is not None:
+            ibsuf_el = _find_any(ibscbs_el, "nfe:IBSUF", "IBSUF", ns)
+            ibsmun_el = _find_any(ibscbs_el, "nfe:IBSMun", "IBSMun", ns)
+            cbs_el = _find_any(ibscbs_el, "nfe:CBS", "CBS", ns)
+            is_el = _find_any(ibscbs_el, "nfe:IS", "IS", ns)
 
     return ItemNFe(
         número=int(numero_str),
@@ -114,6 +128,23 @@ def _parse_item(det: etree._Element, ns: dict[str, str]) -> ItemNFe:
         cst_icms=_xpath_text_any(icms_el, "nfe:CST/text()", "CST/text()", ns),
         aliquota_icms=_safe_float(_xpath_text_any(icms_el, "nfe:pICMS/text()", "pICMS/text()", ns)),
         valor_icms=_safe_float(_xpath_text_any(icms_el, "nfe:vICMS/text()", "vICMS/text()", ns)),
+        # Reforma Tributária - IBS/CBS/IS (opcionais)
+        aliquota_ibs_uf=_safe_float(
+            _xpath_text_any(ibsuf_el, "nfe:pAliq/text()", "pAliq/text()", ns)
+        ),
+        valor_ibs_uf=_safe_float(
+            _xpath_text_any(ibsuf_el, "nfe:vIBSUF/text()", "vIBSUF/text()", ns)
+        ),
+        aliquota_ibs_mun=_safe_float(
+            _xpath_text_any(ibsmun_el, "nfe:pAliq/text()", "pAliq/text()", ns)
+        ),
+        valor_ibs_mun=_safe_float(
+            _xpath_text_any(ibsmun_el, "nfe:vIBSMun/text()", "vIBSMun/text()", ns)
+        ),
+        aliquota_cbs=_safe_float(_xpath_text_any(cbs_el, "nfe:pAliq/text()", "pAliq/text()", ns)),
+        valor_cbs=_safe_float(_xpath_text_any(cbs_el, "nfe:vCBS/text()", "vCBS/text()", ns)),
+        aliquota_is=_safe_float(_xpath_text_any(is_el, "nfe:pIS/text()", "pIS/text()", ns)),
+        valor_is=_safe_float(_xpath_text_any(is_el, "nfe:vIS/text()", "vIS/text()", ns)),
     )
 
 
@@ -139,6 +170,7 @@ def parse_nfe_xml(xml_content: str | bytes, chave: str) -> NFeResponse:
     emit = _find_any(inf_nfe, "nfe:emit", "emit", ns)
     dest = _find_any(inf_nfe, "nfe:dest", "dest", ns)
     total = _find_any(inf_nfe, "nfe:total/nfe:ICMSTot", "total/ICMSTot", ns)
+    total_reforma = _find_any(inf_nfe, "nfe:total/nfe:IBSCBSTot", "total/IBSCBSTot", ns)
 
     # Data de emissão
     data_emissao = None
@@ -186,6 +218,30 @@ def parse_nfe_xml(xml_content: str | bytes, chave: str) -> NFeResponse:
             valor_nota=_safe_float(_xpath_text_any(total, "nfe:vNF/text()", "vNF/text()", ns)),
         )
 
+    # Totais Reforma Tributária (NT 2025.002 - Grupo W03/IBSCBSTot) - opcionais
+    totais_reforma = None
+    if total_reforma is not None:
+        totais_reforma = TotaisReformaNFe(
+            base_calculo_ibscbs=_safe_float(
+                _xpath_text_any(total_reforma, "nfe:vBCIBSCBS/text()", "vBCIBSCBS/text()", ns)
+            ),
+            valor_ibs_uf=_safe_float(
+                _xpath_text_any(total_reforma, "nfe:vIBSUF/text()", "vIBSUF/text()", ns)
+            ),
+            valor_ibs_mun=_safe_float(
+                _xpath_text_any(total_reforma, "nfe:vIBSMun/text()", "vIBSMun/text()", ns)
+            ),
+            valor_ibs=_safe_float(
+                _xpath_text_any(total_reforma, "nfe:vIBS/text()", "vIBS/text()", ns)
+            ),
+            valor_cbs=_safe_float(
+                _xpath_text_any(total_reforma, "nfe:vCBS/text()", "vCBS/text()", ns)
+            ),
+            valor_is=_safe_float(
+                _xpath_text_any(total_reforma, "nfe:vIS/text()", "vIS/text()", ns)
+            ),
+        )
+
     return NFeResponse(
         chave_acesso=chave,
         número=_xpath_text_any(ide, "nfe:nNF/text()", "nNF/text()", ns),
@@ -198,5 +254,6 @@ def parse_nfe_xml(xml_content: str | bytes, chave: str) -> NFeResponse:
         tipo_operacao=_xpath_text_any(ide, "nfe:tpNF/text()", "tpNF/text()", ns),
         itens=itens,
         totais=totais,
+        totais_reforma=totais_reforma,
         protocolo_autorizacao=protocolo,
     )

--- a/src/mcp_fiscal_brasil/nfe/xml_parser.py
+++ b/src/mcp_fiscal_brasil/nfe/xml_parser.py
@@ -106,11 +106,26 @@ def _parse_item(det: etree._Element, ns: dict[str, str]) -> ItemNFe:
             icms_el = icms_group[0]  # ICMS00, ICMS10, etc.
 
         # Campos Reforma Tributária (NT 2025.002) - opcionais
+        # Obrigatoriedade NF-e: produção CRT3 em 03/08/2026, homologação 01/07/2026,
+        # Simples/MEI em 04/01/2027.
         ibscbs_el = _find_any(imposto, "nfe:IBSCBS", "IBSCBS", ns)
         if ibscbs_el is not None:
-            ibsuf_el = _find_any(ibscbs_el, "nfe:IBSUF", "IBSUF", ns)
-            ibsmun_el = _find_any(ibscbs_el, "nfe:IBSMun", "IBSMun", ns)
-            cbs_el = _find_any(ibscbs_el, "nfe:CBS", "CBS", ns)
+            # NT v1.40 usa tanto IBSUF quanto gIBSUF - aceita ambas as variantes
+            ibsuf_el = _find_any(ibscbs_el, "nfe:gIBSUF", "gIBSUF", ns) or _find_any(
+                ibscbs_el, "nfe:IBSUF", "IBSUF", ns
+            )
+            ibsmun_el = _find_any(ibscbs_el, "nfe:gIBSMun", "gIBSMun", ns) or _find_any(
+                ibscbs_el, "nfe:IBSMun", "IBSMun", ns
+            )
+            cbs_el = _find_any(ibscbs_el, "nfe:gCBS", "gCBS", ns) or _find_any(
+                ibscbs_el, "nfe:CBS", "CBS", ns
+            )
+
+        # IS (Imposto Seletivo) é IRMÃO de IBSCBS em det/imposto/IS per NT 2025.002.
+        # Como fallback, busca também dentro de IBSCBS para compatibilidade
+        # com implementações que posicionaram incorretamente.
+        is_el = _find_any(imposto, "nfe:IS", "IS", ns)
+        if is_el is None and ibscbs_el is not None:
             is_el = _find_any(ibscbs_el, "nfe:IS", "IS", ns)
 
     return ItemNFe(
@@ -143,6 +158,7 @@ def _parse_item(det: etree._Element, ns: dict[str, str]) -> ItemNFe:
         ),
         aliquota_cbs=_safe_float(_xpath_text_any(cbs_el, "nfe:pAliq/text()", "pAliq/text()", ns)),
         valor_cbs=_safe_float(_xpath_text_any(cbs_el, "nfe:vCBS/text()", "vCBS/text()", ns)),
+        # IS usa pIS/vIS (não pAliq como IBS/CBS) - NT 2025.002 seção UB04
         aliquota_is=_safe_float(_xpath_text_any(is_el, "nfe:pIS/text()", "pIS/text()", ns)),
         valor_is=_safe_float(_xpath_text_any(is_el, "nfe:vIS/text()", "vIS/text()", ns)),
     )

--- a/src/mcp_fiscal_brasil/nfse/client.py
+++ b/src/mcp_fiscal_brasil/nfse/client.py
@@ -59,9 +59,6 @@ class NFSeNacionalClient:
         Endpoint: GET /nfse/{chaveAcesso}
         Retorna None se a nota não for encontrada, se houver erro de autenticação
         (certificado não configurado) ou qualquer falha de rede.
+        O método _get já trata todas as exceções; não é necessário try/except aqui.
         """
-        try:
-            return await self._get(f"/nfse/{chave_acesso}")
-        except Exception as exc:
-            logger.debug("Erro inesperado em consultar_por_chave (%s): %s", chave_acesso, exc)
-            return None
+        return await self._get(f"/nfse/{chave_acesso}")

--- a/src/mcp_fiscal_brasil/nfse/client.py
+++ b/src/mcp_fiscal_brasil/nfse/client.py
@@ -1,10 +1,67 @@
 """
-Cliente NFSe.
+Cliente para a API Nacional NFS-e (Sistema Nacional NFS-e - adn.nfse.gov.br).
 
-NFSe não tem padrao nacional unico - cada municipio implementa seu próprio
-webservice (ABRASF, Betha, ISS.net, Curitiba, etc.). Este modulo fornece
-uma interface unificada que abstrai essas diferencas.
+IMPORTANTE: A API Nacional exige certificado digital ICP-Brasil com mTLS.
+Sem certificado configurado, todas as chamadas retornam None e a tool
+cai automaticamente no fallback estático de portais municipais.
+
+Referência: https://www.gov.br/nfse/pt-br/biblioteca/documentacao-tecnica/apis-prod-restrita-e-producao
 """
-# Implementacao futura: detectar padrao pelo municipio e rotear para o webservice correto.
-# Municipios que adotam padrao ABRASF: São Paulo, Rio de Janeiro, Belo Horizonte, etc.
-# Referencia: https://www.abrasf.org.br/
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# URL base da API de Dados Nacionais (ADN) em produção
+_BASE_URL = "https://adn.nfse.gov.br"
+# Timeout conservador: a API pode ser lenta
+_TIMEOUT = httpx.Timeout(connect=5.0, read=20.0, write=10.0, pool=5.0)
+
+
+class NFSeNacionalClient:
+    """
+    Cliente para consulta de NFS-e na API Nacional (adn.nfse.gov.br).
+
+    Retorna None em qualquer erro (auth, timeout, 404, rede) para que a
+    camada superior possa acionar o fallback com orientações manuais.
+    """
+
+    def __init__(self, base_url: str = _BASE_URL) -> None:
+        self._base_url = base_url.rstrip("/")
+
+    async def _get(self, path: str) -> dict[str, Any] | None:
+        """Executa GET na API Nacional. Retorna None em qualquer falha."""
+        url = f"{self._base_url}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                response = await client.get(url)
+            if response.status_code == 404:
+                return None
+            if response.status_code != 200:
+                logger.debug(
+                    "API Nacional NFS-e retornou %d para %s",
+                    response.status_code,
+                    path,
+                )
+                return None
+            return response.json()  # type: ignore[no-any-return]
+        except Exception as exc:
+            logger.debug("Falha na API Nacional NFS-e (%s): %s", path, exc)
+            return None
+
+    async def consultar_por_chave(self, chave_acesso: str) -> dict[str, Any] | None:
+        """
+        Consulta uma NFS-e pela chave de acesso.
+
+        Endpoint: GET /nfse/{chaveAcesso}
+        Retorna None se a nota não for encontrada, se houver erro de autenticação
+        (certificado não configurado) ou qualquer falha de rede.
+        """
+        try:
+            return await self._get(f"/nfse/{chave_acesso}")
+        except Exception as exc:
+            logger.debug("Erro inesperado em consultar_por_chave (%s): %s", chave_acesso, exc)
+            return None

--- a/src/mcp_fiscal_brasil/nfse/client.py
+++ b/src/mcp_fiscal_brasil/nfse/client.py
@@ -2,14 +2,15 @@
 Cliente para a API Nacional NFS-e (Sistema Nacional NFS-e - adn.nfse.gov.br).
 
 IMPORTANTE: A API Nacional exige certificado digital ICP-Brasil com mTLS.
-Sem certificado configurado, todas as chamadas retornam None e a tool
-cai automaticamente no fallback estático de portais municipais.
+Sem certificado configurado, todas as chamadas retornam None (nota nao encontrada)
+ou levantam NFSeNacionalUnavailableError (5xx, timeout, falha de rede).
 
 Referência: https://www.gov.br/nfse/pt-br/biblioteca/documentacao-tecnica/apis-prod-restrita-e-producao
 """
 
 import logging
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -21,19 +22,37 @@ _BASE_URL = "https://adn.nfse.gov.br"
 _TIMEOUT = httpx.Timeout(connect=5.0, read=20.0, write=10.0, pool=5.0)
 
 
+class NFSeNacionalUnavailableError(RuntimeError):
+    """Levantada quando a API Nacional NFS-e está indisponível (5xx, timeout, rede).
+
+    Distinto de retorno None (404 - nota não encontrada), esta exceção sinaliza
+    que o serviço está temporariamente inacessível e o fallback deve ser acionado
+    com motivo de indisponibilidade.
+    """
+
+
 class NFSeNacionalClient:
     """
     Cliente para consulta de NFS-e na API Nacional (adn.nfse.gov.br).
 
-    Retorna None em qualquer erro (auth, timeout, 404, rede) para que a
-    camada superior possa acionar o fallback com orientações manuais.
+    Contratos:
+    - Retorna None quando a nota não é encontrada (HTTP 404).
+    - Levanta NFSeNacionalUnavailableError para 5xx, timeout e erros de rede.
+
+    Isso permite que a camada superior distinga "nota não encontrada" de
+    "API indisponível" ao montar o api_nacional_motivo no fallback.
     """
 
     def __init__(self, base_url: str = _BASE_URL) -> None:
         self._base_url = base_url.rstrip("/")
 
     async def _get(self, path: str) -> dict[str, Any] | None:
-        """Executa GET na API Nacional. Retorna None em qualquer falha."""
+        """
+        Executa GET na API Nacional.
+
+        Retorna None para 404 (nota não encontrada).
+        Levanta NFSeNacionalUnavailableError para 5xx, timeout e falha de rede.
+        """
         url = f"{self._base_url}{path}"
         try:
             async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
@@ -41,24 +60,24 @@ class NFSeNacionalClient:
             if response.status_code == 404:
                 return None
             if response.status_code != 200:
-                logger.debug(
-                    "API Nacional NFS-e retornou %d para %s",
-                    response.status_code,
-                    path,
-                )
-                return None
+                raise NFSeNacionalUnavailableError(f"status={response.status_code} path={path}")
             return response.json()  # type: ignore[no-any-return]
-        except Exception as exc:
-            logger.debug("Falha na API Nacional NFS-e (%s): %s", path, exc)
-            return None
+        except NFSeNacionalUnavailableError:
+            raise
+        except httpx.HTTPError as exc:
+            raise NFSeNacionalUnavailableError(f"path={path}") from exc
 
     async def consultar_por_chave(self, chave_acesso: str) -> dict[str, Any] | None:
         """
         Consulta uma NFS-e pela chave de acesso.
 
         Endpoint: GET /nfse/{chaveAcesso}
-        Retorna None se a nota não for encontrada, se houver erro de autenticação
-        (certificado não configurado) ou qualquer falha de rede.
-        O método _get já trata todas as exceções; não é necessário try/except aqui.
+
+        A chave é codificada com urllib.parse.quote para evitar injecao de
+        caracteres de controle de rota (/, ?, #) no segmento de URL.
+
+        Retorna None se a nota não for encontrada (HTTP 404).
+        Levanta NFSeNacionalUnavailableError se a API estiver indisponível.
         """
-        return await self._get(f"/nfse/{chave_acesso}")
+        chave_segmento = quote(chave_acesso, safe="")
+        return await self._get(f"/nfse/{chave_segmento}")

--- a/src/mcp_fiscal_brasil/nfse/tools.py
+++ b/src/mcp_fiscal_brasil/nfse/tools.py
@@ -1,5 +1,6 @@
 """Ferramentas MCP para NFSe."""
 
+from mcp_fiscal_brasil.nfse.client import NFSeNacionalClient
 from mcp_fiscal_brasil.shared.validators import validate_cnpj
 
 
@@ -62,6 +63,24 @@ async def consultar_nfse(
     municipio = _validar_municipio_nfse(municipio)
     uf_upper = _validar_uf_nfse(uf)
     cnpj_prestador = _validar_cnpj_prestador(cnpj_prestador)
+
+    # Tenta a API do Ambiente de Dados Nacional (ADN) primeiro.
+    # A API exige certificado ICP-Brasil + mTLS; sem certificado retorna None
+    # e caímos no fallback com portais municipais.
+    try:
+        cliente_nacional = NFSeNacionalClient()
+        dados_api = await cliente_nacional.consultar_por_chave(numero)
+        if dados_api is not None:
+            return {
+                "numero": numero,
+                "municipio": municipio,
+                "uf": uf_upper,
+                "fonte": "api_nacional",
+                "status": "encontrada",
+                **dados_api,
+            }
+    except Exception:
+        pass  # Qualquer falha aciona o fallback estático abaixo
 
     # Portais de consulta por município/sistema (50+ capitais e grandes cidades)
     # Formato: "CIDADE/UF": {"portal": "url", "sistema": "tipo_sistema"}

--- a/src/mcp_fiscal_brasil/nfse/tools.py
+++ b/src/mcp_fiscal_brasil/nfse/tools.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from mcp_fiscal_brasil.nfse.client import NFSeNacionalClient
+from mcp_fiscal_brasil.nfse.client import NFSeNacionalClient, NFSeNacionalUnavailableError
 from mcp_fiscal_brasil.shared.validators import validate_cnpj
 
 logger = logging.getLogger(__name__)
@@ -69,8 +69,9 @@ async def consultar_nfse(
     cnpj_prestador = _validar_cnpj_prestador(cnpj_prestador)
 
     # Tenta a API do Ambiente de Dados Nacional (ADN) primeiro.
-    # A API exige certificado ICP-Brasil + mTLS; sem certificado retorna None.
-    # Qualquer falha aciona o fallback estático de portais municipais.
+    # A API exige certificado ICP-Brasil + mTLS.
+    # - None -> 404 (nota não encontrada): fallback com motivo específico
+    # - NFSeNacionalUnavailableError -> 5xx/timeout/rede: fallback com motivo de indisponibilidade
     api_fallback_motivo: str | None = None
     try:
         cliente_nacional = NFSeNacionalClient()
@@ -84,16 +85,23 @@ async def consultar_nfse(
                 "status": "encontrada",
                 **dados_api,
             }
-        # None indica nota não encontrada ou certificado ausente
-        api_fallback_motivo = "API Nacional retornou None (nota não encontrada ou certificado ICP-Brasil não configurado)"
+        # None = HTTP 404: nota não encontrada na base nacional
+        api_fallback_motivo = "Nota não encontrada na API Nacional (HTTP 404 - ausente ou certificado ICP-Brasil não configurado)"
         logger.info(
-            "API Nacional NFS-e: nota %s não encontrada ou sem certificado - usando fallback",
+            "API Nacional NFS-e: nota %s retornou 404 - usando fallback municipal",
             numero,
         )
-    except Exception as exc:
+    except NFSeNacionalUnavailableError as exc:
         api_fallback_motivo = f"API Nacional indisponível: {exc}"
         logger.warning(
-            "Falha ao consultar API Nacional NFS-e para nota %s: %s - usando fallback",
+            "API Nacional NFS-e indisponível para nota %s: %s - usando fallback municipal",
+            numero,
+            exc,
+        )
+    except Exception as exc:
+        api_fallback_motivo = f"Erro inesperado na API Nacional: {exc}"
+        logger.warning(
+            "Erro inesperado ao consultar API Nacional NFS-e para nota %s: %s - usando fallback",
             numero,
             exc,
         )

--- a/src/mcp_fiscal_brasil/nfse/tools.py
+++ b/src/mcp_fiscal_brasil/nfse/tools.py
@@ -1,7 +1,11 @@
 """Ferramentas MCP para NFSe."""
 
+import logging
+
 from mcp_fiscal_brasil.nfse.client import NFSeNacionalClient
 from mcp_fiscal_brasil.shared.validators import validate_cnpj
+
+logger = logging.getLogger(__name__)
 
 
 def _validar_numero_nfse(numero: str) -> str:
@@ -65,8 +69,9 @@ async def consultar_nfse(
     cnpj_prestador = _validar_cnpj_prestador(cnpj_prestador)
 
     # Tenta a API do Ambiente de Dados Nacional (ADN) primeiro.
-    # A API exige certificado ICP-Brasil + mTLS; sem certificado retorna None
-    # e caímos no fallback com portais municipais.
+    # A API exige certificado ICP-Brasil + mTLS; sem certificado retorna None.
+    # Qualquer falha aciona o fallback estático de portais municipais.
+    api_fallback_motivo: str | None = None
     try:
         cliente_nacional = NFSeNacionalClient()
         dados_api = await cliente_nacional.consultar_por_chave(numero)
@@ -79,8 +84,19 @@ async def consultar_nfse(
                 "status": "encontrada",
                 **dados_api,
             }
-    except Exception:
-        pass  # Qualquer falha aciona o fallback estático abaixo
+        # None indica nota não encontrada ou certificado ausente
+        api_fallback_motivo = "API Nacional retornou None (nota não encontrada ou certificado ICP-Brasil não configurado)"
+        logger.info(
+            "API Nacional NFS-e: nota %s não encontrada ou sem certificado - usando fallback",
+            numero,
+        )
+    except Exception as exc:
+        api_fallback_motivo = f"API Nacional indisponível: {exc}"
+        logger.warning(
+            "Falha ao consultar API Nacional NFS-e para nota %s: %s - usando fallback",
+            numero,
+            exc,
+        )
 
     # Portais de consulta por município/sistema (50+ capitais e grandes cidades)
     # Formato: "CIDADE/UF": {"portal": "url", "sistema": "tipo_sistema"}
@@ -184,7 +200,10 @@ async def consultar_nfse(
         },
         "CARUARU/PE": {"portal": "https://nfse.caruaru.pe.gov.br/", "sistema": "ABRASF"},
         # Cidades da Paraíba
-        "CAMPINA GRANDE/PB": {"portal": "https://nfse.campinagde.pb.gov.br/", "sistema": "ABRASF"},
+        "CAMPINA GRANDE/PB": {
+            "portal": "https://nfse.campinagrande.pb.gov.br/",
+            "sistema": "ABRASF",
+        },
         # Cidades do Rio Grande do Norte
         "PARNAMIRIM/RN": {"portal": "https://nfse.parnamirim.rn.gov.br/", "sistema": "ABRASF"},
         # Cidades de Alagoas
@@ -227,7 +246,9 @@ async def consultar_nfse(
         "numero": numero,
         "municipio": municipio,
         "uf": uf_upper,
+        "fonte": "fallback_portal_municipal",
         "status": "consulta_manual_necessaria",
+        "api_nacional_motivo": api_fallback_motivo,
         "motivo": (
             "NFSe não possui API pública padronizada nacional. "
             "Cada município gerencia seu próprio sistema de emissão e consulta."

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -26,7 +26,7 @@ from .cpf.tools import validar_cpf_tool
 from .esocial.tools import listar_eventos_esocial, validar_evento_esocial
 from .nfe.tools import consultar_nfe, consultar_status_sefaz, validar_chave_nfe
 from .nfse.tools import consultar_nfse
-from .shared.validators import validate_cnpj_qualquer
+from .shared.validators import normalizar_cnpj, validate_cnpj_qualquer
 from .simples.tools import consultar_simples_nacional
 from .sped.tools import analisar_sped, listar_registros_sped
 
@@ -50,8 +50,7 @@ def _normalizar_e_validar_cnpjs(cnpjs: list[str]) -> list[str]:
         if not validate_cnpj_qualquer(cnpj):
             invalidos.append(cnpj)
             continue
-        # Para alfanuméricos, preservar letras; para numéricos, remover máscara
-        normalizados.append("".join(c for c in cnpj if c.isalnum()).upper())
+        normalizados.append(normalizar_cnpj(cnpj))
 
     if invalidos:
         raise ValueError(

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -26,7 +26,7 @@ from .cpf.tools import validar_cpf_tool
 from .esocial.tools import listar_eventos_esocial, validar_evento_esocial
 from .nfe.tools import consultar_nfe, consultar_status_sefaz, validar_chave_nfe
 from .nfse.tools import consultar_nfse
-from .shared.validators import validate_cnpj
+from .shared.validators import validate_cnpj_qualquer
 from .simples.tools import consultar_simples_nacional
 from .sped.tools import analisar_sped, listar_registros_sped
 
@@ -47,10 +47,11 @@ def _normalizar_e_validar_cnpjs(cnpjs: list[str]) -> list[str]:
     normalizados: list[str] = []
 
     for cnpj in cnpjs:
-        if not validate_cnpj(cnpj):
+        if not validate_cnpj_qualquer(cnpj):
             invalidos.append(cnpj)
             continue
-        normalizados.append("".join(caractere for caractere in cnpj if caractere.isdigit()))
+        # Para alfanuméricos, preservar letras; para numéricos, remover máscara
+        normalizados.append("".join(c for c in cnpj if c.isalnum()).upper())
 
     if invalidos:
         raise ValueError(

--- a/src/mcp_fiscal_brasil/shared/validators.py
+++ b/src/mcp_fiscal_brasil/shared/validators.py
@@ -8,6 +8,16 @@ def _somente_digitos(valor: str) -> str:
     return re.sub(r"\D", "", valor)
 
 
+def _valor_char_cnpj(c: str) -> int:
+    """Converte caractere para valor no cálculo do CNPJ alfanumérico.
+
+    Conforme IN RFB 2.229/2024: usa código ASCII subtraído de 48.
+    Dígitos: '0'=0, '1'=1, ..., '9'=9.
+    Letras maiúsculas: 'A'=17, 'B'=18, ..., 'Z'=42.
+    """
+    return ord(c) - 48
+
+
 def validate_cpf(cpf: str) -> bool:
     """
     Valida um CPF brasileiro.
@@ -75,6 +85,77 @@ def validate_cnpj(cnpj: str) -> bool:
         return False
 
     return True
+
+
+def validate_cnpj_alfanumerico(cnpj: str) -> bool:
+    """
+    Valida um CNPJ alfanumérico (IN RFB 2.229/2024, vigência jul/2026).
+
+    As 12 primeiras posições podem conter letras maiúsculas (A-Z) ou dígitos.
+    As 2 últimas são dígitos verificadores numéricos calculados pelo módulo 11,
+    usando o valor ASCII de cada caractere subtraído de 48.
+
+    Aceita também CNPJs numéricos puros (14 dígitos), garantindo backward compat.
+    NÃO aceita letras minúsculas nem máscaras (pontos, barra, traço).
+    """
+    if len(cnpj) != 14:
+        return False
+
+    # Somente letras maiúsculas (A-Z) e dígitos são válidos
+    if not re.match(r"^[A-Z0-9]{14}$", cnpj):
+        return False
+
+    # Rejeita sequências com todos os caracteres iguais
+    if len(set(cnpj)) == 1:
+        return False
+
+    # Os 2 últimos caracteres (DVs) devem ser dígitos numéricos
+    if not cnpj[12:].isdigit():
+        return False
+
+    pesos1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    pesos2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+
+    # Primeiro dígito verificador
+    soma = sum(_valor_char_cnpj(cnpj[i]) * pesos1[i] for i in range(12))
+    resto = soma % 11
+    dv1_esperado = 0 if resto < 2 else 11 - resto
+    if dv1_esperado != int(cnpj[12]):
+        return False
+
+    # Segundo dígito verificador
+    soma = sum(_valor_char_cnpj(cnpj[i]) * pesos2[i] for i in range(13))
+    resto = soma % 11
+    dv2_esperado = 0 if resto < 2 else 11 - resto
+    if dv2_esperado != int(cnpj[13]):
+        return False
+
+    return True
+
+
+def validate_cnpj_qualquer(cnpj: str) -> bool:
+    """
+    Valida qualquer CNPJ: detecta se é numérico ou alfanumérico e delega.
+
+    CNPJs numéricos (somente dígitos, com ou sem máscara) usam validate_cnpj.
+    CNPJs alfanuméricos (contêm letras A-Z, sem máscara) usam validate_cnpj_alfanumerico.
+    """
+    if not cnpj:
+        return False
+
+    # Se após remover máscara numérica sobra algo com 14 chars e sem letras -> numérico
+    apenas_digitos = _somente_digitos(cnpj)
+    if len(apenas_digitos) == 14 and apenas_digitos == cnpj.replace(".", "").replace(
+        "/", ""
+    ).replace("-", ""):
+        return validate_cnpj(cnpj)
+
+    # Se o CNPJ (sem máscara) contém letras maiúsculas -> alfanumérico
+    cnpj_sem_mascara = cnpj.replace(".", "").replace("/", "").replace("-", "").upper()
+    if len(cnpj_sem_mascara) == 14:
+        return validate_cnpj_alfanumerico(cnpj_sem_mascara)
+
+    return False
 
 
 def validate_chave_nfe(chave: str) -> bool:

--- a/src/mcp_fiscal_brasil/shared/validators.py
+++ b/src/mcp_fiscal_brasil/shared/validators.py
@@ -95,8 +95,10 @@ def validate_cnpj_alfanumerico(cnpj: str) -> bool:
     As 2 últimas são dígitos verificadores numéricos calculados pelo módulo 11,
     usando o valor ASCII de cada caractere subtraído de 48.
 
-    Aceita também CNPJs numéricos puros (14 dígitos), garantindo backward compat.
-    NÃO aceita letras minúsculas nem máscaras (pontos, barra, traço).
+    Esta função NÃO aceita máscaras (pontos, barra, traço) nem letras minúsculas.
+    Aceita CNPJs numéricos puros (14 dígitos sem máscara) como caso especial,
+    pois o algoritmo é compatível com ambos os formatos.
+    Para validar qualquer CNPJ com ou sem máscara, use validate_cnpj_qualquer.
     """
     if len(cnpj) != 14:
         return False
@@ -156,6 +158,17 @@ def validate_cnpj_qualquer(cnpj: str) -> bool:
         return validate_cnpj_alfanumerico(cnpj_sem_mascara)
 
     return False
+
+
+def normalizar_cnpj(cnpj: str) -> str:
+    """
+    Remove a máscara de um CNPJ (numérico ou alfanumérico) e normaliza para maiúsculas.
+
+    Para CNPJs numéricos: remove pontos, barra e traço.
+    Para CNPJs alfanuméricos (IN RFB 2.229/2024): preserva as letras, remove máscara.
+    Não valida o CNPJ - use validate_cnpj_qualquer antes se necessário.
+    """
+    return "".join(c for c in cnpj if c.isalnum()).upper()
 
 
 def validate_chave_nfe(chave: str) -> bool:

--- a/src/mcp_fiscal_brasil/shared/validators.py
+++ b/src/mcp_fiscal_brasil/shared/validators.py
@@ -141,6 +141,14 @@ def validate_cnpj_qualquer(cnpj: str) -> bool:
 
     CNPJs numéricos (somente dígitos, com ou sem máscara) usam validate_cnpj.
     CNPJs alfanuméricos (contêm letras A-Z, sem máscara) usam validate_cnpj_alfanumerico.
+
+    Tratamento de máscara (comportamento intencional e defensivo):
+    - Este dispatcher remove apenas os separadores padrão de CNPJ: ponto, barra e traço.
+    - Outros caracteres como espaços tornam o input inválido (retorna False).
+    - Isso é diferente de normalizar_cnpj, que usa isalnum() e remove qualquer
+      caractere não alfanumérico. A validação rejeita inputs com formato estranho
+      antes de normalizar, mantendo fronteiras de entrada bem definidas.
+    - Para normalizar antes de validar, use normalizar_cnpj() + validate_cnpj_alfanumerico().
     """
     if not cnpj:
         return False

--- a/tests/test_nfe_reforma_tributaria.py
+++ b/tests/test_nfe_reforma_tributaria.py
@@ -220,6 +220,47 @@ class TestNFeIBSCBS:
         assert item.aliquota_cbs == 5.80
         assert item.valor_cbs == 58.0
 
+    def test_parse_item_com_tags_g_variantes_nt_v140(self) -> None:
+        """Variantes gIBSUF/gIBSMun/gCBS da NT v1.40 devem ser extraídas corretamente.
+
+        O parser aceita tanto IBSUF quanto gIBSUF (e equivalentes) para retrocompatibilidade.
+        """
+        xml = (
+            XML_NFE_COM_IBSCBS.replace("<IBSUF>", "<gIBSUF>")
+            .replace("</IBSUF>", "</gIBSUF>")
+            .replace("<IBSMun>", "<gIBSMun>")
+            .replace("</IBSMun>", "</gIBSMun>")
+            .replace("<CBS>", "<gCBS>")
+            .replace("</CBS>", "</gCBS>")
+        )
+        resp = parse_nfe_xml(xml, "35240112345678000195550010000001231000000012")
+        item = resp.itens[0]
+        assert item.aliquota_ibs_uf == 9.0
+        assert item.valor_ibs_uf == 90.0
+        assert item.aliquota_ibs_mun == 3.65
+        assert item.valor_ibs_mun == 36.5
+        assert item.aliquota_cbs == 5.80
+        assert item.valor_cbs == 58.0
+
+    def test_parse_item_is_dentro_de_ibscbs_fallback_compatibilidade(self) -> None:
+        """IS posicionado DENTRO de IBSCBS (posição incorreta) ainda deve ser extraído.
+
+        O parser usa fallback: busca IS em imposto/IS (posição correta per NT 2025.002)
+        e, se não encontrar, tenta imposto/IBSCBS/IS (posição de implementações anteriores).
+        """
+        # Move o bloco IS para dentro de IBSCBS (antes do fechamento </IBSCBS>)
+        xml = XML_NFE_COM_IBSCBS.replace(
+            "        </IBSCBS>\n        <IS>",
+            "        <IS>",
+        ).replace(
+            "        </IS>\n      </imposto>",
+            "        </IS>\n        </IBSCBS>\n      </imposto>",
+        )
+        resp = parse_nfe_xml(xml, "35240112345678000195550010000001231000000012")
+        item = resp.itens[0]
+        assert item.aliquota_is == 1.0
+        assert item.valor_is == 10.0
+
 
 # XML com namespace real do portal fiscal (cobre caminho com namespace no parser)
 XML_NFE_COM_NAMESPACE = """<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/test_nfe_reforma_tributaria.py
+++ b/tests/test_nfe_reforma_tributaria.py
@@ -1,0 +1,190 @@
+"""Testes para campos de Reforma Tributária (IBS/CBS/IS) no parser NF-e.
+
+Baseado na NT 2025.002 - Adequação NF-e/NFC-e ao IBS, CBS e IS.
+Grupo UB: det/imposto/IBSCBS com subgrupos IBSUF, IBSMun, CBS.
+Totais Grupo W03: vBCIBSCBS, vIBSUF, vIBSMun, vIBS, vCBS, vIS.
+"""
+
+from mcp_fiscal_brasil.nfe.xml_parser import parse_nfe_xml
+
+XML_NFE_COM_IBSCBS = """
+<NFe>
+  <infNFe Id="NFe35240112345678000195550010000001231000000012">
+    <ide>
+      <mod>55</mod>
+      <serie>1</serie>
+      <nNF>999</nNF>
+      <dhEmi>2026-01-15T10:00:00-03:00</dhEmi>
+      <natOp>Venda com Reforma Tributária</natOp>
+      <tpNF>1</tpNF>
+    </ide>
+    <emit>
+      <CNPJ>12345678000195</CNPJ>
+      <xNome>EMPRESA REFORMA TRIBUTARIA LTDA</xNome>
+    </emit>
+    <det nItem="1">
+      <prod>
+        <cProd>PROD-RT-01</cProd>
+        <xProd>Produto com IBS CBS IS</xProd>
+        <NCM>84713012</NCM>
+        <CFOP>5102</CFOP>
+        <uCom>UN</uCom>
+        <qCom>1.0000</qCom>
+        <vUnCom>1000.00</vUnCom>
+        <vProd>1000.00</vProd>
+      </prod>
+      <imposto>
+        <ICMS>
+          <ICMS00>
+            <CST>00</CST>
+            <pICMS>12.00</pICMS>
+            <vICMS>120.00</vICMS>
+          </ICMS00>
+        </ICMS>
+        <IBSCBS>
+          <IBSUF>
+            <vBC>1000.00</vBC>
+            <pAliq>9.00</pAliq>
+            <vIBSUF>90.00</vIBSUF>
+          </IBSUF>
+          <IBSMun>
+            <vBC>1000.00</vBC>
+            <pAliq>3.65</pAliq>
+            <vIBSMun>36.50</vIBSMun>
+          </IBSMun>
+          <CBS>
+            <vBC>1000.00</vBC>
+            <pAliq>5.80</pAliq>
+            <vCBS>58.00</vCBS>
+          </CBS>
+          <IS>
+            <vBCIS>1000.00</vBCIS>
+            <pIS>1.00</pIS>
+            <vIS>10.00</vIS>
+          </IS>
+        </IBSCBS>
+      </imposto>
+    </det>
+    <total>
+      <ICMSTot>
+        <vProd>1000.00</vProd>
+        <vICMS>120.00</vICMS>
+        <vNF>1000.00</vNF>
+      </ICMSTot>
+      <IBSCBSTot>
+        <vBCIBSCBS>1000.00</vBCIBSCBS>
+        <vIBSUF>90.00</vIBSUF>
+        <vIBSMun>36.50</vIBSMun>
+        <vIBS>126.50</vIBS>
+        <vCBS>58.00</vCBS>
+        <vIS>10.00</vIS>
+      </IBSCBSTot>
+    </total>
+  </infNFe>
+</NFe>
+"""
+
+XML_NFE_SEM_IBSCBS = """
+<NFe>
+  <infNFe Id="NFe35240112345678000195550010000001231000000099">
+    <ide>
+      <mod>55</mod>
+      <serie>1</serie>
+      <nNF>1</nNF>
+      <dhEmi>2024-01-01T08:00:00-03:00</dhEmi>
+      <natOp>Venda normal pre-reforma</natOp>
+      <tpNF>1</tpNF>
+    </ide>
+    <emit>
+      <CNPJ>12345678000195</CNPJ>
+      <xNome>EMPRESA ANTIGA LTDA</xNome>
+    </emit>
+    <det nItem="1">
+      <prod>
+        <cProd>PROD-01</cProd>
+        <xProd>Produto sem IBS CBS</xProd>
+        <NCM>84713012</NCM>
+        <CFOP>5102</CFOP>
+        <uCom>UN</uCom>
+        <qCom>5.0000</qCom>
+        <vUnCom>200.00</vUnCom>
+        <vProd>1000.00</vProd>
+      </prod>
+      <imposto>
+        <ICMS>
+          <ICMS00>
+            <CST>00</CST>
+            <pICMS>12.00</pICMS>
+            <vICMS>120.00</vICMS>
+          </ICMS00>
+        </ICMS>
+      </imposto>
+    </det>
+    <total>
+      <ICMSTot>
+        <vProd>1000.00</vProd>
+        <vICMS>120.00</vICMS>
+        <vNF>1000.00</vNF>
+      </ICMSTot>
+    </total>
+  </infNFe>
+</NFe>
+"""
+
+
+class TestNFeIBSCBS:
+    def test_parse_item_com_ibscbs_extrai_ibs_uf(self) -> None:
+        resp = parse_nfe_xml(XML_NFE_COM_IBSCBS, "35240112345678000195550010000001231000000012")
+        assert len(resp.itens) == 1
+        item = resp.itens[0]
+        assert item.aliquota_ibs_uf == 9.0
+        assert item.valor_ibs_uf == 90.0
+
+    def test_parse_item_com_ibscbs_extrai_ibs_mun(self) -> None:
+        resp = parse_nfe_xml(XML_NFE_COM_IBSCBS, "35240112345678000195550010000001231000000012")
+        item = resp.itens[0]
+        assert item.aliquota_ibs_mun == 3.65
+        assert item.valor_ibs_mun == 36.5
+
+    def test_parse_item_com_ibscbs_extrai_cbs(self) -> None:
+        resp = parse_nfe_xml(XML_NFE_COM_IBSCBS, "35240112345678000195550010000001231000000012")
+        item = resp.itens[0]
+        assert item.aliquota_cbs == 5.80
+        assert item.valor_cbs == 58.0
+
+    def test_parse_item_com_ibscbs_extrai_is(self) -> None:
+        resp = parse_nfe_xml(XML_NFE_COM_IBSCBS, "35240112345678000195550010000001231000000012")
+        item = resp.itens[0]
+        assert item.aliquota_is == 1.0
+        assert item.valor_is == 10.0
+
+    def test_parse_totais_reforma_extraidos(self) -> None:
+        resp = parse_nfe_xml(XML_NFE_COM_IBSCBS, "35240112345678000195550010000001231000000012")
+        assert resp.totais_reforma is not None
+        assert resp.totais_reforma.base_calculo_ibscbs == 1000.0
+        assert resp.totais_reforma.valor_ibs_uf == 90.0
+        assert resp.totais_reforma.valor_ibs_mun == 36.5
+        assert resp.totais_reforma.valor_ibs == 126.5
+        assert resp.totais_reforma.valor_cbs == 58.0
+        assert resp.totais_reforma.valor_is == 10.0
+
+    def test_parse_nfe_pre_reforma_sem_ibscbs_compativel(self) -> None:
+        """NF-e sem grupos IBS/CBS/IS não deve quebrar - campos ficam None."""
+        resp = parse_nfe_xml(XML_NFE_SEM_IBSCBS, "35240112345678000195550010000001231000000099")
+        assert resp.totais_reforma is None
+        item = resp.itens[0]
+        assert item.aliquota_ibs_uf is None
+        assert item.valor_ibs_uf is None
+        assert item.aliquota_cbs is None
+        assert item.valor_cbs is None
+        assert item.aliquota_is is None
+        assert item.valor_is is None
+
+    def test_parse_nfe_pre_reforma_icms_continua_funcionando(self) -> None:
+        """Campos ICMS legados não são afetados pela adição dos campos RT."""
+        resp = parse_nfe_xml(XML_NFE_SEM_IBSCBS, "35240112345678000195550010000001231000000099")
+        assert resp.totais is not None
+        assert resp.totais.valor_icms == 120.0
+        assert resp.totais.valor_nota == 1000.0
+        assert resp.itens[0].aliquota_icms == 12.0
+        assert resp.itens[0].valor_icms == 120.0

--- a/tests/test_nfe_reforma_tributaria.py
+++ b/tests/test_nfe_reforma_tributaria.py
@@ -2,7 +2,9 @@
 
 Baseado na NT 2025.002 - Adequação NF-e/NFC-e ao IBS, CBS e IS.
 Grupo UB: det/imposto/IBSCBS com subgrupos IBSUF, IBSMun, CBS.
+IS (Imposto Seletivo): det/imposto/IS - IRMÃO de IBSCBS (não dentro).
 Totais Grupo W03: vBCIBSCBS, vIBSUF, vIBSMun, vIBS, vCBS, vIS.
+Obrigatoriedade: produção CRT3 em 03/08/2026, homologação 01/07/2026, Simples/MEI 04/01/2027.
 """
 
 from mcp_fiscal_brasil.nfe.xml_parser import parse_nfe_xml
@@ -57,12 +59,12 @@ XML_NFE_COM_IBSCBS = """
             <pAliq>5.80</pAliq>
             <vCBS>58.00</vCBS>
           </CBS>
-          <IS>
-            <vBCIS>1000.00</vBCIS>
-            <pIS>1.00</pIS>
-            <vIS>10.00</vIS>
-          </IS>
         </IBSCBS>
+        <IS>
+          <vBCIS>1000.00</vBCIS>
+          <pIS>1.00</pIS>
+          <vIS>10.00</vIS>
+        </IS>
       </imposto>
     </det>
     <total>
@@ -188,3 +190,138 @@ class TestNFeIBSCBS:
         assert resp.totais.valor_nota == 1000.0
         assert resp.itens[0].aliquota_icms == 12.0
         assert resp.itens[0].valor_icms == 120.0
+
+    def test_parse_item_is_como_irmao_de_ibscbs(self) -> None:
+        """IS em det/imposto/IS (irmão de IBSCBS) deve ser extraído corretamente.
+
+        Posição correta per NT 2025.002: IS é irmão de IBSCBS, não filho.
+        """
+        resp = parse_nfe_xml(XML_NFE_COM_IBSCBS, "35240112345678000195550010000001231000000012")
+        item = resp.itens[0]
+        assert item.aliquota_is == 1.0
+        assert item.valor_is == 10.0
+
+    def test_parse_nfe_com_namespace_real(self) -> None:
+        """NF-e com namespace real http://www.portalfiscal.inf.br/nfe deve ser parseada."""
+        resp = parse_nfe_xml(XML_NFE_COM_NAMESPACE, "35240112345678000195550010000001231000000011")
+        assert resp.número == "999"
+        assert len(resp.itens) == 1
+        assert resp.itens[0].valor_total == 1000.0
+        assert resp.itens[0].aliquota_icms == 12.0
+
+    def test_parse_ibscbs_parcial_sem_ibsuf_ibsmun(self) -> None:
+        """NF-e com apenas CBS em IBSCBS (sem IBSUF/IBSMun): campos ausentes = None."""
+        resp = parse_nfe_xml(XML_NFE_IBSCBS_PARCIAL, "35240112345678000195550010000001231000000011")
+        item = resp.itens[0]
+        assert item.aliquota_ibs_uf is None
+        assert item.valor_ibs_uf is None
+        assert item.aliquota_ibs_mun is None
+        assert item.valor_ibs_mun is None
+        assert item.aliquota_cbs == 5.80
+        assert item.valor_cbs == 58.0
+
+
+# XML com namespace real do portal fiscal (cobre caminho com namespace no parser)
+XML_NFE_COM_NAMESPACE = """<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc xmlns="http://www.portalfiscal.inf.br/nfe" versao="4.00">
+  <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe Id="NFe35240112345678000195550010000001231000000011" versao="4.00">
+      <ide>
+        <mod>55</mod>
+        <serie>1</serie>
+        <nNF>999</nNF>
+        <dhEmi>2026-01-15T10:00:00-03:00</dhEmi>
+        <natOp>Venda</natOp>
+        <tpNF>1</tpNF>
+      </ide>
+      <emit>
+        <CNPJ>12345678000195</CNPJ>
+        <xNome>EMPRESA NAMESPACE LTDA</xNome>
+      </emit>
+      <det nItem="1">
+        <prod>
+          <cProd>PROD-NS-01</cProd>
+          <xProd>Produto com namespace</xProd>
+          <NCM>84713012</NCM>
+          <CFOP>5102</CFOP>
+          <uCom>UN</uCom>
+          <qCom>1.0000</qCom>
+          <vUnCom>1000.00</vUnCom>
+          <vProd>1000.00</vProd>
+        </prod>
+        <imposto>
+          <ICMS>
+            <ICMS00>
+              <CST>00</CST>
+              <pICMS>12.00</pICMS>
+              <vICMS>120.00</vICMS>
+            </ICMS00>
+          </ICMS>
+        </imposto>
+      </det>
+      <total>
+        <ICMSTot>
+          <vProd>1000.00</vProd>
+          <vICMS>120.00</vICMS>
+          <vNF>1000.00</vNF>
+        </ICMSTot>
+      </total>
+    </infNFe>
+  </NFe>
+</nfeProc>
+"""
+
+# XML com IBSCBS parcial (apenas CBS, sem IBSUF e IBSMun)
+XML_NFE_IBSCBS_PARCIAL = """
+<NFe>
+  <infNFe Id="NFe35240112345678000195550010000001231000000011">
+    <ide>
+      <mod>55</mod>
+      <serie>1</serie>
+      <nNF>999</nNF>
+      <dhEmi>2026-01-15T10:00:00-03:00</dhEmi>
+      <natOp>Venda parcial RT</natOp>
+      <tpNF>1</tpNF>
+    </ide>
+    <emit>
+      <CNPJ>12345678000195</CNPJ>
+      <xNome>EMPRESA PARCIAL LTDA</xNome>
+    </emit>
+    <det nItem="1">
+      <prod>
+        <cProd>PROD-PARCIAL-01</cProd>
+        <xProd>Produto CBS apenas</xProd>
+        <NCM>84713012</NCM>
+        <CFOP>5102</CFOP>
+        <uCom>UN</uCom>
+        <qCom>1.0000</qCom>
+        <vUnCom>1000.00</vUnCom>
+        <vProd>1000.00</vProd>
+      </prod>
+      <imposto>
+        <ICMS>
+          <ICMS00>
+            <CST>00</CST>
+            <pICMS>12.00</pICMS>
+            <vICMS>120.00</vICMS>
+          </ICMS00>
+        </ICMS>
+        <IBSCBS>
+          <CBS>
+            <vBC>1000.00</vBC>
+            <pAliq>5.80</pAliq>
+            <vCBS>58.00</vCBS>
+          </CBS>
+        </IBSCBS>
+      </imposto>
+    </det>
+    <total>
+      <ICMSTot>
+        <vProd>1000.00</vProd>
+        <vICMS>120.00</vICMS>
+        <vNF>1000.00</vNF>
+      </ICMSTot>
+    </total>
+  </infNFe>
+</NFe>
+"""

--- a/tests/test_nfse_nacional.py
+++ b/tests/test_nfse_nacional.py
@@ -85,15 +85,22 @@ class TestConsultarNFSeComFallback:
         assert resultado["numero"] == "99999"
         assert resultado["municipio"] == "São Paulo"
         assert resultado["uf"] == "SP"
-        # Fallback deve informar onde consultar manualmente
-        assert "portal_municipio" in resultado or "status" in resultado
+        # Fallback deve informar explicitamente a fonte, status e motivo
+        assert resultado["fonte"] == "fallback_portal_municipal"
+        assert resultado["status"] == "consulta_manual_necessaria"
+        assert resultado["api_nacional_motivo"] is not None
+        assert "portal_municipio" in resultado
 
     @pytest.mark.asyncio
     async def test_fallback_estatico_quando_api_nacional_lanca_excecao(self) -> None:
-        """Quando o cliente da API lança exceção, cai no fallback."""
+        """Quando o cliente da API lança exceção de indisponibilidade, cai no fallback."""
+        from mcp_fiscal_brasil.nfse.client import NFSeNacionalUnavailableError
+
         with patch("mcp_fiscal_brasil.nfse.tools.NFSeNacionalClient") as mock_client_class:
             mock_instance = MagicMock()
-            mock_instance.consultar_por_chave = AsyncMock(side_effect=Exception("Erro de rede"))
+            mock_instance.consultar_por_chave = AsyncMock(
+                side_effect=NFSeNacionalUnavailableError("status=503 path=/nfse/55555")
+            )
             mock_client_class.return_value = mock_instance
 
             resultado = await consultar_nfse(
@@ -103,7 +110,10 @@ class TestConsultarNFSeComFallback:
             )
 
         assert resultado["numero"] == "55555"
-        assert "status" in resultado
+        assert resultado["fonte"] == "fallback_portal_municipal"
+        assert resultado["status"] == "consulta_manual_necessaria"
+        assert resultado["api_nacional_motivo"] is not None
+        assert "indisponível" in resultado["api_nacional_motivo"]
 
     @pytest.mark.asyncio
     async def test_api_nacional_quando_retorna_dados(self) -> None:

--- a/tests/test_nfse_nacional.py
+++ b/tests/test_nfse_nacional.py
@@ -50,14 +50,19 @@ class TestNFSeNacionalClient:
         assert resultado is None
 
     @pytest.mark.asyncio
-    async def test_consultar_por_chave_retorna_none_em_erro(self) -> None:
-        """Quando a API lança exceção, deve retornar None (aciona fallback)."""
+    async def test_consultar_por_chave_retorna_none_quando_get_retorna_none(self) -> None:
+        """Quando _get retorna None (erro de rede, auth, 404), consultar_por_chave repassa None.
+
+        _get já captura todas as exceções internamente e retorna None. O double try/except
+        em consultar_por_chave foi removido pois era caminho morto (Fix 6).
+        """
         client = NFSeNacionalClient()
         with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
-            mock_get.side_effect = Exception("Timeout de conexão")
+            mock_get.return_value = None
             resultado = await client.consultar_por_chave("CHAVE_COM_ERRO")
 
         assert resultado is None
+        mock_get.assert_called_once_with("/nfse/CHAVE_COM_ERRO")
 
 
 class TestConsultarNFSeComFallback:

--- a/tests/test_nfse_nacional.py
+++ b/tests/test_nfse_nacional.py
@@ -1,0 +1,126 @@
+"""Testes para NFS-e Nacional via API REST (Sistema Nacional NFS-e).
+
+A API Nacional (adn.nfse.gov.br) exige certificado digital ICP-Brasil + mTLS,
+portanto os testes usam mocks. O fallback estático deve sempre funcionar.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_fiscal_brasil.nfse.client import NFSeNacionalClient
+from mcp_fiscal_brasil.nfse.tools import consultar_nfse
+
+
+class TestNFSeNacionalClient:
+    """Testes unitários do cliente da API Nacional NFS-e."""
+
+    @pytest.mark.asyncio
+    async def test_consultar_por_chave_retorna_dados_mock(self) -> None:
+        """Quando a API responde com sucesso, retorna dados estruturados."""
+        mock_response = {
+            "numero": "12345",
+            "municipio": "São Paulo",
+            "uf": "SP",
+            "prestador": {"cnpj": "33000167000101", "razaoSocial": "EMPRESA TESTE LTDA"},
+            "valorServico": "1500.00",
+            "valorIss": "75.00",
+            "aliquotaIss": "5.00",
+        }
+
+        client = NFSeNacionalClient()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+            resultado = await client.consultar_por_chave("CHAVE123456789")
+
+        assert resultado is not None
+        assert resultado["numero"] == "12345"
+        mock_get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_consultar_por_chave_retorna_none_em_404(self) -> None:
+        """Quando a API retorna 404, deve retornar None (aciona fallback)."""
+        client = NFSeNacionalClient()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+            resultado = await client.consultar_por_chave("CHAVE_INEXISTENTE")
+
+        assert resultado is None
+
+    @pytest.mark.asyncio
+    async def test_consultar_por_chave_retorna_none_em_erro(self) -> None:
+        """Quando a API lança exceção, deve retornar None (aciona fallback)."""
+        client = NFSeNacionalClient()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = Exception("Timeout de conexão")
+            resultado = await client.consultar_por_chave("CHAVE_COM_ERRO")
+
+        assert resultado is None
+
+
+class TestConsultarNFSeComFallback:
+    """Testes de integração: tentativa API Nacional + fallback estático."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_estatico_quando_api_nacional_indisponivel(self) -> None:
+        """Quando a API Nacional falha, cai no fallback com orientações manuais."""
+        with patch("mcp_fiscal_brasil.nfse.tools.NFSeNacionalClient") as mock_client_class:
+            mock_instance = MagicMock()
+            mock_instance.consultar_por_chave = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_instance
+
+            resultado = await consultar_nfse(
+                numero="99999",
+                municipio="São Paulo",
+                uf="SP",
+            )
+
+        assert resultado["numero"] == "99999"
+        assert resultado["municipio"] == "São Paulo"
+        assert resultado["uf"] == "SP"
+        # Fallback deve informar onde consultar manualmente
+        assert "portal_municipio" in resultado or "status" in resultado
+
+    @pytest.mark.asyncio
+    async def test_fallback_estatico_quando_api_nacional_lanca_excecao(self) -> None:
+        """Quando o cliente da API lança exceção, cai no fallback."""
+        with patch("mcp_fiscal_brasil.nfse.tools.NFSeNacionalClient") as mock_client_class:
+            mock_instance = MagicMock()
+            mock_instance.consultar_por_chave = AsyncMock(side_effect=Exception("Erro de rede"))
+            mock_client_class.return_value = mock_instance
+
+            resultado = await consultar_nfse(
+                numero="55555",
+                municipio="Belo Horizonte",
+                uf="MG",
+            )
+
+        assert resultado["numero"] == "55555"
+        assert "status" in resultado
+
+    @pytest.mark.asyncio
+    async def test_api_nacional_quando_retorna_dados(self) -> None:
+        """Quando a API Nacional retorna dados, eles são incluídos na resposta."""
+        dados_api = {
+            "numero": "77777",
+            "municipio": "Brasília",
+            "uf": "DF",
+            "prestador": {"cnpj": "33000167000101", "razaoSocial": "EMPRESA DF LTDA"},
+            "valorServico": "2000.00",
+        }
+
+        with patch("mcp_fiscal_brasil.nfse.tools.NFSeNacionalClient") as mock_client_class:
+            mock_instance = MagicMock()
+            mock_instance.consultar_por_chave = AsyncMock(return_value=dados_api)
+            mock_client_class.return_value = mock_instance
+
+            resultado = await consultar_nfse(
+                numero="77777",
+                municipio="Brasília",
+                uf="DF",
+            )
+
+        assert resultado["numero"] == "77777"
+        assert resultado.get("fonte") == "api_nacional"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,6 +5,7 @@ import pytest
 from mcp_fiscal_brasil.shared.validators import (
     format_cnpj,
     format_cpf,
+    normalizar_cnpj,
     validate_chave_nfe,
     validate_cnpj,
     validate_cnpj_alfanumerico,
@@ -128,8 +129,10 @@ class TestValidateCNPJAlfanumerico:
         assert validate_cnpj_alfanumerico("33000167000101") is True
 
     def test_cnpj_alfanumerico_todos_iguais_invalido(self) -> None:
-        # Sequências onde TODOS os 14 caracteres são idênticos são inválidas
-        assert validate_cnpj_alfanumerico("AAAAAAAAAAAAAA") is False
+        # Sequências com 14 chars idênticos devem ser rejeitadas pelo check de uniformidade.
+        # Usar "00000000000000" (numérico uniforme) para testar especificamente esse caminho,
+        # pois "AAAAAAAAAAAAAA" seria rejeitado antes pelo check de DVs (cnpj[12:] deve ser dígito).
+        assert validate_cnpj_alfanumerico("00000000000000") is False
 
 
 class TestValidateCNPJQualquer:
@@ -152,3 +155,24 @@ class TestValidateCNPJQualquer:
 
     def test_cnpj_tamanho_errado_invalido(self) -> None:
         assert validate_cnpj_qualquer("123") is False
+
+
+class TestNormalizarCNPJ:
+    """Testes para normalizar_cnpj: remove máscara e normaliza para maiúsculas."""
+
+    def test_cnpj_numerico_com_mascara(self) -> None:
+        # Máscara padrão numérica: pontos, barra e traço removidos
+        assert normalizar_cnpj("33.000.167/0001-01") == "33000167000101"
+
+    def test_cnpj_alfanumerico_com_mascara(self) -> None:
+        # Máscara alfanumérica: caracteres não-alfanuméricos (pontos, barra, traço) removidos
+        # "AB.123.CD0/0001-08" tem 18 chars; sem máscara = "AB123CD0000108" (14 chars)
+        assert normalizar_cnpj("AB.123.CD0/0001-08") == "AB123CD0000108"
+
+    def test_minusculas_convertidas_para_maiusculas(self) -> None:
+        # Letras minúsculas devem ser convertidas para maiúsculas
+        assert normalizar_cnpj("ab123cd0000108") == "AB123CD0000108"
+
+    def test_ja_normalizado_retorna_igual(self) -> None:
+        # CNPJ já normalizado (sem máscara, maiúsculas) deve retornar igual
+        assert normalizar_cnpj("33000167000101") == "33000167000101"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,6 +7,8 @@ from mcp_fiscal_brasil.shared.validators import (
     format_cpf,
     validate_chave_nfe,
     validate_cnpj,
+    validate_cnpj_alfanumerico,
+    validate_cnpj_qualquer,
     validate_cpf,
 )
 
@@ -87,3 +89,62 @@ class TestFormatCNPJ:
     def test_tamanho_errado_levanta_erro(self) -> None:
         with pytest.raises(ValueError):
             format_cnpj("123")
+
+
+class TestValidateCNPJAlfanumerico:
+    """Testes para validação de CNPJ alfanumérico (IN RFB 2.229/2024, vigência jul/2026).
+
+    CNPJs fictícios com DVs calculados pelo algoritmo módulo 11 com conversão ASCII-48:
+    - AB123CD0000108 (DVs calculados: 0,8)
+    - XY987EF0000279 (DVs calculados: 7,9)
+    """
+
+    def test_cnpj_alfanumerico_valido(self) -> None:
+        # AB123CD00001 + DVs 08
+        assert validate_cnpj_alfanumerico("AB123CD0000108") is True
+
+    def test_cnpj_alfanumerico_segundo_exemplo_valido(self) -> None:
+        # XY987EF00002 + DVs 79
+        assert validate_cnpj_alfanumerico("XY987EF0000279") is True
+
+    def test_cnpj_alfanumerico_dv_errado(self) -> None:
+        # DV correto é 08, usar 09 deve ser inválido
+        assert validate_cnpj_alfanumerico("AB123CD0000109") is False
+
+    def test_cnpj_alfanumerico_tamanho_errado(self) -> None:
+        assert validate_cnpj_alfanumerico("AB123CD00001") is False
+        assert validate_cnpj_alfanumerico("AB123CD000010812345") is False
+
+    def test_cnpj_alfanumerico_letras_minusculas_invalido(self) -> None:
+        # CNPJ alfanumérico usa somente letras maiúsculas
+        assert validate_cnpj_alfanumerico("ab123cd0000108") is False
+
+    def test_cnpj_numerico_aceito_por_alfanumerico(self) -> None:
+        # CNPJs numéricos existentes continuam válidos (backward compat)
+        assert validate_cnpj_alfanumerico("33000167000101") is True
+
+    def test_cnpj_alfanumerico_todos_iguais_invalido(self) -> None:
+        # Sequências onde TODOS os 14 caracteres são idênticos são inválidas
+        assert validate_cnpj_alfanumerico("AAAAAAAAAAAAAA") is False
+
+
+class TestValidateCNPJQualquer:
+    """Testes para o dispatcher que detecta formato e delega."""
+
+    def test_cnpj_numerico_valido(self) -> None:
+        assert validate_cnpj_qualquer("33.000.167/0001-01") is True
+
+    def test_cnpj_numerico_invalido(self) -> None:
+        assert validate_cnpj_qualquer("33.000.167/0001-02") is False
+
+    def test_cnpj_alfanumerico_valido(self) -> None:
+        assert validate_cnpj_qualquer("AB123CD0000108") is True
+
+    def test_cnpj_alfanumerico_invalido(self) -> None:
+        assert validate_cnpj_qualquer("AB123CD0000109") is False
+
+    def test_cnpj_vazio_invalido(self) -> None:
+        assert validate_cnpj_qualquer("") is False
+
+    def test_cnpj_tamanho_errado_invalido(self) -> None:
+        assert validate_cnpj_qualquer("123") is False

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -51,12 +51,12 @@ class TestValidateCNPJ:
 
 class TestValidateChaveNFe:
     def test_chave_valida_44_digitos(self) -> None:
-        # Chave com DV correto (calculado)
-        # Usamos uma chave conhecida
-        chave = "31060107364617000135550000000194291370923172"
-        # Esta chave especifica pode ou não ser válida dependendo do DV
-        # Testamos o formato
+        # Chave real da NF-e com DV correto: cUF=35 (SP), AAMM=2401,
+        # CNPJ=12345678000195, mod=55, serie=001, nNF=000000123, tpEmis=1,
+        # cNF=00000001, cDV=1 (calculado pelo módulo 11)
+        chave = "35240112345678000195550010000001231000000011"
         assert len(chave) == 44
+        assert validate_chave_nfe(chave) is True
 
     def test_chave_tamanho_errado(self) -> None:
         assert validate_chave_nfe("1234") is False
@@ -107,9 +107,13 @@ class TestValidateCNPJAlfanumerico:
         # XY987EF00002 + DVs 79
         assert validate_cnpj_alfanumerico("XY987EF0000279") is True
 
-    def test_cnpj_alfanumerico_dv_errado(self) -> None:
-        # DV correto é 08, usar 09 deve ser inválido
+    def test_cnpj_alfanumerico_dv2_errado(self) -> None:
+        # DV1 correto é 0, DV2 correto é 8 -> usar DV2=9 invalida
         assert validate_cnpj_alfanumerico("AB123CD0000109") is False
+
+    def test_cnpj_alfanumerico_dv1_errado(self) -> None:
+        # DV1 correto é 0 -> usar DV1=1 invalida (AB123CD000011X com qualquer DV2)
+        assert validate_cnpj_alfanumerico("AB123CD0000118") is False
 
     def test_cnpj_alfanumerico_tamanho_errado(self) -> None:
         assert validate_cnpj_alfanumerico("AB123CD00001") is False


### PR DESCRIPTION
## Resumo

Este PR adiciona suporte completo a tres pilares da Reforma Tributaria de 2026 ao mcp-fiscal-brasil, posicionando a biblioteca como o primeiro MCP open source com cobertura nativa da NT 2025.002.

### 1. Parser NF-e com grupos IBS/CBS/IS (NT 2025.002 v1.40)

O parser `nfe/xml_parser.py` agora extrai os novos campos da Reforma Tributaria em cada item (`det`) e nos totais da nota (`IBSCBSTot`):

- **IBS-UF** (`det/imposto/IBSCBS/gIBSUF` ou `IBSUF`): aliquota e valor por estado
- **IBS-Mun** (`det/imposto/IBSCBS/gIBSMun` ou `IBSMun`): aliquota e valor por municipio
- **CBS** (`det/imposto/IBSCBS/gCBS` ou `CBS`): aliquota e valor federal
- **IS** (`det/imposto/IS`): Imposto Seletivo como irmao de IBSCBS (corrigido em review - posicionamento incorreto como filho foi um bug detectado na auditoria pre-merge)

O IS usa `pIS`/`vIS` em vez de `pAliq` como IBS/CBS - diferenca documentada em comentario inline.

Aceita tanto as variantes `gIBSUF`/`gIBSMun`/`gCBS` (NT v1.40) quanto `IBSUF`/`IBSMun`/`CBS` (versoes anteriores) via `_find_any`, garantindo compatibilidade retroativa. Suporte a namespace real `http://www.portalfiscal.inf.br/nfe` validado em teste dedicado.

Obrigatoriedade: producao CRT3 em 03/08/2026, homologacao 01/07/2026, Simples/MEI em 04/01/2027.

### 2. Validacao de CNPJ alfanumerico (IN RFB 2.229/2024)

Novo `validate_cnpj_alfanumerico` em `shared/validators.py`:

- Suporta os 12 primeiros caracteres alfanumericos (A-Z ou 0-9) com 2 DVs numericos
- Algoritmo modulo 11 com tabela de valores ASCII verificado manualmente em multiplos exemplos
- `validate_cnpj_qualquer` despacha automaticamente entre numerico e alfanumerico
- `normalizar_cnpj` centraliza remocao de mascara (eliminando duplicacao entre `validators.py` e `server.py`)
- Vigencia: julho de 2026

### 3. Cliente NFS-e Nacional com fallback melhorado

- `nfse/client.py`: removido double try/except desnecessario em `consultar_por_chave` (`_get` ja captura todas as excecoes internamente)
- `nfse/tools.py`: fallback para portais municipais agora distingue "API indisponivel" (log `WARNING`) de "nota nao encontrada" (log `INFO`); retorno inclui campo `api_nacional_motivo` para diagnostico; typo `campinagde` corrigido para `campinagrande`

## Cobertura de Testes

- **159 testes passando**, 0 falhas
- Novos testes adicionados:
  - IS na posicao correta como irmao de IBSCBS
  - NF-e com namespace real do portal fiscal
  - IBSCBS parcial (apenas CBS, sem IBSUF/IBSMun) - campos ausentes ficam None
  - CNPJ alfanumerico com DV1 errado (invalida)
  - CNPJ alfanumerico com DV2 errado (invalida)
  - NFS-e fallback distinguindo exception de None

## Qualidade

- `ruff check`: limpo
- `ruff format`: 107 arquivos formatados
- `mypy`: 20 erros pre-existentes em `server.py` (stubs FastMCP ausentes) - nenhum novo introduzido

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Passou a suportar a Reforma Tributária em NF-e, incluindo extração de IBS (UF/município), CBS e IS, além de novos totais relacionados.
  * Implementada consulta assíncrona de NFS-e pela API Nacional, com fallback automático para consulta manual via portal municipal.
  * Adicionada validação e normalização de CNPJ alfanumérico conforme IN RFB 2.229/2024.

* **Refactor**
  * Atualização do fluxo de normalização/validação de CNPJ no servidor.

* **Tests**
  * Novos testes cobrindo Reforma Tributária em NF-e, NFS-e nacional e normalizadores/validadores de CNPJ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->