### PR TITLE
ci: publica no registry oficial MCP via OIDC

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,27 @@
+name: Publica no Registry Oficial MCP
+
+on:
+  workflow_dispatch: {}
+  release:
+    types: [published]
+
+jobs:
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout do codigo
+        uses: actions/checkout@v4
+
+      - name: Instala mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Autentica no registry MCP via OIDC do GitHub
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publica o servidor no registry MCP
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## O que este PR faz

Adiciona o workflow `.github/workflows/publish-mcp-registry.yml` para publicar o `mcp-fiscal-brasil` no [registry oficial MCP](https://registry.modelcontextprotocol.io) de forma automatizada e sem login interativo.

## Como funciona

O workflow usa autenticacao OIDC do GitHub, que nao requer nenhum secret adicional no repositorio. O runner do GitHub Actions recebe um token OIDC temporario que o registry MCP valida para confirmar que a publicacao vem do repositorio `DeHor-Labs/mcp-fiscal-brasil`, autorizando o namespace `io.github.dehor-labs/mcp-fiscal-brasil`.

### Passos do workflow

1. Checkout do codigo
2. Download do binario `mcp-publisher` (release oficial do registry MCP)
3. Autenticacao via `mcp-publisher login github-oidc`
4. Publicacao via `mcp-publisher publish` (lê `./server.json` da raiz)

## Triggers

- `workflow_dispatch` - disparo manual via `gh workflow run` ou pela UI do GitHub
- `release: types: [published]` - disparo automatico a cada nova release publicada

## Permissoes necessarias

```yaml
permissions:
  id-token: write  # obrigatorio para OIDC
  contents: read
```

## Verificacao apos o merge

Apos o merge, disparar manualmente com:

```bash
gh workflow run publish-mcp-registry.yml --repo DeHor-Labs/mcp-fiscal-brasil
```

O servidor deve aparecer em:
```
https://registry.modelcontextprotocol.io/v0/servers?search=fiscal
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adicionado workflow de automação para publicar o servidor no Registry Oficial MCP automaticamente quando um release é criado ou através de acionamento manual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->