### PR TITLE
fix: reduz description do server.json para <= 100 chars (registry MCP)

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dehor-labs/mcp-fiscal-brasil",
   "title": "MCP Fiscal Brasil",
-  "description": "MCP fiscal brasileiro - CNPJ, NF-e, Reforma Tributaria IBS/CBS, calculo ICMS/Simples Nacional, tabelas NCM/CFOP, indexadores BCB; 36 ferramentas, zero API key.",
+  "description": "Ferramentas fiscais brasileiras: CNPJ, NF-e, IBS/CBS, ICMS, Simples Nacional, NCM/CFOP. Sem API key.",
   "version": "0.3.0",
   "repository": {
     "url": "https://github.com/DeHor-Labs/mcp-fiscal-brasil",


### PR DESCRIPTION
## Problema

O workflow de publicacao no registry MCP falhou com erro 422:

```
{"errors":[{"message":"expected length <= 100","location":"body._meta.io.description","value":"...159 chars..."}]}
```

O registry MCP impoe limite de 100 caracteres para o campo `description` do `server.json`.
A descricao atual tinha **159 caracteres**.

## Correcao

Nova descricao com **100 caracteres exatos**:

> Ferramentas fiscais brasileiras: CNPJ, NF-e, IBS/CBS, ICMS, Simples Nacional, NCM/CFOP. Sem API key.

## Proximos passos

Apos o merge, re-disparar o workflow:

```bash
gh workflow run publish-mcp-registry.yml --repo DeHor-Labs/mcp-fiscal-brasil
```

## Referencia

- Run com falha: https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/runs/27780114637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Descrição do serviço foi aprimorada e completamente atualizada com informações muito mais específicas e completas sobre todas as ferramentas fiscais brasileiras oferecidas. Agora inclui detalhes sobre funcionalidades relacionadas a CNPJ, NF-e, IBS/CBS, ICMS, Simples Nacional e NCM/CFOP. Também reforça que o serviço não necessita de chave de API para funcionar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->