### PR TITLE
fix: corrige case do namespace no server.json (io.github.DeHor-Labs)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.dehor-labs/mcp-fiscal-brasil",
+  "name": "io.github.DeHor-Labs/mcp-fiscal-brasil",
   "title": "MCP Fiscal Brasil",
   "description": "Ferramentas fiscais brasileiras: CNPJ, NF-e, IBS/CBS, ICMS, Simples Nacional, NCM/CFOP. Sem API key.",
   "version": "0.3.0",


### PR DESCRIPTION
## Problema

O segundo run de publicacao no registry MCP falhou com erro 403:

```
You do not have permission to publish this server.
You have permission to publish: io.github.DeHor-Labs/*
Attempting to publish: io.github.dehor-labs/mcp-fiscal-brasil
```

O registry MCP e case-sensitive no namespace OIDC. O GitHub OIDC resolve
a organizacao como `DeHor-Labs` (preservando maiusculas), mas o `server.json`
tinha o namespace em minusculo (`dehor-labs`), causando a recusa.

## Correcao

```diff
- "name": "io.github.dehor-labs/mcp-fiscal-brasil",
+ "name": "io.github.DeHor-Labs/mcp-fiscal-brasil",
```

## Historico dos runs

| Run | Erro |
|-----|------|
| [#27780114637](https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/runs/27780114637) | 422: description > 100 chars (corrigido no PR #57) |
| [#27780284434](https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/runs/27780284434) | 403: namespace case mismatch (este PR) |

## Proximos passos

Apos o merge, re-disparar:

```bash
gh workflow run publish-mcp-registry.yml --repo DeHor-Labs/mcp-fiscal-brasil
```