### PR TITLE
chore: bump v0.3.1 - corrige mcp-name e namespace para DeHor-Labs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1] - 2026-06-18
+
+### Fixed
+
+- Corrige `mcp-name` no README para `io.github.DeHor-Labs/mcp-fiscal-brasil` (case correto da org no GitHub), necessario para validacao de ownership no registry oficial MCP.
+- Corrige namespace no `server.json` para `io.github.DeHor-Labs/mcp-fiscal-brasil`.
+
 ## [0.3.0] - 2026-06-17
 
 Onda 1: expansao de tabelas fiscais offline, indexadores do Banco Central e exposicao

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mcp-name: io.github.dehor-labs/mcp-fiscal-brasil
+mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil
 
 <p align="center">
   <img src="assets/banner.svg" width="800" alt="MCP Fiscal Brasil">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-fiscal-brasil"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP fiscal brasileiro - 36 ferramentas, zero API key. CNPJ, NF-e, Reforma Tributaria IBS/CBS, ICMS, Simples Nacional, NCM/CFOP, indexadores BCB."
 authors = [
     { name = "Nikolas de Hor" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DeHor-Labs/mcp-fiscal-brasil",
   "title": "MCP Fiscal Brasil",
   "description": "Ferramentas fiscais brasileiras: CNPJ, NF-e, IBS/CBS, ICMS, Simples Nacional, NCM/CFOP. Sem API key.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "repository": {
     "url": "https://github.com/DeHor-Labs/mcp-fiscal-brasil",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-fiscal-brasil",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Problema

A publicacao no registry MCP falhou com erro 400 na terceira tentativa:

```
registry validation failed for package 0 (mcp-fiscal-brasil):
PyPI package 'mcp-fiscal-brasil' ownership validation failed.
The server name 'io.github.DeHor-Labs/mcp-fiscal-brasil' must appear as
'mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil' in the package README
```

O registry MCP valida ownership comparando o `mcp-name` no README do PyPI
com o `name` no `server.json`. O README tinha o case antigo (`dehor-labs`
minusculo), mas o namespace correto e `DeHor-Labs` (com maiusculas, como o
GitHub OIDC resolve o nome da org).

Como o PyPI nao permite resubmissao da mesma versao com README diferente,
e necessario bump de versao para publicar o README corrigido.

## Correcoes neste PR

| Arquivo | Mudanca |
|---------|---------|
| `README.md` | `mcp-name: io.github.dehor-labs/...` -> `io.github.DeHor-Labs/...` |
| `server.json` | `name` e `packages[0].version` corrigidos (DeHor-Labs, 0.3.1) |
| `pyproject.toml` | version `0.3.0` -> `0.3.1` |
| `CHANGELOG.md` | Entrada da v0.3.1 |

## Proximos passos apos o merge

Criar a release v0.3.1 para disparar simultaneamente:
- `publish.yml` - publica no PyPI com README corrigido
- `publish-mcp-registry.yml` - publica no registry MCP apos o PyPI atualizar

```bash
gh release create v0.3.1 --repo DeHor-Labs/mcp-fiscal-brasil \
  --title "v0.3.1" \
  --notes "Corrige namespace/mcp-name para io.github.DeHor-Labs (case correto para publicacao no registry MCP)."
```

## Historico das tentativas de publicacao

| Run | Erro |
|-----|------|
| [#27780114637](https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/runs/27780114637) | 422: description > 100 chars (corrigido no PR #57) |
| [#27780284434](https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/runs/27780284434) | 403: namespace case mismatch (corrigido no PR #58) |
| [#27780427772](https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/runs/27780427772) | 400: mcp-name no README PyPI com case errado (este PR) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão - v0.3.1

* **Bug Fixes**
  * Corrigida a capitalização do identificador do serviço para conformidade com o registry oficial.
  * Ajustado o namespace para validação correta de ownership.

* **Chores**
  * Versão atualizada para 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->