### PR TITLE
fix: sincroniza versão 0.3.1 e aguarda PyPI antes de publicar no registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -25,7 +25,7 @@ jobs:
           VERSION=$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
           echo "Aguardando mcp-fiscal-brasil==$VERSION no PyPI"
           for i in $(seq 1 30); do
-            if curl -sfo /dev/null "https://pypi.org/pypi/mcp-fiscal-brasil/$VERSION/json"; then
+            if curl -sfo /dev/null --connect-timeout 10 --max-time 20 "https://pypi.org/pypi/mcp-fiscal-brasil/$VERSION/json"; then
               echo "Pacote $VERSION disponivel no PyPI"; exit 0
             fi
             echo "Tentativa $i: ainda nao disponivel, aguardando 10s"; sleep 10

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -14,11 +14,23 @@ jobs:
 
     steps:
       - name: Checkout do codigo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Instala mcp-publisher
         run: |
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Aguardar pacote no PyPI
+        run: |
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "Aguardando mcp-fiscal-brasil==$VERSION no PyPI"
+          for i in $(seq 1 30); do
+            if curl -sfo /dev/null "https://pypi.org/pypi/mcp-fiscal-brasil/$VERSION/json"; then
+              echo "Pacote $VERSION disponivel no PyPI"; exit 0
+            fi
+            echo "Tentativa $i: ainda nao disponivel, aguardando 10s"; sleep 10
+          done
+          echo "Timeout aguardando o pacote no PyPI"; exit 1
 
       - name: Autentica no registry MCP via OIDC do GitHub
         run: ./mcp-publisher login github-oidc

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-fiscal-brasil",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Node.js wrapper para o CLI Python mcp-fiscal-brasil. Consultas fiscais brasileiras (CNPJ, NFe, SPED) em JS/TS.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/mcp_fiscal_brasil/__init__.py
+++ b/src/mcp_fiscal_brasil/__init__.py
@@ -1,6 +1,6 @@
 """MCP Fiscal Brasil - Servidor MCP e SDK Python para o sistema fiscal brasileiro."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Nikolas de Hor"
 __description__ = (
     "Servidor MCP para integrar IAs com o sistema fiscal brasileiro. "


### PR DESCRIPTION
## Resumo

Este PR corrige três inconsistências deixadas pelo bump apressado para v0.3.1, sem publicar novamente no PyPI (o pacote 0.3.1 já está lá e é imutável).

- **`src/mcp_fiscal_brasil/__init__.py`**: `__version__` estava em `0.3.0`, atualizado para `0.3.1` para refletir o que está no `pyproject.toml` e no PyPI.
- **`npm-wrapper/package.json`**: `version` estava em `0.3.0`, atualizado para `0.3.1`.
- **`.github/workflows/publish-mcp-registry.yml`**: adicionado step **"Aguardar pacote no PyPI"** antes do `mcp-publisher publish`, eliminando a race condition em que o registry era atualizado antes do pacote estar disponível no PyPI. Usa a API JSON do PyPI (`curl` com `-f`) em loop de 30 tentativas com intervalo de 10s (timeout total de 5 min). Também atualizado `actions/checkout` de `v4` para `v6`, alinhado com `ci.yml` e demais workflows do repositório.

## Plano de testes

- [ ] Verificar que CI (`ci.yml`) passa em verde na branch
- [ ] Confirmar que `__version__` importado é `"0.3.1"` via `python -c "import mcp_fiscal_brasil; print(mcp_fiscal_brasil.__version__)"`
- [ ] Confirmar que `npm-wrapper/package.json` reporta `"0.3.1"`
- [ ] Verificar sintaxe YAML do workflow editado (ex.: `yamllint .github/workflows/publish-mcp-registry.yml`)
- [ ] Em próximo release, observar que o step de espera conclui com sucesso antes do publish no registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Atualizada a versão do pacote para **0.3.1**.
  * Aprimorado o fluxo de publicação automática: agora é feito um aguardo por disponibilidade do pacote no repositório central (com verificações e tempo limite) antes de concluir a etapa de publicação, melhorando a confiabilidade da distribuição em diferentes ambientes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->