### PR TITLE
feat: modulo NF-e (parse, DANFE, assinatura, distribuicao, manifestacao) v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.4.0] - 2026-06-20
+
+Onda 2 NF-e: parse, DANFE, assinatura, distribuicao e manifestacao. Total de tools
+sobe de 36 para 41.
+
+### Added
+
+#### Parse e DANFE offline (modulo `nfe`)
+
+- `parse_nfe_xml` - parseia XML bruto de NF-e ou NFC-e e retorna dados estruturados
+  (emitente, destinatario, itens, totais, protocolo). Sem API key, offline.
+- `gerar_danfe` - gera DANFE PDF (A4, modelo 55) a partir do XML. Retorna base64.
+  Sem API key, offline. Requer namespace `http://www.portalfiscal.inf.br/nfe`.
+  Modelo 65 (NFC-e) nao suportado na v1.0.0 da lib brazilfiscalreport.
+- `validar_assinatura_nfe` - valida assinatura XMLDSig e extrai dados do certificado
+  assinante (titular, CNPJ/CPF, validade, AC emissora). Sem API key, offline.
+  Suporte opcional a CA bundle PEM para validar cadeia ICP-Brasil.
+
+#### Distribuicao e manifestacao com certificado A1 (opt-in)
+
+- `baixar_nfe_distribuicao` - baixa documentos via NFeDistribuicaoDFe (SEFAZ) usando
+  certificado A1 local (.pfx/.p12). Suporta distNSU, consNSU e consChNFe.
+  O certificado nunca e enviado a servidores externos - autenticacao mTLS local.
+- `manifestar_nfe` - registra manifestacao do destinatario via NFeRecepcaoEvento.
+  Eventos: 210200 (Ciencia), 210210 (Confirmacao), 210220 (Desconhecimento),
+  210240 (Operacao nao Realizada). Assinatura XMLDSig feita localmente.
+
+#### Novas dependencias
+
+- `brazilfiscalreport==1.0.0` - geracao de DANFE PDF
+- `signxml>=4.5.1` - validacao e assinatura XMLDSig
+- `cryptography>=48.0.1` - manipulacao de certificados X.509 e PKCS12
+
+### Security
+
+- Toda entrada XML externa e validada via `parse_xml()` (lxml com
+  `resolve_entities=False`, `no_network=True`) antes de ser entregue a
+  brazilfiscalreport, que usa `xml.etree` sem protecao XXE propria.
+- Senhas de certificados A1 nunca aparecem em logs, excecoes ou disco persistente.
+- Arquivos PEM temporarios criados com permissao 0600 e removidos no bloco `finally`.
+
 ## [0.3.1] - 2026-06-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil
 </p>
 
 <p align="center">
-  <strong>36 ferramentas fiscais. Zero API key. Zero cadastro. 100% open source.</strong><br>
+  <strong>41 ferramentas fiscais. Zero API key. Zero cadastro. 100% open source.</strong><br>
   O primeiro MCP com suporte a Reforma Tributaria 2026 (IBS/CBS) - a camada open source para agentes de IA trabalharem com compliance fiscal brasileiro.
 </p>
 
@@ -167,6 +167,11 @@ Funcionam 100% sem chaves de API. Instale e use imediatamente.
 | NFe | `validar_chave_nfe` | Valida dígito + extrai UF, CNPJ, data, número | Offline |
 | NFe | `consultar_status_sefaz` | Status do webservice SEFAZ por estado | BrasilAPI (grátis) |
 | NFe | `consultar_nfe` | Consulta NFe completa pela chave de 44 dígitos | BrasilAPI (grátis) |
+| NFe | `parse_nfe_xml` | Parseia XML bruto de NF-e/NFC-e e retorna dados estruturados | Offline |
+| NFe | `gerar_danfe` | Gera DANFE PDF (A4) a partir do XML de NF-e (mod 55) | Offline |
+| NFe | `validar_assinatura_nfe` | Valida assinatura XMLDSig e extrai dados do certificado | Offline |
+| NFe | `baixar_nfe_distribuicao` | Baixa documentos via NFeDistribuicaoDFe (requer cert A1 local) | SEFAZ (mTLS) |
+| NFe | `manifestar_nfe` | Manifesta destinatario em NF-e via NFeRecepcaoEvento (requer cert A1) | SEFAZ (mTLS) |
 | CPF | `validar_cpf` | Validação de dígito verificador | Offline |
 | SPED | `analisar_sped` | Analisa arquivo EFD/ECD/ECF: período, empresa, erros | Offline |
 | SPED | `listar_registros_sped` | Filtra registros por tipo (C100, E110, etc.) | Offline |
@@ -184,6 +189,18 @@ Retornam URLs e instruções - exigem ação manual nos portais governamentais.
 | NFSe | `consultar_nfse` | URL do portal NFSe do município + sistema utilizado |
 | Certidões | `consultar_certidao_federal` | URL do e-CAC para emissão de CND federal |
 | Certidões | `consultar_certidao_fgts` | URL do portal Caixa para consulta do CRF |
+
+---
+
+### 🔐 Ferramentas com Certificado A1 (opt-in)
+
+As tools `baixar_nfe_distribuicao` e `manifestar_nfe` requerem um certificado
+digital A1 (`.pfx`/`.p12`) **instalado localmente no seu computador**.
+
+- O certificado e a senha **nunca sao enviados a nenhum servidor externo**.
+- A autenticacao mTLS e a assinatura XMLDSig sao feitas localmente.
+- Estas tools se conectam diretamente aos webservices da SEFAZ (Ambiente Nacional).
+- Todas as demais tools (parse, DANFE, assinatura, consultas) funcionam sem certificado.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-fiscal-brasil"
-version = "0.3.1"
-description = "MCP fiscal brasileiro - 36 ferramentas, zero API key. CNPJ, NF-e, Reforma Tributaria IBS/CBS, ICMS, Simples Nacional, NCM/CFOP, indexadores BCB."
+version = "0.4.0"
+description = "MCP fiscal brasileiro - 41 ferramentas, zero API key. CNPJ, NF-e, Reforma Tributaria IBS/CBS, ICMS, Simples Nacional, NCM/CFOP, indexadores BCB."
 authors = [
     { name = "Nikolas de Hor" }
 ]
@@ -63,6 +63,9 @@ dependencies = [
     "typer>=0.25.1",
     "fastapi>=0.136.1",
     "uvicorn>=0.42.0",
+    "brazilfiscalreport==1.0.0",
+    "signxml>=4.5.1",
+    "cryptography>=48.0.1",
 ]
 
 [project.optional-dependencies]
@@ -122,7 +125,11 @@ module = [
 ]
 # Decoradores @app.tool() do FastMCP nao sao tipados; o override por modulo
 # e mais cirurgico do que rebaixar o strict global.
+# warn_unused_ignores = false: server.py usa hasattr guard antes de .model_dump()
+# em dados_completos (tipado como object no dataclass de distribuicao); o mypy
+# strict reporta o type: ignore como unused mesmo com a guarda em vigor.
 disallow_untyped_decorators = false
+warn_unused_ignores = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/mcp_fiscal_brasil/__init__.py
+++ b/src/mcp_fiscal_brasil/__init__.py
@@ -1,6 +1,6 @@
 """MCP Fiscal Brasil - Servidor MCP e SDK Python para o sistema fiscal brasileiro."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __author__ = "Nikolas de Hor"
 __description__ = (
     "Servidor MCP para integrar IAs com o sistema fiscal brasileiro. "

--- a/src/mcp_fiscal_brasil/nfe/assinatura.py
+++ b/src/mcp_fiscal_brasil/nfe/assinatura.py
@@ -1,0 +1,267 @@
+"""Validacao de assinatura digital XMLDSig em documentos NF-e (ICP-Brasil)."""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from lxml import etree
+from signxml import XMLVerifier  # type: ignore[attr-defined]
+
+from .._core.errors import FiscalValidationError
+from .._core.logging import get_logger
+from ..shared.xml_utils import parse_xml
+
+logger_assinatura = get_logger(__name__)
+
+# Limite maximo para o ca_bundle a fim de evitar processamento de entrada gigante
+_CA_BUNDLE_MAX_BYTES = 1 * 1024 * 1024  # 1 MB
+
+if TYPE_CHECKING:
+    from cryptography.x509 import Certificate
+
+# Pattern para extrair CNPJ de 14 digitos numericos do CN do certificado
+_CNPJ_RE = re.compile(r"\d{14}")
+
+
+@dataclass(frozen=True)
+class AssinaturaResult:
+    """Resultado da validacao de assinatura digital XMLDSig de uma NF-e."""
+
+    assinatura_valida: bool
+    """True se a assinatura criptografica e a integridade do digest forem validas."""
+
+    motivo: str | None = None
+    """Descricao do erro caso assinatura_valida seja False, None se valida."""
+
+    titular: str | None = None
+    """CN (Common Name) do certificado assinante, normalmente razao social + CNPJ."""
+
+    cnpj_cpf: str | None = None
+    """CNPJ ou CPF extraido do CN do certificado, se presente."""
+
+    validade_inicio: datetime | None = None
+    """Inicio da validade do certificado."""
+
+    validade_fim: datetime | None = None
+    """Fim da validade do certificado."""
+
+    ac_emissora: str | None = None
+    """DN do emissor (Autoridade Certificadora) do certificado."""
+
+
+def _extrair_cert_x509(signature_xml: etree._Element) -> Certificate | None:
+    """Extrai o certificado X.509 do elemento Signature do XML, se presente."""
+    from cryptography import x509
+
+    ns = {
+        "ds": "http://www.w3.org/2000/09/xmldsig#",
+    }
+    x509_nodes = signature_xml.xpath(".//ds:X509Certificate/text()", namespaces=ns)
+    if not x509_nodes:
+        return None
+
+    try:
+        der_bytes = base64.b64decode(str(x509_nodes[0]).strip())
+        return x509.load_der_x509_certificate(der_bytes)
+    except Exception as exc:
+        logger_assinatura.debug("nfe.assinatura.extrair_cert_x509.falhou", erro=str(exc))
+        return None
+
+
+def _extrair_cn(cert: Certificate) -> str | None:
+    """Extrai o valor do atributo CN (Common Name) do Subject do certificado."""
+    from cryptography.x509.oid import NameOID
+
+    try:
+        attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        if attrs:
+            return str(attrs[0].value)
+    except Exception as exc:
+        logger_assinatura.debug("nfe.assinatura.extrair_cn.falhou", erro=str(exc))
+    return None
+
+
+def _extrair_cnpj_cpf(cn: str | None) -> str | None:
+    """Extrai CNPJ de 14 digitos numericos do CN do certificado, se presente."""
+    if not cn:
+        return None
+    match = _CNPJ_RE.search(cn)
+    return match.group() if match else None
+
+
+def _extrair_ac_emissora(cert: Certificate) -> str | None:
+    """Retorna o DN do emissor do certificado como string legivel."""
+    try:
+        issuer_attrs = []
+        for attr in cert.issuer:
+            value = (
+                attr.value
+                if isinstance(attr.value, str)
+                else attr.value.decode("utf-8", errors="replace")
+            )
+            issuer_attrs.append(f"{attr.oid.dotted_string}={value}")
+        return ", ".join(issuer_attrs) if issuer_attrs else None
+    except Exception as exc:
+        logger_assinatura.debug("nfe.assinatura.extrair_ac_emissora.falhou", erro=str(exc))
+        return None
+
+
+def _preencher_dados_cert(
+    cert: Certificate,
+) -> tuple[str | None, str | None, datetime | None, datetime | None, str | None]:
+    """Extrai titular, cnpj_cpf, validade_inicio, validade_fim, ac_emissora do cert."""
+    cn = _extrair_cn(cert)
+    cnpj_cpf = _extrair_cnpj_cpf(cn)
+
+    try:
+        validade_inicio: datetime | None = cert.not_valid_before_utc
+    except AttributeError:
+        # Python < 3.11 usa not_valid_before (sem fuso)
+        try:
+            validade_inicio = cert.not_valid_before
+        except Exception:
+            validade_inicio = None
+
+    try:
+        validade_fim: datetime | None = cert.not_valid_after_utc
+    except AttributeError:
+        try:
+            validade_fim = cert.not_valid_after
+        except Exception:
+            validade_fim = None
+
+    ac_emissora = _extrair_ac_emissora(cert)
+    return cn, cnpj_cpf, validade_inicio, validade_fim, ac_emissora
+
+
+def validar_assinatura_nfe(
+    xml_content: str | bytes,
+    ca_bundle: str | bytes | None = None,
+) -> AssinaturaResult:
+    """
+    Valida a assinatura digital XMLDSig de uma NF-e.
+
+    Verifica a integridade do Reference/DigestValue e a assinatura criptografica
+    do elemento Signature presente em infNFe. Extrai dados do certificado assinante.
+
+    Args:
+        xml_content: Conteudo XML da NF-e (str ou bytes). Todo XML externo
+            e parseado via parse_xml() (anti-XXE).
+        ca_bundle: Opcional. PEM com cadeia ICP-Brasil para validar o emissor
+            do certificado.
+            - ``str``: caminho de arquivo PEM no sistema de arquivos. O arquivo
+              deve existir e ser legivel; caso contrario, levanta
+              ``FiscalValidationError`` com mensagem clara.
+            - ``bytes``: conteudo PEM diretamente em memoria.
+            - ``None``: valida a assinatura sem exigir cadeia confiavel (nao
+              falha por ausencia de bundle, mas nao confirma a AC emissora).
+
+    Returns:
+        AssinaturaResult com o resultado da validacao e dados do certificado.
+        NUNCA reporta assinatura invalida como valida.
+
+    Raises:
+        FiscalValidationError: Se ``ca_bundle`` for ``str`` e o caminho nao existir,
+            ou se o conteudo exceder 1 MB.
+        XMLParseError: Se o XML for malformado (propagado de parse_xml).
+    """
+    # Valida ca_bundle str (caminho de arquivo) antes de qualquer processamento
+    if isinstance(ca_bundle, str):
+        if not os.path.isfile(ca_bundle):
+            raise FiscalValidationError(
+                message=(
+                    f"Arquivo ca_bundle nao encontrado: '{ca_bundle}'. "
+                    "Informe o caminho absoluto de um arquivo PEM valido da cadeia ICP-Brasil."
+                ),
+                field="ca_bundle",
+                value=ca_bundle,
+            )
+
+    # Valida tamanho do ca_bundle antes de qualquer processamento (DoS guard)
+    if ca_bundle is not None:
+        bundle_bytes = ca_bundle if isinstance(ca_bundle, bytes) else ca_bundle.encode()
+        if len(bundle_bytes) > _CA_BUNDLE_MAX_BYTES:
+            raise FiscalValidationError(
+                message="O ca_bundle excede o limite de 1 MB. Forneca apenas a cadeia ICP-Brasil necessaria.",
+                field="ca_bundle",
+                value=f"{len(bundle_bytes)} bytes",
+            )
+
+    # Parseia via parse_xml (resolve_entities=False, no_network=True) - anti-XXE
+    root = parse_xml(xml_content)
+
+    # Localiza o elemento Signature (pode estar dentro de NFe ou diretamente na raiz)
+    ns_ds = {"ds": "http://www.w3.org/2000/09/xmldsig#"}
+    signature_nodes = root.xpath(".//ds:Signature", namespaces=ns_ds)
+    if not signature_nodes:
+        return AssinaturaResult(
+            assinatura_valida=False,
+            motivo="Elemento Signature nao encontrado no XML.",
+        )
+
+    # Dados do certificado (extraidos antes da verificacao para retornar mesmo em falha)
+    signature_el = signature_nodes[0]
+    cert_obj = _extrair_cert_x509(signature_el)
+    titular: str | None = None
+    cnpj_cpf: str | None = None
+    validade_inicio: datetime | None = None
+    validade_fim: datetime | None = None
+    ac_emissora: str | None = None
+
+    if cert_obj is not None:
+        titular, cnpj_cpf, validade_inicio, validade_fim, ac_emissora = _preencher_dados_cert(
+            cert_obj
+        )
+
+    try:
+        verifier = XMLVerifier()
+        xml_bytes = etree.tostring(root)
+
+        if ca_bundle is not None:
+            # Validacao completa: verifica assinatura + cadeia de confianca ICP-Brasil.
+            # ca_bundle pode ser bytes PEM ou str com caminho para arquivo PEM.
+            verifier.verify(data=xml_bytes, ca_pem_file=ca_bundle)
+        elif cert_obj is not None:
+            # Validacao sem cadeia: verifica integridade (DigestValue) e assinatura
+            # criptografica usando o certificado embutido no proprio XML.
+            # Nao valida se o certificado e confiavel (sem CA bundle).
+            verifier.verify(data=xml_bytes, x509_cert=cert_obj)
+        else:
+            # Sem certificado embutido e sem ca_bundle: impossivel validar a
+            # confianca do assinante. Retorna invalido para evitar falsa validacao
+            # contra a CA store do sistema (que aceitaria qualquer cert SSL).
+            return AssinaturaResult(
+                assinatura_valida=False,
+                motivo=(
+                    "XML nao contem certificado embutido e nenhum ca_bundle foi fornecido; "
+                    "impossivel validar a confianca do assinante."
+                ),
+            )
+
+        return AssinaturaResult(
+            assinatura_valida=True,
+            motivo=None,
+            titular=titular,
+            cnpj_cpf=cnpj_cpf,
+            validade_inicio=validade_inicio,
+            validade_fim=validade_fim,
+            ac_emissora=ac_emissora,
+        )
+    except Exception as exc:
+        return AssinaturaResult(
+            assinatura_valida=False,
+            motivo=str(exc),
+            titular=titular,
+            cnpj_cpf=cnpj_cpf,
+            validade_inicio=validade_inicio,
+            validade_fim=validade_fim,
+            ac_emissora=ac_emissora,
+        )
+
+
+__all__ = ["AssinaturaResult", "validar_assinatura_nfe"]

--- a/src/mcp_fiscal_brasil/nfe/danfe.py
+++ b/src/mcp_fiscal_brasil/nfe/danfe.py
@@ -1,0 +1,275 @@
+"""Geracao de DANFE em PDF a partir de XML de NF-e.
+
+Suporte a modelo 55 (NF-e) com namespace do portal fiscal (portalfiscal.inf.br/nfe).
+Modelo 65 (NFC-e) nao e suportado na versao 1.0.0 da lib brazilfiscalreport.
+
+Seguranca:
+- Todo XML externo e parseado via parse_xml() (resolve_entities=False, no_network=True)
+  antes de ser entregue a lib brazilfiscalreport. Isso impede XXE e billion-laughs
+  mesmo quando o XML vem de fonte nao confiavel (usuario ou LLM).
+- A lib brazilfiscalreport usa xml.etree internamente (sem protecao XXE propria);
+  a validacao previa via lxml com _SAFE_PARSER e a barreira de seguranca.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from lxml import etree
+from pydantic import BaseModel
+
+from .._core.errors import FiscalValidationError
+from ..shared.xml_utils import NS_NFE, parse_xml, xpath_text
+from .xml_parser import extrair_chave_nfe, extrair_modelo_nfe
+
+
+class DanfeGenerationError(FiscalValidationError):
+    """Erro ao gerar o DANFE."""
+
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        super().__init__(message=reason, field=field, value=value)
+
+
+class DanfeResult(BaseModel):
+    """Resultado da geracao de DANFE em PDF."""
+
+    pdf_base64: str
+    """Conteudo do PDF codificado em base64."""
+
+    modelo: int
+    """Modelo do documento fiscal: 55 para NF-e."""
+
+    nome_arquivo: str
+    """Nome de arquivo sugerido para o PDF, incluindo a chave de acesso."""
+
+    paginas: int | None = None
+    """Numero de paginas do PDF (disponivel quando calculavel)."""
+
+    chave_acesso: str
+    """Chave de acesso de 44 digitos do documento."""
+
+    numero: str | None = None
+    """Numero da nota fiscal extraido do XML."""
+
+    serie: str | None = None
+    """Serie da nota fiscal extraida do XML."""
+
+
+def _extrair_metadados_xml(xml_content: str | bytes) -> tuple[str, int, str | None, str | None]:
+    """
+    Extrai chave, modelo, numero e serie do XML da NF-e.
+
+    Delega extracao de chave e modelo aos helpers compartilhados
+    extrair_chave_nfe e extrair_modelo_nfe (xml_parser.py), que ja
+    aplicam parse_xml (anti-XXE) internamente.
+
+    Args:
+        xml_content: Conteudo XML da nota fiscal.
+
+    Returns:
+        Tupla (chave, modelo, numero, serie).
+
+    Raises:
+        DanfeGenerationError: Se o XML nao contiver infNFe valido ou chave invalida.
+        XMLParseError: Se o XML estiver malformado (propagado de parse_xml).
+    """
+    chave = extrair_chave_nfe(xml_content)
+    if chave is None:
+        raise DanfeGenerationError(
+            field="xml",
+            value="<xml>",
+            reason=(
+                "XML invalido: elemento <infNFe> nao encontrado ou Id nao contem "
+                "44 digitos numericos. Verifique se o XML e uma NF-e valida."
+            ),
+        )
+
+    modelo = extrair_modelo_nfe(xml_content)
+
+    # Extrai numero e serie diretamente do XML parseado (seguro, anti-XXE via parse_xml)
+    root = parse_xml(xml_content)
+    ns = NS_NFE
+    ide = root.find(".//nfe:ide", ns)
+    if ide is None:
+        ide = root.find(".//ide")
+
+    def _text(el: etree._Element | None, xpath_ns: str, xpath_plain: str) -> str | None:
+        if el is None:
+            return None
+        return xpath_text(el, xpath_ns, ns) or xpath_text(el, xpath_plain, {})
+
+    numero = _text(ide, "nfe:nNF/text()", "nNF/text()")
+    serie = _text(ide, "nfe:serie/text()", "serie/text()")
+
+    return chave, modelo, numero, serie
+
+
+def _verificar_namespace_portalfiscal(xml_content: str | bytes) -> None:
+    """
+    Verifica se o XML contem o namespace do portal fiscal necessario para a lib.
+
+    A brazilfiscalreport 1.0.0 requer o namespace
+    'http://www.portalfiscal.inf.br/nfe' no XML para funcionar corretamente.
+    Se o namespace estiver ausente, lanca DanfeGenerationError com instrucao clara.
+
+    Args:
+        xml_content: Conteudo XML como string ou bytes.
+
+    Raises:
+        DanfeGenerationError: Se o namespace do portal fiscal nao for encontrado.
+    """
+    ns_portalfiscal = "http://www.portalfiscal.inf.br/nfe"
+    conteudo = (
+        xml_content
+        if isinstance(xml_content, str)
+        else xml_content.decode("utf-8", errors="replace")
+    )
+    if ns_portalfiscal not in conteudo:
+        raise DanfeGenerationError(
+            field="namespace",
+            value="<xml>",
+            reason=(
+                "O XML nao contem o namespace do portal fiscal "
+                f"('{ns_portalfiscal}'). "
+                "A geracao de DANFE requer o namespace no elemento raiz. "
+                'Exemplo: <nfeProc xmlns="http://www.portalfiscal.inf.br/nfe"> '
+                'ou <NFe xmlns="http://www.portalfiscal.inf.br/nfe">.'
+            ),
+        )
+
+
+def _normalizar_xml_para_danfe(xml_content: str | bytes) -> str:
+    """
+    Converte o XML para string UTF-8 para a lib brazilfiscalreport.
+
+    A lib usa ET.fromstring internamente e aceita string. Como o XML ja foi
+    validado (anti-XXE) em _extrair_metadados_xml, aqui apenas convertemos
+    o tipo sem novo parse.
+
+    Args:
+        xml_content: XML como string ou bytes.
+
+    Returns:
+        XML como string UTF-8.
+    """
+    if isinstance(xml_content, bytes):
+        return xml_content.decode("utf-8", errors="replace")
+    return xml_content
+
+
+def gerar_danfe(xml_content: str | bytes) -> DanfeResult:
+    """
+    Gera o DANFE em PDF a partir do XML de uma NF-e (modelo 55).
+
+    Suporta apenas modelo 55. Modelo 65 (NFC-e) nao e suportado pela
+    brazilfiscalreport 1.0.0 - sera suportado em versao futura da lib.
+
+    SEGURANCA: o XML e validado via parse_xml() (anti-XXE) antes de ser
+    entregue a lib brazilfiscalreport, que usa xml.etree sem protecao propria.
+
+    O XML pode conter ou nao o involucro de protocolo <nfeProc>. Quando o XML
+    nao tiver protocolo de autorizacao, o DANFE e gerado sem o numero de
+    protocolo no rodape (comportamento identico ao da lib).
+
+    NAMESPACE OBRIGATORIO: o XML deve conter o namespace do portal fiscal
+    (http://www.portalfiscal.inf.br/nfe) para que a lib possa processar o XML.
+
+    Args:
+        xml_content: XML completo da NF-e como string ou bytes.
+                     Deve conter o namespace do portal fiscal
+                     (http://www.portalfiscal.inf.br/nfe).
+                     Aceita XML com ou sem involucro <nfeProc>.
+
+    Returns:
+        DanfeResult com o PDF em base64, metadados do documento e nome de
+        arquivo sugerido.
+
+    Raises:
+        DanfeGenerationError: Se o XML for invalido, o modelo nao for suportado
+                              (65 = nao suportado, ver nota acima), o namespace
+                              estiver ausente, ou a geracao do PDF falhar.
+        XMLParseError: Se o XML estiver malformado (propagado de parse_xml).
+    """
+    # parse_xml (anti-XXE) e chamado dentro de _extrair_metadados_xml
+    chave, modelo, numero, serie = _extrair_metadados_xml(xml_content)
+
+    if modelo == 65:
+        raise DanfeGenerationError(
+            field="ide/mod",
+            value="65",
+            reason=(
+                "DANFE NFC-e (modelo 65) ainda nao e suportado nesta versao. "
+                "A lib brazilfiscalreport 1.0.0 nao possui classe dedicada a NFC-e. "
+                "Para NFC-e, utilize uma solucao especifica de cupom fiscal. "
+                "Esta ferramenta suporta apenas NF-e (modelo 55)."
+            ),
+        )
+
+    if modelo != 55:
+        raise DanfeGenerationError(
+            field="ide/mod",
+            value=str(modelo),
+            reason=(
+                f"Modelo de documento '{modelo}' nao suportado para geracao de DANFE. "
+                "Modelo suportado: 55 (NF-e)."
+            ),
+        )
+
+    # Verificacao de namespace antes de entregar a lib (falha clara ao inves de erro obscuro)
+    _verificar_namespace_portalfiscal(xml_content)
+
+    xml_str = _normalizar_xml_para_danfe(xml_content)
+    pdf_bytes = _gerar_danfe_nfe(xml_str, chave)
+
+    pdf_base64 = base64.b64encode(pdf_bytes).decode("ascii")
+    nome_arquivo = f"DANFE_NFE_{chave}.pdf"
+
+    return DanfeResult(
+        pdf_base64=pdf_base64,
+        modelo=modelo,
+        nome_arquivo=nome_arquivo,
+        paginas=None,  # fpdf2 nao expoe contagem de paginas apos output()
+        chave_acesso=chave,
+        numero=numero,
+        serie=serie,
+    )
+
+
+def _gerar_danfe_nfe(xml_str: str, chave: str) -> bytes:
+    """
+    Gera o PDF do DANFE A4 para NF-e (modelo 55).
+
+    O XML ja foi validado (anti-XXE) e verificado com namespace antes desta chamada.
+
+    Args:
+        xml_str: XML da NF-e como string com namespace do portal fiscal.
+        chave: Chave de acesso de 44 digitos (usada apenas para mensagens de erro).
+
+    Returns:
+        Bytes do PDF gerado.
+
+    Raises:
+        DanfeGenerationError: Se a geracao do PDF falhar.
+    """
+    try:
+        from brazilfiscalreport.danfe import Danfe
+
+        danfe = Danfe(xml=xml_str)
+        result = danfe.output()
+        # output() sem argumento retorna bytearray; converte para bytes
+        return bytes(result) if result is not None else b""
+    except ImportError as exc:
+        raise DanfeGenerationError(
+            field="dependencia",
+            value="brazilfiscalreport",
+            reason=(
+                "Biblioteca 'brazilfiscalreport' nao encontrada. "
+                "Instale com: pip install brazilfiscalreport"
+            ),
+        ) from exc
+    except Exception as exc:
+        raise DanfeGenerationError(
+            field="xml",
+            value=chave,
+            reason=f"Erro ao gerar DANFE NF-e: {exc}",
+        ) from exc

--- a/src/mcp_fiscal_brasil/nfe/distribuicao.py
+++ b/src/mcp_fiscal_brasil/nfe/distribuicao.py
@@ -1,0 +1,899 @@
+"""
+Distribuicao de NF-e via NFeDistribuicaoDFe (Ambiente Nacional, mTLS A1).
+
+Suporta os tres modos:
+- distNSU: busca incremental por ultimo NSU
+- consNSU: consulta por NSU especifico
+- consChNFe: consulta por chave de acesso de 44 digitos
+
+Tambem oferece manifestacao do destinatario (eventos 210200/210210/210220/210240).
+
+SEGURANCA:
+- Senha do .pfx e chave privada NUNCA aparecem em logs, excecoes ou disco persistente.
+- Arquivos PEM temporarios (quando necessarios) sao criados com permissao 0600
+  e apagados no bloco finally.
+- XML externo sempre parseado via parse_xml() (anti-XXE).
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import os
+import re
+import ssl
+import tempfile
+import xml.sax.saxutils
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+from lxml import etree
+from signxml import XMLSigner  # type: ignore[attr-defined]
+
+from .._core.errors import FiscalHTTPError, FiscalValidationError
+from .._core.logging import get_logger
+from ..shared.rate_limiter import SlidingWindowRateLimiter
+from ..shared.validators import validate_chave_nfe
+from ..shared.xml_utils import build_soap_envelope, extract_soap_body, parse_xml
+from .xml_parser import parse_nfe_xml
+
+if TYPE_CHECKING:
+    from .schemas import NFeResponse
+
+logger = get_logger(__name__)
+
+# Rate limiter conservador para endpoints SEFAZ (~1 req/s).
+# Distribui a cota por chave de endpoint para nao misturar
+# distribuicao e recepcao de eventos.
+_sefaz_nfe_limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=1.0)
+
+# Tipo de ambiente SEFAZ
+Ambiente = Literal["producao", "homologacao"]
+
+# Codigos de evento de manifestacao do destinatario
+EVENTO_CIENCIA = "210200"
+EVENTO_CONFIRMACAO = "210210"
+EVENTO_DESCONHECIMENTO = "210220"
+EVENTO_OPERACAO_NAO_REALIZADA = "210240"
+
+_EVENTOS_VALIDOS = {
+    EVENTO_CIENCIA,
+    EVENTO_CONFIRMACAO,
+    EVENTO_DESCONHECIMENTO,
+    EVENTO_OPERACAO_NAO_REALIZADA,
+}
+
+# Endpoints NFeDistribuicaoDFe
+_ENDPOINTS_DISTRIBUICAO: dict[Ambiente, str] = {
+    "producao": "https://www1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx",
+    "homologacao": "https://hom1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx",
+}
+
+# Endpoints NFeRecepcaoEvento (Ambiente Nacional - AN)
+_ENDPOINTS_EVENTO: dict[Ambiente, str] = {
+    "producao": "https://www.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx",
+    "homologacao": "https://hom.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx",
+}
+
+_NS_NFE = "http://www.portalfiscal.inf.br/nfe"
+_NS_DS = "http://www.w3.org/2000/09/xmldsig#"
+
+# Regex: CNPJ 14 digitos numericos ou CPF 11 digitos numericos
+_CNPJ_RE = re.compile(r"^\d{14}$")
+_CPF_RE = re.compile(r"^\d{11}$")
+_NSU_RE = re.compile(r"^\d{1,15}$")
+
+# Mapeamento simplificado UF sigla -> codigo numerico IBGE
+_UF_CODIGOS: dict[str, str] = {
+    "AC": "12",
+    "AL": "27",
+    "AM": "13",
+    "AP": "16",
+    "BA": "29",
+    "CE": "23",
+    "DF": "53",
+    "ES": "32",
+    "GO": "52",
+    "MA": "21",
+    "MG": "31",
+    "MS": "50",
+    "MT": "51",
+    "PA": "15",
+    "PB": "25",
+    "PE": "26",
+    "PI": "22",
+    "PR": "41",
+    "RJ": "33",
+    "RN": "24",
+    "RO": "11",
+    "RR": "14",
+    "RS": "43",
+    "SC": "42",
+    "SE": "28",
+    "SP": "35",
+    "TO": "17",
+}
+
+
+# ---------------------------------------------------------------------------
+# Schemas de retorno
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DocumentoDistribuicao:
+    """Documento retornado pela consulta de distribuicao NF-e."""
+
+    nsu: str
+    """Numero Sequencial Unico do documento."""
+
+    tipo: str
+    """Tipo do schema: resNFe (resumo), procNFe ou nfeProc (completo), etc."""
+
+    schema: str
+    """Nome do schema (ex: resNFe_v1.01.xsd, procNFe_v4.00.xsd)."""
+
+    chave: str | None
+    """Chave de acesso de 44 digitos, se disponivel no documento."""
+
+    resumo: dict[str, str | None] | None
+    """Campos principais do resNFe (emitente, valor, situacao), se for resumo.
+
+    O campo 'situacao' corresponde a cSitNFe da SEFAZ e pode ser None quando o
+    resNFe nao trouxer esse elemento (nao confundir com digVal, que e o digest).
+    """
+
+    dados_completos: NFeResponse | None
+    """NFeResponse parseado via parse_nfe_xml, se for procNFe/nfeProc."""
+
+
+@dataclass(frozen=True)
+class DistribuicaoResult:
+    """Resultado de uma consulta NFeDistribuicaoDFe."""
+
+    ultimo_nsu: str
+    """Ultimo NSU retornado pela SEFAZ nesta consulta."""
+
+    max_nsu: str
+    """Maior NSU disponivel para o ator consultante."""
+
+    documentos: list[DocumentoDistribuicao]
+    """Lista de documentos retornados."""
+
+
+@dataclass(frozen=True)
+class ManifestacaoResult:
+    """Resultado de uma manifestacao do destinatario."""
+
+    sucesso: bool
+    """True se o evento foi recebido pela SEFAZ com sucesso."""
+
+    chave: str
+    """Chave de acesso da NF-e manifestada."""
+
+    tipo_evento: str
+    """Codigo do evento (ex: 210200)."""
+
+    numero_protocolo: str | None
+    """Numero do protocolo retornado pela SEFAZ."""
+
+    codigo_retorno: str | None
+    """cStat retornado pela SEFAZ (135 = sucesso)."""
+
+    motivo: str | None
+    """xMotivo retornado pela SEFAZ."""
+
+
+# ---------------------------------------------------------------------------
+# Utilidades internas
+# ---------------------------------------------------------------------------
+
+
+def _somente_digitos(valor: str) -> str:
+    return re.sub(r"\D", "", valor)
+
+
+def _validar_cnpj_cpf(valor: str, campo: str) -> str:
+    """Valida e normaliza CNPJ (14 dig) ou CPF (11 dig). Lanca FiscalValidationError."""
+    digitos = _somente_digitos(valor)
+    if _CNPJ_RE.match(digitos) or _CPF_RE.match(digitos):
+        return digitos
+    raise FiscalValidationError(
+        message=f"O campo '{campo}' deve ser um CNPJ (14 digitos) ou CPF (11 digitos) numerico. Recebido: {valor!r}",
+        field=campo,
+        value=valor,
+    )
+
+
+def _validar_nsu(nsu: str | int, campo: str = "nsu") -> str:
+    """Valida e normaliza NSU (1-15 digitos numericos). Lanca FiscalValidationError."""
+    nsu_str = str(nsu).strip()
+    if not _NSU_RE.match(nsu_str):
+        raise FiscalValidationError(
+            message=f"NSU invalido: '{nsu_str}'. Deve conter apenas digitos (max 15).",
+            field=campo,
+            value=nsu_str,
+        )
+    return nsu_str.zfill(15)
+
+
+def _validar_chave(chave: str) -> str:
+    """Valida chave de acesso de 44 digitos. Lanca FiscalValidationError."""
+    chave_limpa = _somente_digitos(chave)
+    if not validate_chave_nfe(chave_limpa):
+        raise FiscalValidationError(
+            message=f"Chave de acesso invalida (44 digitos, modulo 11). Recebido: {chave!r}",
+            field="chave",
+            value=chave,
+        )
+    return chave_limpa
+
+
+def _carregar_pkcs12(
+    caminho_certificado: str,
+    senha: str,
+) -> tuple[bytes, bytes, list[bytes]]:
+    """
+    Carrega um arquivo PKCS12 (.pfx/.p12) e retorna (chave_pem, cert_pem, chain_pem).
+
+    SEGURANCA: a senha NAO e logada nem incluida em mensagens de excecao.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.serialization import pkcs12
+
+    try:
+        with open(caminho_certificado, "rb") as f:
+            pfx_data = f.read()
+    except OSError as exc:
+        raise FiscalValidationError(
+            message=f"Nao foi possivel abrir o certificado: {exc.strerror}. Verifique o caminho.",
+            field="caminho_certificado",
+            value=caminho_certificado,
+        ) from exc
+
+    try:
+        private_key, certificate, additional_certs = pkcs12.load_key_and_certificates(
+            pfx_data, senha.encode("utf-8")
+        )
+    except Exception as exc:
+        # Evitar vazar a senha na mensagem
+        exc_str = str(exc)
+        if "password" in exc_str.lower() or "senha" in exc_str.lower():
+            motivo = "Senha incorreta ou certificado corrompido."
+        else:
+            motivo = f"Erro ao carregar certificado PKCS12: {exc.__class__.__name__}"
+        raise FiscalValidationError(
+            message=motivo,
+            field="caminho_certificado",
+            value=caminho_certificado,
+        ) from exc
+
+    if private_key is None or certificate is None:
+        raise FiscalValidationError(
+            message="Certificado ou chave privada ausente no arquivo PKCS12.",
+            field="caminho_certificado",
+            value=caminho_certificado,
+        )
+
+    chave_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    cert_pem = certificate.public_bytes(serialization.Encoding.PEM)
+    chain_pem = []
+    for c in additional_certs or []:
+        chain_pem.append(c.public_bytes(serialization.Encoding.PEM))
+
+    return chave_pem, cert_pem, chain_pem
+
+
+def _escrever_pem_atomico(suffix: str, conteudo: bytes) -> str:
+    """
+    Cria um arquivo PEM temporario com permissao 0600 de forma atomica.
+
+    Usa tempfile.mkstemp(), que cria o arquivo atomicamente com permissao 0600
+    (sem janela de exposicao em 0644). Retorna o caminho do arquivo criado;
+    o chamador e responsavel por apagar o arquivo no bloco finally.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    try:
+        os.write(fd, conteudo)
+    finally:
+        os.close(fd)
+    return path
+
+
+def _criar_ssl_context_em_memoria(
+    chave_pem: bytes,
+    cert_pem: bytes,
+    chain_pem: list[bytes],
+) -> ssl.SSLContext:
+    """
+    Monta um ssl.SSLContext usando arquivos PEM temporarios com permissao 0600.
+
+    Os arquivos sao criados com os.open (O_CREAT|O_WRONLY|O_EXCL, 0o600)
+    para que ja nascam com a permissao restrita, sem janela 0644. Sao
+    apagados no bloco finally. A chave privada nunca e logada.
+    """
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = True
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_default_certs()
+
+    tmp_key: str | None = None
+    tmp_cert: str | None = None
+
+    try:
+        tmp_key = _escrever_pem_atomico("_key.pem", chave_pem)
+        tmp_cert = _escrever_pem_atomico("_cert.pem", cert_pem + b"".join(chain_pem))
+
+        ctx.load_cert_chain(certfile=tmp_cert, keyfile=tmp_key)
+    finally:
+        if tmp_key and os.path.exists(tmp_key):
+            os.unlink(tmp_key)
+        if tmp_cert and os.path.exists(tmp_cert):
+            os.unlink(tmp_cert)
+
+    return ctx
+
+
+def _descompactar_doc_zip(doc_zip_b64: str) -> bytes:
+    """Descompacta um docZip (base64 + gzip) retornado pela SEFAZ."""
+    compressed = base64.b64decode(doc_zip_b64.strip())
+    return gzip.decompress(compressed)
+
+
+def _extrair_chave_xml(root: etree._Element) -> str | None:
+    """Tenta extrair a chave de acesso de 44 digitos do XML."""
+    ns = {"nfe": _NS_NFE}
+    candidates = [
+        ".//nfe:infNFe/@Id",
+        ".//nfe:chNFe/text()",
+        ".//nfe:chNFe",
+    ]
+    for xpath in candidates:
+        vals = root.xpath(xpath, namespaces=ns)
+        if vals:
+            raw = str(vals[0]).strip()
+            digitos = _somente_digitos(raw)
+            if len(digitos) == 44:
+                return digitos
+    return None
+
+
+def _extrair_resumo_resnfe(root: etree._Element) -> dict[str, str | None]:
+    """Extrai campos principais de um documento resNFe."""
+    ns = {"nfe": _NS_NFE}
+
+    def _txt(xpath: str) -> str:
+        vals = root.xpath(xpath, namespaces=ns)
+        return str(vals[0]).strip() if vals else ""
+
+    def _txt_or_none(xpath: str) -> str | None:
+        vals = root.xpath(xpath, namespaces=ns)
+        return str(vals[0]).strip() if vals else None
+
+    return {
+        "chave": _txt(".//nfe:chNFe/text()"),
+        "emitente_cnpj": _txt(".//nfe:CNPJ/text()"),
+        "emitente_nome": _txt(".//nfe:xNome/text()"),
+        "valor_nf": _txt(".//nfe:vNF/text()"),
+        # cSitNFe e o campo correto para situacao da NF-e no resNFe;
+        # digVal e o digest do documento e NAO deve ser retornado aqui.
+        "situacao": _txt_or_none(".//nfe:cSitNFe/text()"),
+        "data_autorizacao": _txt(".//nfe:dhRecbto/text()"),
+        "tipo_nf": _txt(".//nfe:tpNF/text()"),
+    }
+
+
+def _parse_documento(nsu: str, doc_xml_bytes: bytes, schema_name: str) -> DocumentoDistribuicao:
+    """Parseia um documento retornado pela SEFAZ e monta DocumentoDistribuicao."""
+    try:
+        root = parse_xml(doc_xml_bytes)
+    except Exception:
+        return DocumentoDistribuicao(
+            nsu=nsu,
+            tipo="desconhecido",
+            schema=schema_name,
+            chave=None,
+            resumo=None,
+            dados_completos=None,
+        )
+
+    chave = _extrair_chave_xml(root)
+    schema_lower = schema_name.lower()
+
+    # Tipos de documento completo (contem a NF-e autenticada)
+    if any(t in schema_lower for t in ("procnfe", "nfeproc")):
+        dados_completos = None
+        if chave:
+            try:
+                dados_completos = parse_nfe_xml(doc_xml_bytes, chave)
+            except Exception:
+                pass
+        return DocumentoDistribuicao(
+            nsu=nsu,
+            tipo="procNFe",
+            schema=schema_name,
+            chave=chave,
+            resumo=None,
+            dados_completos=dados_completos,
+        )
+
+    # resNFe: resumo
+    if "resnfe" in schema_lower:
+        resumo = _extrair_resumo_resnfe(root)
+        return DocumentoDistribuicao(
+            nsu=nsu,
+            tipo="resNFe",
+            schema=schema_name,
+            chave=chave or resumo.get("chave") or None,
+            resumo=resumo,
+            dados_completos=None,
+        )
+
+    return DocumentoDistribuicao(
+        nsu=nsu,
+        tipo=schema_name,
+        schema=schema_name,
+        chave=chave,
+        resumo=None,
+        dados_completos=None,
+    )
+
+
+def _construir_body_dist_nsu(
+    cnpj_cpf: str,
+    uf_autor: str,
+    ultimo_nsu: str,
+) -> str:
+    """Monta o corpo SOAP para distNSU (distribuicao incremental por ultimo NSU)."""
+    tipo = "CNPJ" if len(cnpj_cpf) == 14 else "CPF"
+    uf_autor_esc = xml.sax.saxutils.escape(uf_autor)
+    return (
+        f'<nfeDistDFeInt xmlns="{_NS_NFE}" versao="1.01">'
+        f"<tpAmb>1</tpAmb>"
+        f"<cUFAutor>{uf_autor_esc}</cUFAutor>"
+        f"<{tipo}>{cnpj_cpf}</{tipo}>"
+        f"<distNSU>"
+        f"<ultNSU>{ultimo_nsu}</ultNSU>"
+        f"</distNSU>"
+        f"</nfeDistDFeInt>"
+    )
+
+
+def _construir_body_cons_nsu(
+    cnpj_cpf: str,
+    uf_autor: str,
+    nsu: str,
+) -> str:
+    """Monta o corpo SOAP para consNSU (consulta por NSU especifico)."""
+    tipo = "CNPJ" if len(cnpj_cpf) == 14 else "CPF"
+    uf_autor_esc = xml.sax.saxutils.escape(uf_autor)
+    return (
+        f'<nfeDistDFeInt xmlns="{_NS_NFE}" versao="1.01">'
+        f"<tpAmb>1</tpAmb>"
+        f"<cUFAutor>{uf_autor_esc}</cUFAutor>"
+        f"<{tipo}>{cnpj_cpf}</{tipo}>"
+        f"<consNSU>"
+        f"<NSU>{nsu}</NSU>"
+        f"</consNSU>"
+        f"</nfeDistDFeInt>"
+    )
+
+
+def _construir_body_cons_ch_nfe(
+    cnpj_cpf: str,
+    uf_autor: str,
+    chave: str,
+) -> str:
+    """Monta o corpo SOAP para consChNFe (consulta por chave de 44 digitos)."""
+    tipo = "CNPJ" if len(cnpj_cpf) == 14 else "CPF"
+    uf_autor_esc = xml.sax.saxutils.escape(uf_autor)
+    return (
+        f'<nfeDistDFeInt xmlns="{_NS_NFE}" versao="1.01">'
+        f"<tpAmb>1</tpAmb>"
+        f"<cUFAutor>{uf_autor_esc}</cUFAutor>"
+        f"<{tipo}>{cnpj_cpf}</{tipo}>"
+        f"<consChNFe>"
+        f"<chNFe>{chave}</chNFe>"
+        f"</consChNFe>"
+        f"</nfeDistDFeInt>"
+    )
+
+
+def _parse_retorno_dist(body_el: etree._Element) -> DistribuicaoResult:
+    """Parseia o elemento retDistDFeInt e retorna DistribuicaoResult."""
+    ns = {"nfe": _NS_NFE}
+
+    def _txt(xpath: str) -> str:
+        vals = body_el.xpath(xpath, namespaces=ns)
+        return str(vals[0]).strip() if vals else ""
+
+    c_stat = _txt(".//nfe:cStat/text()")
+    x_motivo = _txt(".//nfe:xMotivo/text()")
+    ultimo_nsu = _txt(".//nfe:ultNSU/text()") or "000000000000000"
+    max_nsu = _txt(".//nfe:maxNSU/text()") or ultimo_nsu
+
+    # cStat != 138 (Documento localizado) e != 137 (Nenhum documento) -> erro
+    if c_stat not in ("137", "138", ""):
+        raise FiscalHTTPError(
+            message=f"SEFAZ retornou erro na distribuicao: {c_stat} - {x_motivo}",
+            status_code=200,
+            url="NFeDistribuicaoDFe",
+        )
+
+    documentos: list[DocumentoDistribuicao] = []
+    docs_el = body_el.xpath(".//nfe:loteDistDFeInt/nfe:docZip", namespaces=ns)
+    for doc_el in docs_el:
+        nsu_doc = str(doc_el.get("NSU", "")).strip()
+        schema_name = str(doc_el.get("schema", "")).strip()
+        doc_zip_b64 = (doc_el.text or "").strip()
+
+        if not doc_zip_b64:
+            continue
+        try:
+            doc_bytes = _descompactar_doc_zip(doc_zip_b64)
+            doc = _parse_documento(nsu_doc, doc_bytes, schema_name)
+        except Exception as exc:
+            logger.warning("nfe.distribuicao.parse_doc_falhou", nsu=nsu_doc, erro=str(exc))
+            doc = DocumentoDistribuicao(
+                nsu=nsu_doc,
+                tipo="erro",
+                schema=schema_name,
+                chave=None,
+                resumo=None,
+                dados_completos=None,
+            )
+        documentos.append(doc)
+
+    return DistribuicaoResult(
+        ultimo_nsu=ultimo_nsu,
+        max_nsu=max_nsu,
+        documentos=documentos,
+    )
+
+
+async def _enviar_soap(
+    url: str,
+    soap_body_content: str,
+    ssl_ctx: ssl.SSLContext,
+    timeout: float = 30.0,
+) -> etree._Element:
+    """Envia requisicao SOAP via mTLS e retorna o elemento Body da resposta.
+
+    Rate limit: maximo 1 req/s por endpoint SEFAZ (conservador para evitar
+    bloqueio por flood). O limitador e aplicado por URL de endpoint.
+    """
+    # Aplica rate-limit por endpoint antes de enviar a requisicao
+    await _sefaz_nfe_limiter.acquire(url)
+
+    envelope = build_soap_envelope(soap_body_content, namespace=_NS_NFE)
+
+    headers = {
+        "Content-Type": "application/soap+xml; charset=utf-8",
+        "SOAPAction": "",
+    }
+
+    try:
+        async with httpx.AsyncClient(verify=ssl_ctx, timeout=timeout) as client:
+            response = await client.post(url, content=envelope.encode("utf-8"), headers=headers)
+    except httpx.RequestError as exc:
+        raise FiscalHTTPError(
+            message=f"Falha de conexao com a SEFAZ: {exc.__class__.__name__}",
+            status_code=0,
+            url=url,
+        ) from exc
+
+    if response.status_code != 200:
+        raise FiscalHTTPError(
+            message=f"SEFAZ retornou HTTP {response.status_code}",
+            status_code=response.status_code,
+            url=url,
+        )
+
+    return extract_soap_body(response.text)
+
+
+# ---------------------------------------------------------------------------
+# Funcoes publicas
+# ---------------------------------------------------------------------------
+
+
+async def baixar_nfe_distribuicao(
+    caminho_certificado: str,
+    senha: str,
+    cnpj_cpf: str,
+    uf: str,
+    modo: Literal["distNSU", "consNSU", "consChNFe"] = "distNSU",
+    ultimo_nsu: str | int = "0",
+    nsu: str | int | None = None,
+    chave: str | None = None,
+    ambiente: Ambiente = "producao",
+    timeout: float = 30.0,
+) -> DistribuicaoResult:
+    """
+    Baixa documentos fiscais via NFeDistribuicaoDFe com mTLS usando certificado A1 local.
+
+    A Ciencia da Operacao (evento 210200) e pre-requisito para a SEFAZ liberar o
+    XML completo (procNFe) ao destinatario. Sem ela, apenas o resNFe (resumo) e
+    disponibilizado. Use manifestar_nfe() apos baixar o resNFe para registrar
+    a ciencia e depois consultar novamente para obter o procNFe completo.
+
+    Args:
+        caminho_certificado: Caminho absoluto para o arquivo .pfx ou .p12.
+        senha: Senha do certificado. NUNCA logada ou incluida em excecoes.
+        cnpj_cpf: CNPJ (14 dig) ou CPF (11 dig) do autor da consulta.
+        uf: Codigo da UF do autor (ex: "35" para SP ou "SP").
+        modo: "distNSU" (incremental), "consNSU" (NSU especifico),
+            "consChNFe" (por chave).
+        ultimo_nsu: Ultimo NSU recebido (modo distNSU). Default 0 = busca todos.
+        nsu: NSU especifico a consultar (modo consNSU).
+        chave: Chave de acesso de 44 digitos (modo consChNFe).
+        ambiente: "producao" ou "homologacao".
+        timeout: Timeout HTTP em segundos.
+
+    Returns:
+        DistribuicaoResult com documentos e NSUs.
+
+    Raises:
+        FiscalValidationError: Inputs invalidos ou certificado invalido/senha errada.
+        FiscalHTTPError: Falha HTTP ou erro retornado pela SEFAZ.
+    """
+    # Validacao de inputs
+    cnpj_cpf_norm = _validar_cnpj_cpf(cnpj_cpf, "cnpj_cpf")
+
+    # UF: aceita sigla (ex: "SP") ou codigo numerico IBGE (ex: "35")
+    uf_str = str(uf).strip()
+    uf_codigo = _UF_CODIGOS.get(uf_str.upper(), uf_str)
+
+    # Carrega o certificado A1
+    chave_pem, cert_pem, chain_pem = _carregar_pkcs12(caminho_certificado, senha)
+    ssl_ctx = _criar_ssl_context_em_memoria(chave_pem, cert_pem, chain_pem)
+
+    # Monta o corpo SOAP conforme o modo
+    endpoint = _ENDPOINTS_DISTRIBUICAO[ambiente]
+
+    if modo == "distNSU":
+        nsu_norm = _validar_nsu(ultimo_nsu, "ultimo_nsu")
+        body_content = _construir_body_dist_nsu(cnpj_cpf_norm, uf_codigo, nsu_norm)
+
+    elif modo == "consNSU":
+        if nsu is None:
+            raise FiscalValidationError(
+                message="Parametro 'nsu' e obrigatorio no modo consNSU.",
+                field="nsu",
+                value=None,
+            )
+        nsu_norm = _validar_nsu(nsu, "nsu")
+        body_content = _construir_body_cons_nsu(cnpj_cpf_norm, uf_codigo, nsu_norm)
+
+    elif modo == "consChNFe":
+        if not chave:
+            raise FiscalValidationError(
+                message="Parametro 'chave' e obrigatorio no modo consChNFe.",
+                field="chave",
+                value=chave,
+            )
+        chave_norm = _validar_chave(chave)
+        body_content = _construir_body_cons_ch_nfe(cnpj_cpf_norm, uf_codigo, chave_norm)
+
+    else:
+        raise FiscalValidationError(
+            message=f"Modo desconhecido: {modo!r}. Use 'distNSU', 'consNSU' ou 'consChNFe'.",
+            field="modo",
+            value=modo,
+        )
+
+    body_el = await _enviar_soap(endpoint, body_content, ssl_ctx, timeout)
+    return _parse_retorno_dist(body_el)
+
+
+def _montar_xml_evento(
+    chave: str,
+    cnpj_cpf: str,
+    tipo_evento: str,
+    numero_sequencia: int,
+    justificativa: str | None,
+    ambiente_codigo: str,
+) -> etree._Element:
+    """Monta o elemento XML do evento de manifestacao (sem assinatura)."""
+    data_hora = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S-00:00")
+    c_orgao = "91"  # AN - Ambiente Nacional para manifestacao
+
+    tipo_tag = "CNPJ" if len(cnpj_cpf) == 14 else "CPF"
+
+    desc_evento = {
+        EVENTO_CIENCIA: "Ciencia da Operacao",
+        EVENTO_CONFIRMACAO: "Confirmacao da Operacao",
+        EVENTO_DESCONHECIMENTO: "Desconhecimento da Operacao",
+        EVENTO_OPERACAO_NAO_REALIZADA: "Operacao nao Realizada",
+    }.get(tipo_evento, "Evento")
+
+    det_evento_inner = f"<descEvento>{desc_evento}</descEvento>" + (
+        f"<xJust>{xml.sax.saxutils.escape(justificativa)}</xJust>" if justificativa else ""
+    )
+
+    xml_str = (
+        f'<envEvento versao="1.00" xmlns="{_NS_NFE}">'
+        f"<idLote>{numero_sequencia}</idLote>"
+        f'<evento versao="1.00">'
+        f'<infEvento Id="ID{tipo_evento}{chave}{str(numero_sequencia).zfill(2)}">'
+        f"<cOrgao>{c_orgao}</cOrgao>"
+        f"<tpAmb>{ambiente_codigo}</tpAmb>"
+        f"<{tipo_tag}>{cnpj_cpf}</{tipo_tag}>"
+        f"<chNFe>{chave}</chNFe>"
+        f"<dhEvento>{data_hora}</dhEvento>"
+        f"<tpEvento>{tipo_evento}</tpEvento>"
+        f"<nSeqEvento>{numero_sequencia}</nSeqEvento>"
+        f"<verEvento>1.00</verEvento>"
+        f'<detEvento versao="1.00">{det_evento_inner}</detEvento>'
+        f"</infEvento>"
+        f"</evento>"
+        f"</envEvento>"
+    )
+    return parse_xml(xml_str.encode("utf-8"))
+
+
+def _get_ref_id(evento_el: etree._Element) -> str:
+    """Retorna o atributo Id de infEvento, ou de evento_el como fallback."""
+    inf_evento = evento_el.find(f".//{{{_NS_NFE}}}infEvento")
+    target = inf_evento if inf_evento is not None else evento_el
+    return str(target.get("Id", ""))
+
+
+def _assinar_evento(
+    evento_el: etree._Element,
+    chave_pem: bytes,
+    cert_pem: bytes,
+) -> etree._Element:
+    """Assina o elemento infEvento com XMLDSig usando a chave privada do certificado A1."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    private_key = load_pem_private_key(chave_pem, password=None)
+    certificate = x509.load_pem_x509_certificate(cert_pem)
+
+    if not isinstance(private_key, (RSAPrivateKey, EllipticCurvePrivateKey)):
+        raise FiscalValidationError(
+            message="Tipo de chave nao suportado para assinatura NF-e: apenas RSA e EC sao aceitos.",
+            field="caminho_certificado",
+            value="",
+        )
+
+    signer = XMLSigner()  # metodo padrao: enveloped
+    signed = signer.sign(
+        evento_el,
+        key=private_key,
+        cert=[certificate],
+        reference_uri="#" + _get_ref_id(evento_el),
+    )
+    return signed
+
+
+def _parse_retorno_evento(
+    body_el: etree._Element, chave: str, tipo_evento: str
+) -> ManifestacaoResult:
+    """Parseia o retEnvEvento e retorna ManifestacaoResult."""
+    ns = {"nfe": _NS_NFE}
+
+    def _txt(xpath: str) -> str:
+        vals = body_el.xpath(xpath, namespaces=ns)
+        return str(vals[0]).strip() if vals else ""
+
+    c_stat = _txt(".//nfe:cStat/text()")
+    x_motivo = _txt(".//nfe:xMotivo/text()")
+    n_prot = _txt(".//nfe:nProt/text()")
+
+    sucesso = c_stat == "135"
+    return ManifestacaoResult(
+        sucesso=sucesso,
+        chave=chave,
+        tipo_evento=tipo_evento,
+        numero_protocolo=n_prot or None,
+        codigo_retorno=c_stat or None,
+        motivo=x_motivo or None,
+    )
+
+
+async def manifestar_nfe(
+    chave: str,
+    tipo_evento: str,
+    caminho_certificado: str,
+    senha: str,
+    cnpj_cpf: str,
+    uf: str = "91",
+    numero_sequencia: int = 1,
+    justificativa: str | None = None,
+    ambiente: Ambiente = "producao",
+    timeout: float = 30.0,
+) -> ManifestacaoResult:
+    """
+    Manifesta o destinatario em uma NF-e via NFeRecepcaoEvento.
+
+    IMPORTANTE: A Ciencia da Operacao (210200) e pre-requisito obrigatorio para
+    a SEFAZ liberar o XML completo (procNFe) ao destinatario. Sem registrar a
+    ciencia primeiro, somente o resNFe (resumo) fica disponivel na distribuicao.
+
+    Eventos disponiveis:
+    - 210200: Ciencia da Operacao (sem justificativa)
+    - 210210: Confirmacao da Operacao (sem justificativa)
+    - 210220: Desconhecimento da Operacao (sem justificativa)
+    - 210240: Operacao nao Realizada (justificativa OBRIGATORIA, min. 15 chars)
+
+    Args:
+        chave: Chave de acesso de 44 digitos da NF-e.
+        tipo_evento: Codigo do evento (ex: "210200").
+        caminho_certificado: Caminho absoluto para o arquivo .pfx/.p12.
+        senha: Senha do certificado A1. NUNCA logada ou incluida em excecoes.
+        cnpj_cpf: CNPJ (14 dig) ou CPF (11 dig) do destinatario.
+        uf: UF do autor (default "91" = AN - Ambiente Nacional).
+        numero_sequencia: Numero sequencial do evento para esta chave (1 a 20).
+        justificativa: Obrigatoria para 210240 (min. 15 chars). Ignorada nos demais.
+        ambiente: "producao" ou "homologacao".
+        timeout: Timeout HTTP em segundos.
+
+    Returns:
+        ManifestacaoResult com protocolo e codigo de retorno da SEFAZ.
+
+    Raises:
+        FiscalValidationError: Inputs invalidos, certificado invalido ou justificativa ausente.
+        FiscalHTTPError: Falha HTTP ou erro da SEFAZ.
+    """
+    chave_norm = _validar_chave(chave)
+    cnpj_cpf_norm = _validar_cnpj_cpf(cnpj_cpf, "cnpj_cpf")
+
+    if tipo_evento not in _EVENTOS_VALIDOS:
+        raise FiscalValidationError(
+            message=f"Tipo de evento invalido: {tipo_evento!r}. Valores aceitos: {sorted(_EVENTOS_VALIDOS)}",
+            field="tipo_evento",
+            value=tipo_evento,
+        )
+
+    if tipo_evento == EVENTO_OPERACAO_NAO_REALIZADA:
+        if not justificativa or len(justificativa.strip()) < 15:
+            raise FiscalValidationError(
+                message="Justificativa obrigatoria para o evento 210240 (Operacao nao Realizada) e deve ter ao menos 15 caracteres.",
+                field="justificativa",
+                value=justificativa,
+            )
+
+    ambiente_codigo = "1" if ambiente == "producao" else "2"
+    endpoint = _ENDPOINTS_EVENTO[ambiente]
+
+    chave_pem, cert_pem, chain_pem = _carregar_pkcs12(caminho_certificado, senha)
+    ssl_ctx = _criar_ssl_context_em_memoria(chave_pem, cert_pem, chain_pem)
+
+    evento_el = _montar_xml_evento(
+        chave=chave_norm,
+        cnpj_cpf=cnpj_cpf_norm,
+        tipo_evento=tipo_evento,
+        numero_sequencia=numero_sequencia,
+        justificativa=justificativa,
+        ambiente_codigo=ambiente_codigo,
+    )
+
+    signed_el = _assinar_evento(evento_el, chave_pem, cert_pem)
+    body_content = etree.tostring(signed_el, encoding="unicode")
+
+    body_el = await _enviar_soap(endpoint, body_content, ssl_ctx, timeout)
+    return _parse_retorno_evento(body_el, chave_norm, tipo_evento)
+
+
+__all__ = [
+    "EVENTO_CIENCIA",
+    "EVENTO_CONFIRMACAO",
+    "EVENTO_DESCONHECIMENTO",
+    "EVENTO_OPERACAO_NAO_REALIZADA",
+    "Ambiente",
+    "DistribuicaoResult",
+    "DocumentoDistribuicao",
+    "ManifestacaoResult",
+    "baixar_nfe_distribuicao",
+    "manifestar_nfe",
+]

--- a/src/mcp_fiscal_brasil/nfe/documento.py
+++ b/src/mcp_fiscal_brasil/nfe/documento.py
@@ -1,0 +1,77 @@
+"""Tool de parse de documento NF-e/NFC-e a partir de XML bruto."""
+
+from pydantic import BaseModel
+
+from .._core.errors import FiscalValidationError
+from .schemas import NFeResponse
+from .xml_parser import extrair_chave_nfe, parse_nfe_xml
+
+
+class DocumentoParseError(FiscalValidationError):
+    """Erro de validacao ao fazer parse de XML de documento fiscal."""
+
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        super().__init__(message=reason, field=field, value=value)
+
+
+class ParseNFeDocumentoResult(BaseModel):
+    """Resultado do parse de documento NF-e/NFC-e."""
+
+    nfe: NFeResponse
+    chave_extraida: str
+    modelo: int
+
+
+def _extrair_chave_do_xml(xml_content: str | bytes) -> str:
+    """
+    Extrai a chave de acesso (44 digitos) do atributo Id do infNFe.
+
+    O atributo Id tem o formato "NFe<44 digitos>" ou apenas "<44 digitos>".
+    Remove o prefixo "NFe" se presente. Delega a extracao ao helper
+    compartilhado extrair_chave_nfe (xml_parser.py).
+
+    Args:
+        xml_content: Conteudo XML da NF-e ou NFC-e.
+
+    Returns:
+        Chave de acesso com 44 digitos.
+
+    Raises:
+        DocumentoParseError: Se o XML nao contiver o elemento infNFe com Id valido.
+    """
+    chave = extrair_chave_nfe(xml_content)
+    if chave is None:
+        raise DocumentoParseError(
+            field="infNFe/@Id",
+            value="<xml>",
+            reason=(
+                "XML invalido: elemento <infNFe> nao encontrado ou Id nao contem "
+                "44 digitos numericos apos remover o prefixo 'NFe'. "
+                "Verifique se o XML e uma NF-e ou NFC-e valida."
+            ),
+        )
+    return chave
+
+
+def parse_nfe_documento(xml_content: str | bytes) -> NFeResponse:
+    """
+    Parseia o XML completo de uma NF-e ou NFC-e e retorna NFeResponse.
+
+    Aceita XMLs com ou sem o involucro de protocolo <nfeProc>, com ou sem
+    namespace do portal fiscal. Extrai a chave de acesso automaticamente do
+    atributo Id do elemento <infNFe>.
+
+    Args:
+        xml_content: XML completo da NF-e ou NFC-e como string ou bytes.
+                     Pode conter o involucro <nfeProc> ou ser a NF-e nua.
+
+    Returns:
+        NFeResponse com todos os dados do documento fiscal.
+
+    Raises:
+        DocumentoParseError: Se o XML nao for uma NF-e/NFC-e valida ou a chave
+                             extraida nao tiver 44 digitos.
+        XMLParseError: Se o XML estiver malformado (lxml nao conseguir parsear).
+    """
+    chave = _extrair_chave_do_xml(xml_content)
+    return parse_nfe_xml(xml_content, chave)

--- a/src/mcp_fiscal_brasil/nfe/xml_parser.py
+++ b/src/mcp_fiscal_brasil/nfe/xml_parser.py
@@ -9,6 +9,63 @@ from ..shared.xml_utils import NS_NFE, parse_xml, xpath_text
 from .schemas import EnderecoNFe, ItemNFe, NFeResponse, TotaisNFe, TotaisReformaNFe
 
 
+def extrair_chave_nfe(xml_content: str | bytes) -> str | None:
+    """
+    Extrai a chave de acesso de 44 digitos do atributo Id do infNFe.
+
+    Remove o prefixo "NFe" se presente. Retorna None se o elemento
+    infNFe nao for encontrado ou se o Id nao contiver 44 digitos.
+
+    Args:
+        xml_content: Conteudo XML da NF-e ou NFC-e.
+
+    Returns:
+        Chave de 44 digitos ou None se nao encontrada.
+    """
+    root = parse_xml(xml_content)
+    ns = NS_NFE
+
+    inf_nfe = root.find(".//nfe:infNFe", ns)
+    if inf_nfe is None:
+        inf_nfe = root.find(".//infNFe")
+    if inf_nfe is None:
+        return None
+
+    raw_id = cast(str, inf_nfe.get("Id", ""))
+    chave = raw_id.removeprefix("NFe")
+    return chave if (len(chave) == 44 and chave.isdigit()) else None
+
+
+def extrair_modelo_nfe(xml_content: str | bytes) -> int:
+    """
+    Extrai o codigo de modelo do documento fiscal (55=NF-e, 65=NFC-e) do XML.
+
+    Retorna 55 como padrao quando o elemento <ide>/<mod> nao for encontrado
+    ou contiver valor nao numerico.
+
+    Args:
+        xml_content: Conteudo XML do documento fiscal.
+
+    Returns:
+        Numero do modelo (55 ou 65 tipicamente).
+    """
+    root = parse_xml(xml_content)
+    ns = NS_NFE
+
+    ide = root.find(".//nfe:ide", ns)
+    if ide is None:
+        ide = root.find(".//ide")
+
+    mod_text = xpath_text(ide, "nfe:mod/text()", ns) if ide is not None else None
+    if mod_text is None and ide is not None:
+        mod_text = xpath_text(ide, "mod/text()", {})
+
+    try:
+        return int(mod_text or "55")
+    except (ValueError, TypeError):
+        return 55
+
+
 def _find_any(
     element: etree._Element | None,
     namespaced_path: str,

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -30,6 +30,15 @@ from .empresa import _tools as empresa_tools
 from .esocial.tools import listar_eventos_esocial, validar_evento_esocial
 from .ibge import _tools as ibge_tools
 from .mei import _tools as mei_tools
+from .nfe.assinatura import AssinaturaResult, validar_assinatura_nfe
+from .nfe.danfe import DanfeResult, gerar_danfe
+from .nfe.distribuicao import (
+    DistribuicaoResult,
+    ManifestacaoResult,
+    baixar_nfe_distribuicao,
+    manifestar_nfe,
+)
+from .nfe.documento import parse_nfe_documento
 from .nfe.tools import consultar_nfe, consultar_status_sefaz, validar_chave_nfe
 from .nfse.tools import consultar_nfse
 from .shared.validators import normalizar_cnpj, validate_cnpj_qualquer
@@ -243,6 +252,282 @@ async def tool_consultar_status_sefaz(uf: str) -> dict[str, Any]:
     """
     resultado = await consultar_status_sefaz(uf)
     return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="parse_nfe_xml",
+    description=(
+        "Parseia o XML completo de uma NF-e ou NFC-e e retorna os dados estruturados. "
+        "Aceita XML com ou sem o involucro <nfeProc> e com ou sem namespace do portal fiscal. "
+        "Util para extrair emitente, destinatario, itens, totais e protocolo a partir do XML bruto."
+    ),
+)
+async def tool_parse_nfe_xml(xml_content: str) -> dict[str, Any]:
+    """Parseia o XML completo de uma NF-e ou NFC-e e retorna os dados estruturados.
+
+    Extrai automaticamente a chave de acesso do atributo Id do elemento <infNFe>.
+    Aceita XMLs com ou sem involucro de protocolo <nfeProc>, com ou sem namespace
+    do portal fiscal (http://www.portalfiscal.inf.br/nfe).
+
+    Args:
+        xml_content: XML completo da NF-e ou NFC-e como string. Pode conter
+                     o involucro <nfeProc> ou ser a NF-e nua. Aceita XML com
+                     ou sem namespace do portal fiscal.
+
+    Returns:
+        dict com os dados do documento: chave_acesso, modelo, emitente, destinatario,
+        itens, totais, protocolo_autorizacao e demais campos da NFeResponse.
+
+    Raises:
+        DocumentoParseError: Se o XML for invalido ou a chave nao tiver 44 digitos.
+        XMLParseError: Se o XML estiver malformado.
+    """
+    resultado = parse_nfe_documento(xml_content)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="gerar_danfe",
+    description=(
+        "Gera o DANFE (Documento Auxiliar da Nota Fiscal Eletronica) em PDF a partir do XML de NF-e. "
+        "Suporta apenas NF-e modelo 55. O PDF e retornado em base64. "
+        "ATENCAO: o XML deve conter o namespace do portal fiscal "
+        "(xmlns='http://www.portalfiscal.inf.br/nfe'). "
+        "Nao e necessario certificado digital - funciona apenas com o XML."
+    ),
+)
+async def tool_gerar_danfe(xml_content: str) -> dict[str, Any]:
+    """Gera o DANFE em PDF a partir do XML de uma NF-e (modelo 55).
+
+    Utiliza a lib brazilfiscalreport para gerar o DANFE A4 no formato retrato.
+    O PDF e retornado como base64 no campo pdf_base64 do resultado.
+
+    NAMESPACE OBRIGATORIO: o XML deve conter o namespace do portal fiscal
+    (http://www.portalfiscal.inf.br/nfe). Modelo 65 (NFC-e) nao e suportado
+    na versao atual.
+
+    SEGURANCA: o XML e validado contra XXE (billion-laughs, entidades externas)
+    antes de ser entregue a lib de geracao do PDF.
+
+    Args:
+        xml_content: XML completo da NF-e como string. Deve conter o namespace
+                     do portal fiscal. Aceita XML com ou sem involucro <nfeProc>.
+
+    Returns:
+        dict com pdf_base64 (PDF em base64), modelo, nome_arquivo, chave_acesso,
+        numero e serie.
+    """
+    resultado: DanfeResult = gerar_danfe(xml_content)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="validar_assinatura_nfe",
+    description=(
+        "Valida a assinatura digital XMLDSig de uma NF-e. "
+        "Verifica a integridade do DigestValue e a assinatura criptografica do certificado. "
+        "Extrai dados do certificado assinante: titular, CNPJ/CPF, validade e autoridade certificadora. "
+        "Opcional: informe um CA bundle PEM para validar a cadeia de confianca ICP-Brasil."
+    ),
+)
+async def tool_validar_assinatura_nfe(
+    xml_content: str,
+    ca_bundle: str | None = None,
+) -> dict[str, Any]:
+    """Valida a assinatura digital XMLDSig de uma NF-e.
+
+    Verifica a integridade (DigestValue) e a assinatura criptografica do
+    elemento Signature presente em infNFe. Extrai dados do certificado assinante.
+
+    Sem ca_bundle: valida apenas a assinatura criptografica e integridade do digest
+    usando o certificado embutido no proprio XML. Nao verifica se o certificado
+    e confiavel (sem cadeia ICP-Brasil).
+
+    Com ca_bundle (PEM): valida a assinatura E a cadeia de confianca ICP-Brasil,
+    garantindo que o certificado foi emitido por uma AC credenciada.
+
+    Args:
+        xml_content: Conteudo XML da NF-e como string. Validado contra XXE (parse_xml).
+        ca_bundle: Opcional. Conteudo PEM (nao o caminho, mas o PEM em si) com a
+                   cadeia ICP-Brasil para validar o emissor do certificado.
+
+    Returns:
+        dict com assinatura_valida (bool), motivo (se invalida), titular (CN),
+        cnpj_cpf, validade_inicio, validade_fim e ac_emissora.
+    """
+    resultado: AssinaturaResult = validar_assinatura_nfe(
+        xml_content,
+        ca_bundle=ca_bundle.encode() if ca_bundle else None,
+    )
+    return {
+        "assinatura_valida": resultado.assinatura_valida,
+        "motivo": resultado.motivo,
+        "titular": resultado.titular,
+        "cnpj_cpf": resultado.cnpj_cpf,
+        "validade_inicio": resultado.validade_inicio.isoformat()
+        if resultado.validade_inicio
+        else None,
+        "validade_fim": resultado.validade_fim.isoformat() if resultado.validade_fim else None,
+        "ac_emissora": resultado.ac_emissora,
+    }
+
+
+@app.tool(
+    name="baixar_nfe_distribuicao",
+    description=(
+        "Baixa documentos fiscais via NFeDistribuicaoDFe (SEFAZ) usando certificado A1 local. "
+        "REQUER certificado digital A1 (.pfx/.p12) do proprio usuario instalado localmente. "
+        "O certificado NUNCA e enviado a nenhum servidor - a autenticacao e feita localmente via mTLS. "
+        "Suporta busca incremental (distNSU), por NSU especifico (consNSU) ou por chave (consChNFe). "
+        "A Ciencia da Operacao (210200) e prerequisito para obter o XML completo (procNFe)."
+    ),
+)
+async def tool_baixar_nfe_distribuicao(
+    caminho_certificado: str,
+    senha: str,
+    cnpj_cpf: str,
+    uf: str,
+    modo: str = "distNSU",
+    ultimo_nsu: str = "0",
+    nsu: str | None = None,
+    chave: str | None = None,
+    ambiente: str = "producao",
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Baixa documentos fiscais via NFeDistribuicaoDFe com mTLS usando certificado A1 local.
+
+    CERTIFICADO LOCAL (opt-in): requer o caminho absoluto para o arquivo .pfx/.p12
+    e a senha. O certificado NUNCA e enviado a qualquer servidor externo. A autenticacao
+    mTLS e feita diretamente entre o cliente e a SEFAZ.
+
+    A Ciencia da Operacao (evento 210200) e pre-requisito para a SEFAZ liberar o
+    XML completo (procNFe) ao destinatario. Sem ela, apenas o resNFe (resumo) fica
+    disponivel. Use manifestar_nfe() apos obter o resNFe.
+
+    Args:
+        caminho_certificado: Caminho absoluto para o arquivo .pfx ou .p12.
+        senha: Senha do certificado. Nunca logada ou incluida em excecoes.
+        cnpj_cpf: CNPJ (14 dig) ou CPF (11 dig) do autor da consulta.
+        uf: Sigla da UF do autor (ex: "SP") ou codigo IBGE (ex: "35").
+        modo: "distNSU" (incremental), "consNSU" (NSU especifico) ou
+              "consChNFe" (por chave de acesso de 44 digitos).
+        ultimo_nsu: Ultimo NSU recebido para modo distNSU. Default "0" busca todos.
+        nsu: NSU especifico para modo consNSU.
+        chave: Chave de acesso de 44 digitos para modo consChNFe.
+        ambiente: "producao" ou "homologacao".
+        timeout: Timeout HTTP em segundos (default 30.0).
+
+    Returns:
+        dict com ultimo_nsu, max_nsu e documentos (lista com nsu, tipo, schema,
+        chave e resumo de cada documento retornado).
+    """
+    resultado: DistribuicaoResult = await baixar_nfe_distribuicao(
+        caminho_certificado=caminho_certificado,
+        senha=senha,
+        cnpj_cpf=cnpj_cpf,
+        uf=uf,
+        modo=modo,  # type: ignore[arg-type]
+        ultimo_nsu=ultimo_nsu,
+        nsu=nsu,
+        chave=chave,
+        ambiente=ambiente,  # type: ignore[arg-type]
+        timeout=timeout,
+    )
+    # Serializa manualmente pois DistribuicaoResult e dataclass frozen com nested dataclasses
+    docs = []
+    for doc in resultado.documentos:
+        docs.append(
+            {
+                "nsu": doc.nsu,
+                "tipo": doc.tipo,
+                "schema": doc.schema,
+                "chave": doc.chave,
+                "resumo": doc.resumo,
+                "dados_completos": (
+                    doc.dados_completos.model_dump(mode="json", exclude_none=True)
+                    if doc.dados_completos is not None
+                    else None
+                ),
+            }
+        )
+    return {
+        "ultimo_nsu": resultado.ultimo_nsu,
+        "max_nsu": resultado.max_nsu,
+        "documentos": docs,
+    }
+
+
+@app.tool(
+    name="manifestar_nfe",
+    description=(
+        "Manifesta o destinatario em uma NF-e via NFeRecepcaoEvento. "
+        "REQUER certificado digital A1 (.pfx/.p12) do proprio usuario instalado localmente. "
+        "O certificado NUNCA e enviado a nenhum servidor - a assinatura e feita localmente. "
+        "Eventos: 210200 (Ciencia), 210210 (Confirmacao), 210220 (Desconhecimento), "
+        "210240 (Operacao nao Realizada, requer justificativa). "
+        "A Ciencia (210200) e prerequisito obrigatorio para obter o XML completo da NF-e."
+    ),
+)
+async def tool_manifestar_nfe(
+    chave: str,
+    tipo_evento: str,
+    caminho_certificado: str,
+    senha: str,
+    cnpj_cpf: str,
+    uf: str = "91",
+    numero_sequencia: int = 1,
+    justificativa: str | None = None,
+    ambiente: str = "producao",
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Manifesta o destinatario em uma NF-e via NFeRecepcaoEvento.
+
+    CERTIFICADO LOCAL (opt-in): requer o caminho absoluto para o arquivo .pfx/.p12
+    e a senha. O certificado NUNCA e enviado a qualquer servidor. A assinatura XMLDSig
+    do evento e feita localmente e o XML assinado e enviado diretamente a SEFAZ.
+
+    Eventos disponiveis:
+    - 210200: Ciencia da Operacao (pre-requisito para obter procNFe)
+    - 210210: Confirmacao da Operacao
+    - 210220: Desconhecimento da Operacao
+    - 210240: Operacao nao Realizada (justificativa OBRIGATORIA, minimo 15 caracteres)
+
+    Args:
+        chave: Chave de acesso de 44 digitos da NF-e.
+        tipo_evento: Codigo do evento ("210200", "210210", "210220" ou "210240").
+        caminho_certificado: Caminho absoluto para o arquivo .pfx/.p12.
+        senha: Senha do certificado A1. Nunca logada ou incluida em excecoes.
+        cnpj_cpf: CNPJ (14 dig) ou CPF (11 dig) do destinatario.
+        uf: UF do autor. Default "91" = AN (Ambiente Nacional) para manifestacao.
+        numero_sequencia: Numero sequencial do evento para esta chave (1 a 20).
+        justificativa: Obrigatoria para evento 210240 (minimo 15 caracteres).
+        ambiente: "producao" ou "homologacao".
+        timeout: Timeout HTTP em segundos (default 30.0).
+
+    Returns:
+        dict com sucesso (bool), chave, tipo_evento, numero_protocolo,
+        codigo_retorno e motivo retornados pela SEFAZ.
+    """
+    resultado: ManifestacaoResult = await manifestar_nfe(
+        chave=chave,
+        tipo_evento=tipo_evento,
+        caminho_certificado=caminho_certificado,
+        senha=senha,
+        cnpj_cpf=cnpj_cpf,
+        uf=uf,
+        numero_sequencia=numero_sequencia,
+        justificativa=justificativa,
+        ambiente=ambiente,  # type: ignore[arg-type]
+        timeout=timeout,
+    )
+    return {
+        "sucesso": resultado.sucesso,
+        "chave": resultado.chave,
+        "tipo_evento": resultado.tipo_evento,
+        "numero_protocolo": resultado.numero_protocolo,
+        "codigo_retorno": resultado.codigo_retorno,
+        "motivo": resultado.motivo,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nfe_assinatura.py
+++ b/tests/test_nfe_assinatura.py
@@ -1,0 +1,415 @@
+"""Testes para validacao de assinatura digital XMLDSig em NF-e."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from lxml import etree
+from signxml import XMLSigner
+
+from mcp_fiscal_brasil.nfe.assinatura import AssinaturaResult, validar_assinatura_nfe
+
+_NS_NFE = "http://www.portalfiscal.inf.br/nfe"
+
+# ID de referencia usado nos XMLs de teste
+_NFE_ID = "NFe35230112345678000195550010000000011000000014"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures de chave/cert
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def chave_ca() -> rsa.RSAPrivateKey:
+    """Chave RSA da CA raiz para testes."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def cert_ca(chave_ca: rsa.RSAPrivateKey) -> x509.Certificate:
+    """Certificado da CA raiz autoassinado com extensoes exigidas pelo signxml 4.x."""
+    ca_name = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "BR"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "AC TESTE RAIZ"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "AC TESTE RAIZ"),
+        ]
+    )
+    pub_key = chave_ca.public_key()
+    return (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(pub_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(pub_key), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(pub_key),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("ac-teste-raiz")]),
+            critical=False,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                key_cert_sign=True,
+                crl_sign=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(chave_ca, hashes.SHA256())
+    )
+
+
+@pytest.fixture(scope="module")
+def chave_privada(chave_ca: rsa.RSAPrivateKey) -> rsa.RSAPrivateKey:
+    """Chave RSA do end-entity (assinante de XML) para testes."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def certificado_autoassinado(
+    chave_privada: rsa.RSAPrivateKey,
+    chave_ca: rsa.RSAPrivateKey,
+    cert_ca: x509.Certificate,
+) -> x509.Certificate:
+    """Certificado end-entity assinado pela CA de teste.
+
+    signxml 4.x exige: BasicConstraints CA=False, SKI, AKI, SAN e KeyUsage.
+    """
+    ee_name = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "BR"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "EMPRESA TESTE LTDA"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "EMPRESA TESTE LTDA:12345678000195"),
+        ]
+    )
+    pub_key = chave_privada.public_key()
+    return (
+        x509.CertificateBuilder()
+        .subject_name(ee_name)
+        .issuer_name(cert_ca.subject)
+        .public_key(pub_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(pub_key), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(chave_ca.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("empresa-teste")]),
+            critical=False,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=True,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(chave_ca, hashes.SHA256())
+    )
+
+
+@pytest.fixture(scope="module")
+def ca_pem_file(cert_ca: x509.Certificate, tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Salva o PEM da CA raiz em arquivo temporario para uso como ca_bundle."""
+    tmp_dir = tmp_path_factory.mktemp("ca")
+    path = str(tmp_dir / "ca.pem")
+    with open(path, "wb") as f:
+        f.write(cert_ca.public_bytes(serialization.Encoding.PEM))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _xml_nfe_minimo() -> str:
+    """Retorna um XML de NF-e minimo (sem assinatura)."""
+    return (
+        f'<NFe xmlns="{_NS_NFE}">'
+        f'<infNFe versao="4.00" Id="{_NFE_ID}">'
+        f"<ide><cUF>35</cUF><nNF>1</nNF></ide>"
+        f"</infNFe>"
+        f"</NFe>"
+    )
+
+
+def _assinar_xml(
+    xml_str: str,
+    key: rsa.RSAPrivateKey,
+    cert: x509.Certificate,
+    reference_uri: str = f"#{_NFE_ID}",
+) -> bytes:
+    """Assina o XML com XMLSigner e retorna os bytes assinados."""
+    root = etree.fromstring(xml_str.encode())
+    signer = XMLSigner()
+    # Inclui somente o EE cert no XML (sem a CA) para respeitar semantica ICP-Brasil
+    signed = signer.sign(root, key=key, cert=[cert], reference_uri=reference_uri)
+    return etree.tostring(signed, encoding="unicode").encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Testes
+# ---------------------------------------------------------------------------
+
+
+class TestValidarAssinaturaNfe:
+    """Testes para a funcao validar_assinatura_nfe."""
+
+    def test_assinatura_valida_retorna_true(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """XML com assinatura correta deve retornar assinatura_valida=True.
+
+        Valida via x509_cert (cert extraido do XML) sem exigir CA bundle.
+        """
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        resultado = validar_assinatura_nfe(xml_assinado)
+
+        assert isinstance(resultado, AssinaturaResult)
+        assert resultado.assinatura_valida is True
+        assert resultado.motivo is None
+
+    def test_assinatura_valida_com_ca_bundle(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+        ca_pem_file: str,
+    ) -> None:
+        """XML valido com ca_bundle correto deve retornar assinatura_valida=True."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        resultado = validar_assinatura_nfe(xml_assinado, ca_bundle=ca_pem_file)
+
+        assert resultado.assinatura_valida is True
+
+    def test_assinatura_valida_extrai_cn_do_certificado(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """Validacao bem-sucedida deve extrair o CN do certificado."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        resultado = validar_assinatura_nfe(xml_assinado)
+
+        assert resultado.titular is not None
+        assert "EMPRESA TESTE" in resultado.titular
+
+    def test_assinatura_valida_extrai_cnpj(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """Deve extrair o CNPJ de 14 digitos do CN do certificado."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        resultado = validar_assinatura_nfe(xml_assinado)
+
+        # CN contem ":12345678000195" -> CNPJ extraido
+        assert resultado.cnpj_cpf == "12345678000195"
+
+    def test_assinatura_valida_retorna_validade_certificado(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """Deve retornar as datas de validade do certificado."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        resultado = validar_assinatura_nfe(xml_assinado)
+
+        assert resultado.validade_inicio is not None
+        assert resultado.validade_fim is not None
+        assert isinstance(resultado.validade_inicio, datetime)
+        assert isinstance(resultado.validade_fim, datetime)
+
+    def test_xml_adulterado_retorna_invalido(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """XML com conteudo alterado apos assinatura deve ser rejeitado."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        # Adultera o XML trocando o numero da NF
+        xml_adulterado = xml_assinado.replace(b"<nNF>1</nNF>", b"<nNF>9999</nNF>")
+
+        resultado = validar_assinatura_nfe(xml_adulterado)
+
+        assert resultado.assinatura_valida is False
+        assert resultado.motivo is not None
+        assert len(resultado.motivo) > 0
+
+    def test_xml_sem_signature_retorna_invalido(self) -> None:
+        """XML sem elemento Signature deve retornar assinatura_valida=False."""
+        xml_sem_assinatura = (
+            f'<NFe xmlns="{_NS_NFE}">'
+            f'<infNFe versao="4.00" Id="{_NFE_ID}">'
+            f"<ide><cUF>35</cUF><nNF>1</nNF></ide>"
+            f"</infNFe>"
+            f"</NFe>"
+        )
+        resultado = validar_assinatura_nfe(xml_sem_assinatura.encode())
+
+        assert resultado.assinatura_valida is False
+        assert resultado.motivo is not None
+        assert "Signature" in resultado.motivo
+
+    def test_xml_invalido_levanta_xml_parse_error(self) -> None:
+        """XML malformado deve levantar XMLParseError (propagado de parse_xml)."""
+        from mcp_fiscal_brasil.shared.exceptions import XMLParseError
+
+        with pytest.raises(XMLParseError):
+            validar_assinatura_nfe(b"<xml_invalido>")
+
+    def test_aceita_str_e_bytes(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """Deve aceitar xml_content como str ou bytes."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+
+        resultado_bytes = validar_assinatura_nfe(xml_assinado)
+        resultado_str = validar_assinatura_nfe(xml_assinado.decode("utf-8"))
+
+        assert resultado_bytes.assinatura_valida == resultado_str.assinatura_valida
+
+    def test_ca_bundle_errado_retorna_invalido(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """Ca_bundle com CA diferente do emissor deve retornar invalido."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        # Gera uma CA diferente (nao assinou o cert EE)
+        outra_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        outra_ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "OUTRA CA")])
+        outra_ca_pub = outra_ca_key.public_key()
+        outra_ca_cert = (
+            x509.CertificateBuilder()
+            .subject_name(outra_ca_name)
+            .issuer_name(outra_ca_name)
+            .public_key(outra_ca_pub)
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .add_extension(x509.SubjectKeyIdentifier.from_public_key(outra_ca_pub), critical=False)
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(outra_ca_pub), critical=False
+            )
+            .add_extension(x509.SubjectAlternativeName([x509.DNSName("outra-ca")]), critical=False)
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .sign(outra_ca_key, hashes.SHA256())
+        )
+        # Salva em arquivo temp
+
+        with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as f:
+            f.write(outra_ca_cert.public_bytes(serialization.Encoding.PEM))
+            ca_errado_path = f.name
+        try:
+            resultado = validar_assinatura_nfe(xml_assinado, ca_bundle=ca_errado_path)
+        finally:
+            os.unlink(ca_errado_path)
+
+        assert resultado.assinatura_valida is False
+        assert resultado.motivo is not None
+
+    def test_sem_ca_bundle_valida_integridade(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """Sem ca_bundle, deve validar integridade via cert embutido no XML."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        # Sem ca_bundle: cert autoassinado (EE) deve passar verificacao criptografica
+        resultado = validar_assinatura_nfe(xml_assinado, ca_bundle=None)
+
+        assert resultado.assinatura_valida is True
+
+    def test_retorna_ac_emissora(
+        self,
+        chave_privada: rsa.RSAPrivateKey,
+        certificado_autoassinado: x509.Certificate,
+    ) -> None:
+        """Deve retornar informacoes da AC emissora do certificado."""
+        xml_assinado = _assinar_xml(_xml_nfe_minimo(), chave_privada, certificado_autoassinado)
+        resultado = validar_assinatura_nfe(xml_assinado)
+
+        # Retorna o DN do issuer do EE cert (que eh a CA de teste)
+        assert resultado.ac_emissora is not None
+        assert "AC TESTE RAIZ" in resultado.ac_emissora
+
+    def test_xml_sem_cert_embutido_e_sem_ca_bundle_retorna_invalido(self) -> None:
+        """XML assinado sem X509Certificate embutido e sem ca_bundle deve retornar
+        assinatura_valida=False com motivo explicativo, nunca confiar na CA store do sistema."""
+        # Monta XML com Signature mas sem o elemento X509Certificate
+        xml_sem_cert = (
+            f'<NFe xmlns="{_NS_NFE}">'
+            f'<infNFe versao="4.00" Id="{_NFE_ID}">'
+            f"<ide><cUF>35</cUF><nNF>1</nNF></ide>"
+            f"</infNFe>"
+            f'<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">'
+            f"<SignedInfo/>"
+            f"<SignatureValue>AAAA</SignatureValue>"
+            f"</Signature>"
+            f"</NFe>"
+        )
+        resultado = validar_assinatura_nfe(xml_sem_cert.encode())
+
+        assert resultado.assinatura_valida is False
+        assert resultado.motivo is not None
+        assert "certificado" in resultado.motivo.lower() or "ca_bundle" in resultado.motivo.lower()
+
+    def test_ca_bundle_maior_que_1mb_levanta_erro(self) -> None:
+        """ca_bundle com mais de 1 MB deve levantar FiscalValidationError antes de processar."""
+        from mcp_fiscal_brasil._core.errors import FiscalValidationError
+
+        ca_bundle_gigante = b"A" * (1024 * 1024 + 1)
+        with pytest.raises(FiscalValidationError, match="1 MB"):
+            validar_assinatura_nfe(b"<NFe/>", ca_bundle=ca_bundle_gigante)

--- a/tests/test_nfe_danfe.py
+++ b/tests/test_nfe_danfe.py
@@ -1,0 +1,438 @@
+"""Testes para geracao de DANFE em PDF (nfe/danfe.py)."""
+
+import base64
+
+import pytest
+
+from mcp_fiscal_brasil._core.errors import FiscalValidationError
+from mcp_fiscal_brasil.nfe.danfe import DanfeGenerationError, DanfeResult, gerar_danfe
+
+# XML completo de NF-e modelo 55 com namespace portalfiscal e protocolo.
+# Necessario namespace pois a lib brazilfiscalreport usa ET.fromstring com URL namespaced.
+XML_NFE_55_COMPLETO = """<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc xmlns="http://www.portalfiscal.inf.br/nfe">
+  <NFe>
+    <infNFe Id="NFe35240112345678000195550010000001231000000012" versao="4.00">
+      <ide>
+        <cUF>35</cUF>
+        <cNF>10000001</cNF>
+        <natOp>Venda de mercadoria</natOp>
+        <mod>55</mod>
+        <serie>1</serie>
+        <nNF>123</nNF>
+        <dhEmi>2024-01-31T10:30:00-03:00</dhEmi>
+        <tpNF>1</tpNF>
+        <idDest>1</idDest>
+        <cMunFG>3550308</cMunFG>
+        <tpImp>1</tpImp>
+        <tpEmis>1</tpEmis>
+        <cDV>2</cDV>
+        <tpAmb>2</tpAmb>
+        <finNFe>1</finNFe>
+        <indFinal>0</indFinal>
+        <indPres>0</indPres>
+        <procEmi>0</procEmi>
+        <verProc>1.0</verProc>
+      </ide>
+      <emit>
+        <CNPJ>12345678000195</CNPJ>
+        <xNome>EMPRESA TESTE LTDA</xNome>
+        <xFant>TESTE</xFant>
+        <enderEmit>
+          <xLgr>Rua Fiscal</xLgr>
+          <nro>100</nro>
+          <xBairro>Centro</xBairro>
+          <cMun>3550308</cMun>
+          <xMun>Sao Paulo</xMun>
+          <UF>SP</UF>
+          <CEP>01001000</CEP>
+          <cPais>1058</cPais>
+          <xPais>Brasil</xPais>
+        </enderEmit>
+        <IE>111111111111</IE>
+        <CRT>3</CRT>
+      </emit>
+      <det nItem="1">
+        <prod>
+          <cProd>SKU-1</cProd>
+          <cEAN>SEM GTIN</cEAN>
+          <xProd>Produto fiscal de teste</xProd>
+          <NCM>01012100</NCM>
+          <CFOP>5102</CFOP>
+          <uCom>UN</uCom>
+          <qCom>2.0000</qCom>
+          <vUnCom>50.00</vUnCom>
+          <vProd>100.00</vProd>
+          <cEANTrib>SEM GTIN</cEANTrib>
+          <uTrib>UN</uTrib>
+          <qTrib>2.0000</qTrib>
+          <vUnTrib>50.00</vUnTrib>
+          <indTot>1</indTot>
+        </prod>
+        <imposto>
+          <ICMS>
+            <ICMS00>
+              <orig>0</orig>
+              <CST>00</CST>
+              <modBC>3</modBC>
+              <vBC>100.00</vBC>
+              <pICMS>18.00</pICMS>
+              <vICMS>18.00</vICMS>
+            </ICMS00>
+          </ICMS>
+          <PIS>
+            <PISAliq>
+              <CST>01</CST>
+              <vBC>100.00</vBC>
+              <pPIS>0.65</pPIS>
+              <vPIS>0.65</vPIS>
+            </PISAliq>
+          </PIS>
+          <COFINS>
+            <COFINSAliq>
+              <CST>01</CST>
+              <vBC>100.00</vBC>
+              <pCOFINS>3.00</pCOFINS>
+              <vCOFINS>3.00</vCOFINS>
+            </COFINSAliq>
+          </COFINS>
+        </imposto>
+      </det>
+      <total>
+        <ICMSTot>
+          <vBC>100.00</vBC>
+          <vICMS>18.00</vICMS>
+          <vICMSDeson>0.00</vICMSDeson>
+          <vFCP>0.00</vFCP>
+          <vBCST>0.00</vBCST>
+          <vST>0.00</vST>
+          <vFCPST>0.00</vFCPST>
+          <vFCPSTRet>0.00</vFCPSTRet>
+          <vProd>100.00</vProd>
+          <vFrete>0.00</vFrete>
+          <vSeg>0.00</vSeg>
+          <vDesc>0.00</vDesc>
+          <vII>0.00</vII>
+          <vIPI>0.00</vIPI>
+          <vIPIDevol>0.00</vIPIDevol>
+          <vPIS>0.65</vPIS>
+          <vCOFINS>3.00</vCOFINS>
+          <vOutro>0.00</vOutro>
+          <vNF>100.00</vNF>
+        </ICMSTot>
+      </total>
+      <transp>
+        <modFrete>9</modFrete>
+      </transp>
+    </infNFe>
+  </NFe>
+  <protNFe versao="4.00">
+    <infProt>
+      <tpAmb>2</tpAmb>
+      <verAplic>SP_NFE_PL_008i2</verAplic>
+      <chNFe>35240112345678000195550010000001231000000012</chNFe>
+      <dhRecbto>2024-01-31T10:31:00-03:00</dhRecbto>
+      <nProt>135240000000001</nProt>
+      <digVal>AAAAAAAAAAAAAAAAAAAAAAAAAAAA</digVal>
+      <cStat>100</cStat>
+      <xMotivo>Autorizado o uso da NF-e</xMotivo>
+    </infProt>
+  </protNFe>
+</nfeProc>
+"""
+
+# XML de NFC-e modelo 65 com namespace portalfiscal (sem involucro protNFe,
+# pois NFC-e pode ser emitida offline)
+XML_NFCE_65_COMPLETO = """<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc xmlns="http://www.portalfiscal.inf.br/nfe">
+  <NFe>
+    <infNFe Id="NFe35240112345678000195650010000004561000000048" versao="4.00">
+      <ide>
+        <cUF>35</cUF>
+        <cNF>10000045</cNF>
+        <natOp>Venda a consumidor</natOp>
+        <mod>65</mod>
+        <serie>1</serie>
+        <nNF>456</nNF>
+        <dhEmi>2024-06-15T14:20:00-03:00</dhEmi>
+        <tpNF>1</tpNF>
+        <idDest>1</idDest>
+        <cMunFG>3550308</cMunFG>
+        <tpImp>4</tpImp>
+        <tpEmis>1</tpEmis>
+        <cDV>8</cDV>
+        <tpAmb>2</tpAmb>
+        <finNFe>1</finNFe>
+        <indFinal>1</indFinal>
+        <indPres>1</indPres>
+        <procEmi>0</procEmi>
+        <verProc>1.0</verProc>
+      </ide>
+      <emit>
+        <CNPJ>12345678000195</CNPJ>
+        <xNome>LOJA TESTE LTDA</xNome>
+        <enderEmit>
+          <xLgr>Rua Comercio</xLgr>
+          <nro>200</nro>
+          <xBairro>Centro</xBairro>
+          <cMun>3550308</cMun>
+          <xMun>Sao Paulo</xMun>
+          <UF>SP</UF>
+          <CEP>01001000</CEP>
+          <cPais>1058</cPais>
+          <xPais>Brasil</xPais>
+        </enderEmit>
+        <IE>111111111111</IE>
+        <CRT>3</CRT>
+      </emit>
+      <det nItem="1">
+        <prod>
+          <cProd>ITEM-01</cProd>
+          <cEAN>SEM GTIN</cEAN>
+          <xProd>Item de consumo</xProd>
+          <NCM>22021000</NCM>
+          <CFOP>5102</CFOP>
+          <uCom>UN</uCom>
+          <qCom>1.0000</qCom>
+          <vUnCom>25.00</vUnCom>
+          <vProd>25.00</vProd>
+          <cEANTrib>SEM GTIN</cEANTrib>
+          <uTrib>UN</uTrib>
+          <qTrib>1.0000</qTrib>
+          <vUnTrib>25.00</vUnTrib>
+          <indTot>1</indTot>
+        </prod>
+        <imposto>
+          <ICMS>
+            <ICMS00>
+              <orig>0</orig>
+              <CST>00</CST>
+              <modBC>3</modBC>
+              <vBC>25.00</vBC>
+              <pICMS>12.00</pICMS>
+              <vICMS>3.00</vICMS>
+            </ICMS00>
+          </ICMS>
+          <PIS>
+            <PISAliq>
+              <CST>01</CST>
+              <vBC>25.00</vBC>
+              <pPIS>0.65</pPIS>
+              <vPIS>0.16</vPIS>
+            </PISAliq>
+          </PIS>
+          <COFINS>
+            <COFINSAliq>
+              <CST>01</CST>
+              <vBC>25.00</vBC>
+              <pCOFINS>3.00</pCOFINS>
+              <vCOFINS>0.75</vCOFINS>
+            </COFINSAliq>
+          </COFINS>
+        </imposto>
+      </det>
+      <total>
+        <ICMSTot>
+          <vBC>25.00</vBC>
+          <vICMS>3.00</vICMS>
+          <vICMSDeson>0.00</vICMSDeson>
+          <vFCP>0.00</vFCP>
+          <vBCST>0.00</vBCST>
+          <vST>0.00</vST>
+          <vFCPST>0.00</vFCPST>
+          <vFCPSTRet>0.00</vFCPSTRet>
+          <vProd>25.00</vProd>
+          <vFrete>0.00</vFrete>
+          <vSeg>0.00</vSeg>
+          <vDesc>0.00</vDesc>
+          <vII>0.00</vII>
+          <vIPI>0.00</vIPI>
+          <vIPIDevol>0.00</vIPIDevol>
+          <vPIS>0.16</vPIS>
+          <vCOFINS>0.75</vCOFINS>
+          <vOutro>0.00</vOutro>
+          <vNF>25.00</vNF>
+        </ICMSTot>
+      </total>
+      <transp>
+        <modFrete>9</modFrete>
+      </transp>
+    </infNFe>
+  </NFe>
+  <protNFe versao="4.00">
+    <infProt>
+      <tpAmb>2</tpAmb>
+      <verAplic>SP_NFE_PL_008i2</verAplic>
+      <chNFe>35240112345678000195650010000004561000000048</chNFe>
+      <dhRecbto>2024-06-15T14:21:00-03:00</dhRecbto>
+      <nProt>265240000000001</nProt>
+      <cStat>100</cStat>
+      <xMotivo>Autorizado o uso da NF-e</xMotivo>
+    </infProt>
+  </protNFe>
+</nfeProc>
+"""
+
+# XML invalido sem infNFe
+XML_SEM_INF_NFE = "<raiz><dados>invalido</dados></raiz>"
+
+
+class TestGerarDanfeNFe:
+    """Testes de geracao de DANFE para NF-e modelo 55."""
+
+    def test_gera_pdf_para_nfe_55(self) -> None:
+        """Deve gerar PDF valido (header %PDF) para NF-e modelo 55."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        pdf_bytes = base64.b64decode(resultado.pdf_base64)
+        assert pdf_bytes[:4] == b"%PDF", "PDF deve comecar com '%PDF'"
+
+    def test_resultado_e_danfe_result(self) -> None:
+        """O retorno deve ser instancia de DanfeResult."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        assert isinstance(resultado, DanfeResult)
+
+    def test_modelo_retornado_e_55(self) -> None:
+        """DanfeResult deve informar modelo 55 para NF-e."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        assert resultado.modelo == 55
+
+    def test_pdf_nao_e_vazio(self) -> None:
+        """PDF gerado nao deve ser vazio."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        pdf_bytes = base64.b64decode(resultado.pdf_base64)
+        assert len(pdf_bytes) > 100, "PDF deve ter conteudo substancial"
+
+    def test_nome_arquivo_contem_chave(self) -> None:
+        """nome_arquivo deve conter a chave de acesso."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        assert "35240112345678000195550010000001231000000012" in resultado.nome_arquivo
+
+    def test_nome_arquivo_tem_extensao_pdf(self) -> None:
+        """nome_arquivo deve terminar com .pdf."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        assert resultado.nome_arquivo.endswith(".pdf")
+
+    def test_chave_acesso_retornada(self) -> None:
+        """DanfeResult deve retornar a chave de acesso extraida do XML."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        assert resultado.chave_acesso == "35240112345678000195550010000001231000000012"
+
+    def test_numero_e_serie_retornados(self) -> None:
+        """DanfeResult deve retornar numero e serie da nota."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        assert resultado.numero == "123"
+        assert resultado.serie == "1"
+
+    def test_aceita_bytes(self) -> None:
+        """Deve aceitar XML como bytes alem de string."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO.encode("utf-8"))
+
+        pdf_bytes = base64.b64decode(resultado.pdf_base64)
+        assert pdf_bytes[:4] == b"%PDF"
+
+    def test_pdf_base64_e_decodificavel(self) -> None:
+        """pdf_base64 deve ser base64 valido decodificavel sem erro."""
+        resultado = gerar_danfe(XML_NFE_55_COMPLETO)
+
+        # Nao deve levantar excecao
+        decoded = base64.b64decode(resultado.pdf_base64)
+        assert isinstance(decoded, bytes)
+
+
+class TestGerarDanfeNFCe:
+    """Testes de comportamento para NFC-e modelo 65.
+
+    A brazilfiscalreport 1.0.0 nao possui classe dedicada a NFC-e.
+    A decisao de implementacao e levantar DanfeGenerationError com mensagem
+    clara ao inves de fallback silencioso, para evitar que o usuario
+    receba um DANFE A4 gerado incorretamente para um cupom fiscal.
+    """
+
+    def test_nfce_65_lanca_danfe_generation_error(self) -> None:
+        """NFC-e modelo 65 deve levantar DanfeGenerationError (nao suportado na v1.0.0)."""
+        with pytest.raises(DanfeGenerationError) as exc_info:
+            gerar_danfe(XML_NFCE_65_COMPLETO)
+
+        msg = str(exc_info.value).lower()
+        assert "65" in msg or "nfc" in msg or "suportado" in msg
+
+    def test_nfce_65_mensagem_orienta_usuario(self) -> None:
+        """Mensagem de erro para NFC-e deve orientar o usuario sobre a limitacao."""
+        with pytest.raises(DanfeGenerationError) as exc_info:
+            gerar_danfe(XML_NFCE_65_COMPLETO)
+
+        # Mensagem deve mencionar o modelo ou a limitacao da versao
+        assert "65" in str(exc_info.value) or "nao" in str(exc_info.value).lower()
+
+    def test_nfce_65_e_fiscal_validation_error(self) -> None:
+        """DanfeGenerationError para NFC-e deve herdar de FiscalValidationError."""
+        with pytest.raises(FiscalValidationError):
+            gerar_danfe(XML_NFCE_65_COMPLETO)
+
+
+class TestGerarDanfeErros:
+    """Testes de tratamento de erros na geracao de DANFE."""
+
+    def test_xml_invalido_lanca_danfe_generation_error(self) -> None:
+        """XML sem infNFe deve levantar DanfeGenerationError."""
+        with pytest.raises(DanfeGenerationError) as exc_info:
+            gerar_danfe(XML_SEM_INF_NFE)
+
+        assert "infNFe" in str(exc_info.value)
+
+    def test_danfe_generation_error_e_fiscal_validation_error(self) -> None:
+        """DanfeGenerationError deve herdar de FiscalValidationError."""
+        with pytest.raises(FiscalValidationError):
+            gerar_danfe(XML_SEM_INF_NFE)
+
+    def test_xml_malformado_lanca_excecao(self) -> None:
+        """XML malformado deve levantar excecao de parse XML."""
+        from mcp_fiscal_brasil.shared.exceptions import XMLParseError
+
+        with pytest.raises((XMLParseError, FiscalValidationError)):
+            gerar_danfe("<xml-nao-fechado>")
+
+    def test_modelo_invalido_lanca_danfe_generation_error(self) -> None:
+        """Modelo desconhecido (nao 55) deve levantar DanfeGenerationError."""
+        # Nota: chave com modelo 99 no campo 21-22 da chave (posicao 20-21, base 0)
+        # Para o teste, o importante e que o campo ide/mod=99 seja lido e rejeitado
+        xml_modelo_invalido = """
+        <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+          <infNFe Id="NFe35240112345678000195990010000001231000000012">
+            <ide><mod>99</mod><serie>1</serie><nNF>1</nNF></ide>
+            <emit><CNPJ>12345678000195</CNPJ><xNome>X</xNome></emit>
+            <total><ICMSTot><vNF>0.00</vNF></ICMSTot></total>
+            <transp><modFrete>9</modFrete></transp>
+          </infNFe>
+        </NFe>
+        """
+        with pytest.raises(DanfeGenerationError) as exc_info:
+            gerar_danfe(xml_modelo_invalido)
+
+        assert "99" in str(exc_info.value) or "suportado" in str(exc_info.value).lower()
+
+    def test_xml_sem_namespace_lanca_danfe_generation_error(self) -> None:
+        """XML de NF-e modelo 55 sem namespace portalfiscal deve levantar DanfeGenerationError."""
+        xml_sem_namespace = """
+        <NFe>
+          <infNFe Id="NFe35240112345678000195550010000001231000000012">
+            <ide><mod>55</mod><serie>1</serie><nNF>123</nNF></ide>
+            <emit><CNPJ>12345678000195</CNPJ><xNome>EMPRESA</xNome></emit>
+            <total><ICMSTot><vNF>100.00</vNF></ICMSTot></total>
+            <transp><modFrete>9</modFrete></transp>
+          </infNFe>
+        </NFe>
+        """
+        with pytest.raises(DanfeGenerationError) as exc_info:
+            gerar_danfe(xml_sem_namespace)
+
+        msg = str(exc_info.value)
+        assert "namespace" in msg.lower() or "portalfiscal" in msg.lower()

--- a/tests/test_nfe_distribuicao.py
+++ b/tests/test_nfe_distribuicao.py
@@ -1,0 +1,581 @@
+"""Testes para baixar_nfe_distribuicao e manifestar_nfe (mocks - sem SEFAZ real)."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import NameOID
+from lxml import etree
+
+from mcp_fiscal_brasil._core.errors import FiscalValidationError
+from mcp_fiscal_brasil.nfe.distribuicao import (
+    EVENTO_CIENCIA,
+    EVENTO_CONFIRMACAO,
+    EVENTO_OPERACAO_NAO_REALIZADA,
+    DistribuicaoResult,
+    DocumentoDistribuicao,
+    ManifestacaoResult,
+    baixar_nfe_distribuicao,
+    manifestar_nfe,
+)
+
+_NS_NFE = "http://www.portalfiscal.inf.br/nfe"
+
+# CNPJ valido para testes (Petrobras, conforme conftest)
+_CNPJ_TESTE = "33000167000101"
+# Chave valida calculada: cUF=35 AAMM=2301 CNPJ=12345678901234 mod=55 serie=001 nNF=1 tpEmis=1 cNF=1
+_BASE_CHAVE = "3523011234567890123455001000000001100000001"
+# DV calculado via modulo 11 (pesos 2-9)
+_pesos = list(range(2, 10))
+_soma = sum(int(d) * _pesos[i % 8] for i, d in enumerate(reversed(_BASE_CHAVE)))
+_resto = _soma % 11
+_dv = 0 if _resto in (0, 1) else 11 - _resto
+_CHAVE_VALIDA = _BASE_CHAVE + str(_dv)
+
+assert len(_CHAVE_VALIDA) == 44
+
+
+# ---------------------------------------------------------------------------
+# Fixtures de certificado
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def chave_privada_a1() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def certificado_a1(chave_privada_a1: rsa.RSAPrivateKey) -> x509.Certificate:
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "BR"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "EMPRESA TESTE:12345678000195"),
+        ]
+    )
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(chave_privada_a1.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(chave_privada_a1, hashes.SHA256())
+    )
+
+
+@pytest.fixture(scope="module")
+def arquivo_pfx(
+    chave_privada_a1: rsa.RSAPrivateKey,
+    certificado_a1: x509.Certificate,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> str:
+    """Cria um arquivo .pfx temporario com o certificado de teste."""
+    pfx_bytes = pkcs12.serialize_key_and_certificates(
+        b"cert_teste",
+        chave_privada_a1,
+        certificado_a1,
+        None,
+        serialization.BestAvailableEncryption(b"senha_teste"),
+    )
+    tmp_dir = tmp_path_factory.mktemp("certs")
+    pfx_path = str(tmp_dir / "cert_teste.pfx")
+    with open(pfx_path, "wb") as f:
+        f.write(pfx_bytes)
+    return pfx_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers para gerar XML de teste
+# ---------------------------------------------------------------------------
+
+
+def _gerar_doc_zip_resnfe(chave: str, c_sit_nfe: str = "100") -> str:
+    """Gera um docZip base64+gzip de um resNFe minimo para testes.
+
+    Args:
+        chave: Chave de acesso de 44 digitos da NF-e.
+        c_sit_nfe: Codigo de situacao da NF-e (cSitNFe). Padrao "100" = Autorizada.
+    """
+    xml = (
+        f'<resNFe versao="1.01" xmlns="{_NS_NFE}">'
+        f"<chNFe>{chave}</chNFe>"
+        f"<CNPJ>12345678000195</CNPJ>"
+        f"<xNome>EMPRESA TESTE LTDA</xNome>"
+        f"<vNF>1000.00</vNF>"
+        f"<tpNF>1</tpNF>"
+        f"<cSitNFe>{c_sit_nfe}</cSitNFe>"
+        f"<dhRecbto>2023-01-15T10:00:00-03:00</dhRecbto>"
+        f"</resNFe>"
+    )
+    compressed = gzip.compress(xml.encode("utf-8"))
+    return base64.b64encode(compressed).decode("ascii")
+
+
+def _montar_retorno_dist_soap(
+    ultimo_nsu: str = "000000000000001",
+    max_nsu: str = "000000000000001",
+    docs: list[tuple[str, str, str]] | None = None,
+    c_stat: str = "138",
+    x_motivo: str = "Documento localizado",
+) -> etree._Element:
+    """Monta um elemento XML simulando o Body SOAP de retDistDFeInt."""
+    docs_xml = ""
+    if docs:
+        for nsu, schema, doc_zip in docs:
+            docs_xml += f'<docZip NSU="{nsu}" schema="{schema}">{doc_zip}</docZip>'
+
+    lote = f"<loteDistDFeInt>{docs_xml}</loteDistDFeInt>" if docs_xml else ""
+
+    body_str = (
+        f'<retDistDFeInt versao="1.01" xmlns="{_NS_NFE}">'
+        f"<tpAmb>1</tpAmb>"
+        f"<verAplic>1.3.0</verAplic>"
+        f"<cStat>{c_stat}</cStat>"
+        f"<xMotivo>{x_motivo}</xMotivo>"
+        f"<dhResp>2023-01-15T10:00:00-03:00</dhResp>"
+        f"<ultNSU>{ultimo_nsu}</ultNSU>"
+        f"<maxNSU>{max_nsu}</maxNSU>"
+        f"{lote}"
+        f"</retDistDFeInt>"
+    )
+    return etree.fromstring(body_str.encode())
+
+
+def _montar_retorno_evento_soap(
+    c_stat: str = "135",
+    x_motivo: str = "Evento registrado e vinculado a NF-e",
+    n_prot: str = "999000000000001",
+) -> etree._Element:
+    """Monta um elemento XML simulando o Body SOAP de retEnvEvento."""
+    body_str = (
+        f'<retEnvEvento versao="1.00" xmlns="{_NS_NFE}">'
+        f"<idLote>1</idLote>"
+        f"<tpAmb>1</tpAmb>"
+        f"<verAplic>1.0</verAplic>"
+        f"<cOrgao>91</cOrgao>"
+        f"<cStat>{c_stat}</cStat>"
+        f"<xMotivo>{x_motivo}</xMotivo>"
+        f'<retEvento versao="1.00">'
+        f"<infEvento>"
+        f"<cOrgao>91</cOrgao>"
+        f"<cStat>{c_stat}</cStat>"
+        f"<xMotivo>{x_motivo}</xMotivo>"
+        f"<nProt>{n_prot}</nProt>"
+        f"</infEvento>"
+        f"</retEvento>"
+        f"</retEnvEvento>"
+    )
+    return etree.fromstring(body_str.encode())
+
+
+# ---------------------------------------------------------------------------
+# Testes de baixar_nfe_distribuicao
+# ---------------------------------------------------------------------------
+
+
+class TestBaixarNfeDistribuicao:
+    """Testes para baixar_nfe_distribuicao com mocks de HTTP."""
+
+    async def test_modo_dist_nsu_retorna_documentos(self, arquivo_pfx: str) -> None:
+        """Modo distNSU deve retornar DistribuicaoResult com documentos."""
+        doc_zip = _gerar_doc_zip_resnfe(_CHAVE_VALIDA)
+        body_mock = _montar_retorno_dist_soap(
+            docs=[("000000000000001", "resNFe_v1.01.xsd", doc_zip)],
+        )
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+                modo="distNSU",
+                ultimo_nsu="0",
+            )
+
+        assert isinstance(resultado, DistribuicaoResult)
+        assert resultado.ultimo_nsu == "000000000000001"
+        assert len(resultado.documentos) == 1
+
+    async def test_modo_dist_nsu_documento_resnfe(self, arquivo_pfx: str) -> None:
+        """O documento retornado no modo distNSU deve ter tipo resNFe."""
+        doc_zip = _gerar_doc_zip_resnfe(_CHAVE_VALIDA)
+        body_mock = _montar_retorno_dist_soap(
+            docs=[("000000000000001", "resNFe_v1.01.xsd", doc_zip)],
+        )
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="35",
+                modo="distNSU",
+            )
+
+        doc = resultado.documentos[0]
+        assert isinstance(doc, DocumentoDistribuicao)
+        assert doc.tipo == "resNFe"
+        assert doc.resumo is not None
+
+    async def test_modo_cons_nsu(self, arquivo_pfx: str) -> None:
+        """Modo consNSU deve passar NSU especifico na requisicao."""
+        body_mock = _montar_retorno_dist_soap(
+            docs=[],
+            c_stat="137",
+            x_motivo="Nenhum documento localizado",
+        )
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ) as mock_soap:
+            resultado = await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+                modo="consNSU",
+                nsu="42",
+            )
+
+        mock_soap.assert_called_once()
+        # Verifica que o body contem consNSU
+        call_args = mock_soap.call_args
+        body_content = call_args[0][1]  # segundo argumento posicional
+        assert "consNSU" in body_content
+        assert len(resultado.documentos) == 0
+
+    async def test_modo_cons_ch_nfe(self, arquivo_pfx: str) -> None:
+        """Modo consChNFe deve passar a chave de acesso na requisicao."""
+        doc_zip = _gerar_doc_zip_resnfe(_CHAVE_VALIDA)
+        body_mock = _montar_retorno_dist_soap(
+            docs=[("000000000000042", "resNFe_v1.01.xsd", doc_zip)],
+        )
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ) as mock_soap:
+            resultado = await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+                modo="consChNFe",
+                chave=_CHAVE_VALIDA,
+            )
+
+        call_args = mock_soap.call_args
+        body_content = call_args[0][1]
+        assert "consChNFe" in body_content
+        assert _CHAVE_VALIDA in body_content
+        assert len(resultado.documentos) == 1
+
+    async def test_erro_sem_certificado(self) -> None:
+        """Caminho de certificado inexistente deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await baixar_nfe_distribuicao(
+                caminho_certificado="/caminho/inexistente.pfx",
+                senha="qualquer",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+            )
+        assert "certificado" in exc_info.value.message.lower()
+
+    async def test_erro_senha_incorreta(self, arquivo_pfx: str) -> None:
+        """Senha errada deve levancar FiscalValidationError sem vazar a senha."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_errada",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+            )
+        # A senha NAO deve aparecer na mensagem de erro
+        assert "senha_errada" not in exc_info.value.message
+
+    async def test_erro_cnpj_invalido(self, arquivo_pfx: str) -> None:
+        """CNPJ com formato invalido deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf="123",
+                uf="SP",
+            )
+        assert exc_info.value.field == "cnpj_cpf"
+
+    async def test_erro_chave_invalida_modo_cons_ch(self, arquivo_pfx: str) -> None:
+        """Chave de acesso invalida no modo consChNFe deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+                modo="consChNFe",
+                chave="1234567890",
+            )
+        assert exc_info.value.field == "chave"
+
+    async def test_erro_modo_cons_nsu_sem_nsu(self, arquivo_pfx: str) -> None:
+        """Modo consNSU sem o parametro nsu deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+                modo="consNSU",
+                nsu=None,
+            )
+        assert exc_info.value.field == "nsu"
+
+    async def test_parsing_chave_no_resnfe(self, arquivo_pfx: str) -> None:
+        """O campo chave do documento resNFe deve ser extraido corretamente."""
+        doc_zip = _gerar_doc_zip_resnfe(_CHAVE_VALIDA)
+        body_mock = _montar_retorno_dist_soap(
+            docs=[("000000000000001", "resNFe_v1.01.xsd", doc_zip)],
+        )
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await baixar_nfe_distribuicao(
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                uf="SP",
+            )
+
+        doc = resultado.documentos[0]
+        # Chave do resNFe eh os 44 digitos numericos
+        assert doc.chave is not None
+        assert len(doc.chave) == 44
+
+
+# ---------------------------------------------------------------------------
+# Testes de _extrair_resumo_resnfe (campo situacao)
+# ---------------------------------------------------------------------------
+
+
+def test_extrair_resumo_resnfe_usa_csitnfe() -> None:
+    """situacao deve vir de cSitNFe, nao de digVal."""
+    from lxml import etree as _etree
+
+    from mcp_fiscal_brasil.nfe.distribuicao import _extrair_resumo_resnfe
+
+    xml_com_csitnfe = (
+        f'<resNFe versao="1.01" xmlns="{_NS_NFE}">'
+        f"<chNFe>{'0' * 44}</chNFe>"
+        f"<cSitNFe>100</cSitNFe>"
+        f"<digVal>abc123</digVal>"
+        f"</resNFe>"
+    )
+    root = _etree.fromstring(xml_com_csitnfe.encode())
+    resumo = _extrair_resumo_resnfe(root)
+    assert resumo["situacao"] == "100", "situacao deve ser o valor de cSitNFe"
+
+
+def test_extrair_resumo_resnfe_sem_csitnfe_retorna_none() -> None:
+    """Quando cSitNFe ausente, situacao deve ser None (nao digVal)."""
+    from lxml import etree as _etree
+
+    from mcp_fiscal_brasil.nfe.distribuicao import _extrair_resumo_resnfe
+
+    xml_sem_csitnfe = (
+        f'<resNFe versao="1.01" xmlns="{_NS_NFE}">'
+        f"<chNFe>{'0' * 44}</chNFe>"
+        f"<digVal>hash_do_documento</digVal>"
+        f"</resNFe>"
+    )
+    root = _etree.fromstring(xml_sem_csitnfe.encode())
+    resumo = _extrair_resumo_resnfe(root)
+    assert resumo["situacao"] is None, "situacao deve ser None quando cSitNFe ausente"
+
+
+# ---------------------------------------------------------------------------
+# Testes de manifestar_nfe
+# ---------------------------------------------------------------------------
+
+
+class TestManifestarNfe:
+    """Testes para manifestar_nfe com mocks de HTTP."""
+
+    async def test_ciencia_sucesso(self, arquivo_pfx: str) -> None:
+        """Evento 210200 (Ciencia) deve retornar ManifestacaoResult com sucesso."""
+        body_mock = _montar_retorno_evento_soap()
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_CIENCIA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+
+        assert isinstance(resultado, ManifestacaoResult)
+        assert resultado.sucesso is True
+        assert resultado.codigo_retorno == "135"
+        assert resultado.numero_protocolo == "999000000000001"
+
+    async def test_confirmacao_sucesso(self, arquivo_pfx: str) -> None:
+        """Evento 210210 (Confirmacao) deve retornar sucesso."""
+        body_mock = _montar_retorno_evento_soap()
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_CONFIRMACAO,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+
+        assert resultado.sucesso is True
+
+    async def test_operacao_nao_realizada_requer_justificativa(self, arquivo_pfx: str) -> None:
+        """Evento 210240 sem justificativa deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_OPERACAO_NAO_REALIZADA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+        assert exc_info.value.field == "justificativa"
+
+    async def test_operacao_nao_realizada_justificativa_curta(self, arquivo_pfx: str) -> None:
+        """Justificativa com menos de 15 chars deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_OPERACAO_NAO_REALIZADA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                justificativa="curto",
+            )
+        assert "15" in exc_info.value.message
+
+    async def test_operacao_nao_realizada_com_justificativa_valida(self, arquivo_pfx: str) -> None:
+        """Evento 210240 com justificativa valida deve montar o XML e chamar SOAP."""
+        body_mock = _montar_retorno_evento_soap()
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ) as mock_soap:
+            resultado = await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_OPERACAO_NAO_REALIZADA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+                justificativa="Produto nao foi recebido pelo destinatario",
+            )
+
+        mock_soap.assert_called_once()
+        assert resultado.sucesso is True
+
+    async def test_tipo_evento_invalido(self, arquivo_pfx: str) -> None:
+        """Tipo de evento desconhecido deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento="999999",
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+        assert exc_info.value.field == "tipo_evento"
+
+    async def test_chave_invalida_levanta_validation_error(self, arquivo_pfx: str) -> None:
+        """Chave de acesso invalida deve levancar FiscalValidationError."""
+        with pytest.raises(FiscalValidationError) as exc_info:
+            await manifestar_nfe(
+                chave="0000",
+                tipo_evento=EVENTO_CIENCIA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+        assert exc_info.value.field == "chave"
+
+    async def test_evento_contem_chave_e_tipo(self, arquivo_pfx: str) -> None:
+        """O body enviado a SEFAZ deve conter a chave e o tipo do evento."""
+        body_mock = _montar_retorno_evento_soap()
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ) as mock_soap:
+            await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_CIENCIA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+
+        call_args = mock_soap.call_args
+        body_content = call_args[0][1]
+        assert _CHAVE_VALIDA in body_content
+        assert EVENTO_CIENCIA in body_content
+
+    async def test_montagem_evento_assina_xml(self, arquivo_pfx: str) -> None:
+        """O body deve conter um elemento Signature (evento assinado)."""
+        body_mock = _montar_retorno_evento_soap()
+
+        with patch(
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            new=AsyncMock(return_value=body_mock),
+        ) as mock_soap:
+            await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_CIENCIA,
+                caminho_certificado=arquivo_pfx,
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )
+
+        call_args = mock_soap.call_args
+        body_content = call_args[0][1]
+        assert "Signature" in body_content
+
+    async def test_sem_certificado_levanta_validation_error(self) -> None:
+        """Certificado inexistente deve levancar FiscalValidationError antes de HTTP."""
+        with pytest.raises(FiscalValidationError):
+            await manifestar_nfe(
+                chave=_CHAVE_VALIDA,
+                tipo_evento=EVENTO_CIENCIA,
+                caminho_certificado="/nao_existe.pfx",
+                senha="senha_teste",
+                cnpj_cpf=_CNPJ_TESTE,
+            )

--- a/tests/test_nfe_documento.py
+++ b/tests/test_nfe_documento.py
@@ -1,0 +1,268 @@
+"""Testes para parse_nfe_documento (nfe/documento.py)."""
+
+import pytest
+
+from mcp_fiscal_brasil._core.errors import FiscalValidationError
+from mcp_fiscal_brasil.nfe.documento import DocumentoParseError, parse_nfe_documento
+
+# XML minimo de NF-e modelo 55 sem namespace, sem protocolo
+XML_NFE_55_SIMPLES = """
+<NFe>
+  <infNFe Id="NFe35240112345678000195550010000001231000000012">
+    <ide>
+      <mod>55</mod>
+      <serie>1</serie>
+      <nNF>123</nNF>
+      <dhEmi>2024-01-31T10:30:00-03:00</dhEmi>
+      <natOp>Venda de mercadoria</natOp>
+      <tpNF>1</tpNF>
+    </ide>
+    <emit>
+      <CNPJ>12345678000195</CNPJ>
+      <xNome>EMPRESA TESTE LTDA</xNome>
+      <enderEmit>
+        <xLgr>Rua Fiscal</xLgr>
+        <nro>100</nro>
+        <xBairro>Centro</xBairro>
+        <xMun>Goiania</xMun>
+        <UF>GO</UF>
+        <CEP>74000000</CEP>
+      </enderEmit>
+    </emit>
+    <det nItem="1">
+      <prod>
+        <cProd>SKU-1</cProd>
+        <xProd>Produto fiscal de teste</xProd>
+        <NCM>01012100</NCM>
+        <CFOP>5102</CFOP>
+        <uCom>UN</uCom>
+        <qCom>2.0000</qCom>
+        <vUnCom>50.00</vUnCom>
+        <vProd>100.00</vProd>
+      </prod>
+      <imposto>
+        <ICMS>
+          <ICMS00>
+            <CST>00</CST>
+            <pICMS>18.00</pICMS>
+            <vICMS>18.00</vICMS>
+          </ICMS00>
+        </ICMS>
+      </imposto>
+    </det>
+    <total>
+      <ICMSTot>
+        <vProd>100.00</vProd>
+        <vNF>100.00</vNF>
+      </ICMSTot>
+    </total>
+  </infNFe>
+</NFe>
+"""
+
+# XML de NFC-e modelo 65 sem namespace
+XML_NFCE_65_SIMPLES = """
+<NFe>
+  <infNFe Id="NFe35240112345678000195650010000004561000000048">
+    <ide>
+      <mod>65</mod>
+      <serie>1</serie>
+      <nNF>456</nNF>
+      <dhEmi>2024-06-15T14:20:00-03:00</dhEmi>
+      <natOp>Venda a consumidor</natOp>
+      <tpNF>1</tpNF>
+    </ide>
+    <emit>
+      <CNPJ>12345678000195</CNPJ>
+      <xNome>LOJA TESTE LTDA</xNome>
+    </emit>
+    <dest>
+      <CPF>12345678901</CPF>
+      <xNome>CONSUMIDOR</xNome>
+    </dest>
+    <det nItem="1">
+      <prod>
+        <cProd>ITEM-01</cProd>
+        <xProd>Item de consumo</xProd>
+        <NCM>22021000</NCM>
+        <CFOP>5102</CFOP>
+        <uCom>UN</uCom>
+        <qCom>1.0000</qCom>
+        <vUnCom>25.00</vUnCom>
+        <vProd>25.00</vProd>
+      </prod>
+      <imposto>
+        <ICMS>
+          <ICMS00>
+            <CST>00</CST>
+            <pICMS>12.00</pICMS>
+            <vICMS>3.00</vICMS>
+          </ICMS00>
+        </ICMS>
+      </imposto>
+    </det>
+    <total>
+      <ICMSTot>
+        <vProd>25.00</vProd>
+        <vNF>25.00</vNF>
+      </ICMSTot>
+    </total>
+  </infNFe>
+</NFe>
+"""
+
+# XML com involucro nfeProc
+XML_NFE_COM_PROC = """
+<nfeProc xmlns="http://www.portalfiscal.inf.br/nfe">
+  <NFe>
+    <infNFe Id="NFe35240112345678000195550010000001231000000012">
+      <ide>
+        <mod>55</mod>
+        <serie>1</serie>
+        <nNF>123</nNF>
+        <dhEmi>2024-01-31T10:30:00-03:00</dhEmi>
+        <natOp>Venda de mercadoria</natOp>
+        <tpNF>1</tpNF>
+      </ide>
+      <emit>
+        <CNPJ>12345678000195</CNPJ>
+        <xNome>EMPRESA TESTE LTDA</xNome>
+      </emit>
+      <total>
+        <ICMSTot>
+          <vProd>100.00</vProd>
+          <vNF>100.00</vNF>
+        </ICMSTot>
+      </total>
+    </infNFe>
+  </NFe>
+  <protNFe>
+    <infProt>
+      <nProt>135240000000001</nProt>
+    </infProt>
+  </protNFe>
+</nfeProc>
+"""
+
+# XML invalido sem infNFe
+XML_SEM_INF_NFE = "<raiz><dados>invalido</dados></raiz>"
+
+# XML com Id invalido (prefixo correto mas menos de 44 digitos)
+XML_COM_ID_INVALIDO = """
+<NFe>
+  <infNFe Id="NFe1234">
+    <ide><mod>55</mod></ide>
+  </infNFe>
+</NFe>
+"""
+
+# XML com Id sem digitos (apenas texto)
+XML_COM_ID_NAO_NUMERICO = """
+<NFe>
+  <infNFe Id="INVALIDO_NAO_NUMERICO_AAAAAAAAAAA_BBBBBBBBBBB_CCCCCCCCCC">
+    <ide><mod>55</mod></ide>
+  </infNFe>
+</NFe>
+"""
+
+
+class TestParseNFeDocumentoSucesso:
+    """Testes de parse bem-sucedido de NF-e e NFC-e."""
+
+    def test_parse_nfe_modelo_55_extrai_chave_e_campos(self) -> None:
+        """Parse de NF-e modelo 55 deve extrair chave, numero, serie e modelo."""
+        resultado = parse_nfe_documento(XML_NFE_55_SIMPLES)
+
+        assert resultado.chave_acesso == "35240112345678000195550010000001231000000012"
+        assert resultado.número == "123"
+        assert resultado.serie == "1"
+        assert resultado.modelo == "55"
+
+    def test_parse_nfe_modelo_55_extrai_emitente(self) -> None:
+        """Parse de NF-e deve extrair dados do emitente corretamente."""
+        resultado = parse_nfe_documento(XML_NFE_55_SIMPLES)
+
+        assert resultado.emitente is not None
+        assert resultado.emitente.cnpj == "12345678000195"
+        assert resultado.emitente.nome == "EMPRESA TESTE LTDA"
+
+    def test_parse_nfe_modelo_55_extrai_itens(self) -> None:
+        """Parse de NF-e deve extrair pelo menos 1 item."""
+        resultado = parse_nfe_documento(XML_NFE_55_SIMPLES)
+
+        assert len(resultado.itens) == 1
+        item = resultado.itens[0]
+        assert item.codigo_produto == "SKU-1"
+        assert item.valor_total == 100.0
+
+    def test_parse_nfe_modelo_55_extrai_totais(self) -> None:
+        """Parse de NF-e deve extrair totais da nota."""
+        resultado = parse_nfe_documento(XML_NFE_55_SIMPLES)
+
+        assert resultado.totais is not None
+        assert resultado.totais.valor_nota == 100.0
+
+    def test_parse_nfce_modelo_65_extrai_chave_e_modelo(self) -> None:
+        """Parse de NFC-e modelo 65 deve extrair chave e identificar modelo 65."""
+        resultado = parse_nfe_documento(XML_NFCE_65_SIMPLES)
+
+        assert resultado.chave_acesso == "35240112345678000195650010000004561000000048"
+        assert resultado.modelo == "65"
+        assert resultado.número == "456"
+
+    def test_parse_nfe_com_nfeproc_extrai_protocolo(self) -> None:
+        """Parse de NF-e com involucro nfeProc deve extrair protocolo de autorizacao."""
+        resultado = parse_nfe_documento(XML_NFE_COM_PROC)
+
+        assert resultado.chave_acesso == "35240112345678000195550010000001231000000012"
+        assert resultado.protocolo_autorizacao == "135240000000001"
+
+    def test_parse_aceita_bytes(self) -> None:
+        """Parse deve aceitar XML como bytes alem de string."""
+        resultado = parse_nfe_documento(XML_NFE_55_SIMPLES.encode("utf-8"))
+
+        assert resultado.chave_acesso == "35240112345678000195550010000001231000000012"
+
+    def test_resultado_e_nfe_response(self) -> None:
+        """O retorno deve ser uma instancia de NFeResponse com sucesso=True."""
+        from mcp_fiscal_brasil.nfe.schemas import NFeResponse
+
+        resultado = parse_nfe_documento(XML_NFE_55_SIMPLES)
+
+        assert isinstance(resultado, NFeResponse)
+        assert resultado.sucesso is True
+
+
+class TestParseNFeDocumentoErros:
+    """Testes de tratamento de erros no parse."""
+
+    def test_xml_sem_inf_nfe_lanca_documento_parse_error(self) -> None:
+        """XML sem elemento infNFe deve levantar DocumentoParseError."""
+        with pytest.raises(DocumentoParseError) as exc_info:
+            parse_nfe_documento(XML_SEM_INF_NFE)
+
+        assert "infNFe" in str(exc_info.value)
+
+    def test_xml_com_id_invalido_lanca_documento_parse_error(self) -> None:
+        """XML com Id de infNFe invalido deve levantar DocumentoParseError."""
+        with pytest.raises(DocumentoParseError) as exc_info:
+            parse_nfe_documento(XML_COM_ID_INVALIDO)
+
+        assert "44" in str(exc_info.value)
+
+    def test_xml_com_id_nao_numerico_lanca_documento_parse_error(self) -> None:
+        """XML com Id nao numerico deve levantar DocumentoParseError."""
+        with pytest.raises(DocumentoParseError):
+            parse_nfe_documento(XML_COM_ID_NAO_NUMERICO)
+
+    def test_xml_malformado_lanca_excecao(self) -> None:
+        """XML malformado deve levantar excecao de parse XML."""
+        from mcp_fiscal_brasil.shared.exceptions import XMLParseError
+
+        with pytest.raises((XMLParseError, FiscalValidationError)):
+            parse_nfe_documento("<nao-fechado>")
+
+    def test_documento_parse_error_e_fiscal_validation_error(self) -> None:
+        """DocumentoParseError deve herdar de FiscalValidationError."""
+        with pytest.raises(FiscalValidationError):
+            parse_nfe_documento(XML_SEM_INF_NFE)

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,20 @@ wheels = [
 ]
 
 [[package]]
+name = "brazilfiscalreport"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fpdf2" },
+    { name = "phonenumbers" },
+    { name = "python-barcode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/47/62da752eb9a5002ab00d32f1ad23400cd5fc52257ae474aa88e2ba3a0061/brazilfiscalreport-1.0.0.tar.gz", hash = "sha256:b6d75cf557a2709c31454decf4fef3e5a7338618245299ed9f77eb2cc05204f5", size = 221124, upload-time = "2026-06-12T03:44:11.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c7/3c39aa7cb1f99282565b05760fd4858de274380972dea5fe26d2f257dd4a/brazilfiscalreport-1.0.0-py3-none-any.whl", hash = "sha256:aa689685ab035c229294f2fdb28450a46699737b1f47123c156a66b84f65fcd5", size = 222861, upload-time = "2026-06-12T03:44:09.969Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -599,6 +613,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -751,6 +774,77 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/c9/4141c90a90db20f807c7e10bfd689fe53eb8f7f4caff58ee4d4dfe46919f/fonttools-4.63.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3297a6a4059b4acc3a1e9a8b04741f240a80044eef08ebd32e8b5bcdddce75b", size = 2884632, upload-time = "2026-05-14T12:02:38.56Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/46/ad12b5c10eae602d7ef814b02afa08aacbf89da917fed5b071282b7eadc2/fonttools-4.63.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b1cd75a03ad8cb5bc40c90bfde68c0c47de423aa19e5c0f362b43520645eea94", size = 2429441, upload-time = "2026-05-14T12:02:41.162Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8f/bdca24a84c81d56fffed052229cdcff368f6e05882e526f4558891481f65/fonttools-4.63.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0425b277a59cff3d80ca42162a8de360f318438a2ac83570842a678d826d579", size = 4946346, upload-time = "2026-05-14T12:02:43.41Z" },
+    { url = "https://files.pythonhosted.org/packages/04/59/a639c0e136441ee91a65b56fdf89e5d075927e7a09c559d1b0f5276577db/fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7e5c9973aa04c95650c96e5f5ad865fbf42d62079163ecfab1e01cbc2504c22", size = 4903184, upload-time = "2026-05-14T12:02:45.742Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/53/91b7e0cb45b536f3da1b29ba8cbab89f27e8b986809e0b1982303a3f4eca/fonttools-4.63.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cb014d58140a38135f16064c74c652ed57aa0b75cbf8bb59cac821f7edb5334e", size = 4922967, upload-time = "2026-05-14T12:02:48.386Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b7/87439bf44e6b97c5538cd29d0b7e366a5b8ce2cc132a4134fb67fa3f2fa2/fonttools-4.63.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:032038247a96c1690f9f31e377c389383c902531b085aa4e4dabd6f57f870e69", size = 5042799, upload-time = "2026-05-14T12:02:50.424Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/7c/8b96c3263b89ef99cded544c0f0636686f85dbd3c211c4dceef0231fca23/fonttools-4.63.0-cp310-cp310-win32.whl", hash = "sha256:a8b33a82979e0a6a34ff435cc81317be1f95ec1ebb7a3a2d1c8a6a54f02ae44e", size = 1519704, upload-time = "2026-05-14T12:02:52.523Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4d/2c2f0069970b6907de8fb5b05c5c0193cc22f717df151d1c7aef1c738f58/fonttools-4.63.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c18358a155d75034911c5ee397a5b44cd19dd325dbb8b35fb60bf421d6a72ac", size = 1568666, upload-time = "2026-05-14T12:02:54.917Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2b/a7f1545bdf5da69c4bda0cea2a5781f0ad2a6623e0277267672db43c5fe6/fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f", size = 2881793, upload-time = "2026-05-14T12:02:56.645Z" },
+    { url = "https://files.pythonhosted.org/packages/49/50/965308c703f085f225db2886813b27e015b8b3438c350b22dd65b52c2a2c/fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9", size = 2428130, upload-time = "2026-05-14T12:02:58.891Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/38/6937fbd7f2dc3a6b48725851bc2c15ec949b9af14d9bbcb5fe83cdf9bdf9/fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b", size = 5111952, upload-time = "2026-05-14T12:03:01.263Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/a81f20050a3115b57d62c8e781446949512eac36690dc384ccea65ff4cc1/fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18", size = 5082308, upload-time = "2026-05-14T12:03:03.211Z" },
+    { url = "https://files.pythonhosted.org/packages/67/00/cdd9d4944ca6ae280d01e69cc37bde3bf663630b837a6fc6d2cd65d80e0e/fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0", size = 5087932, upload-time = "2026-05-14T12:03:05.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f1/0aa0dbea778c75adbef223c42019fd47d22262b905974d62d829545d485f/fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007", size = 5213271, upload-time = "2026-05-14T12:03:07.238Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/253e4056e1f0e67b9390125a154b73b5eb73ad521bece95c004858fdeec2/fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb", size = 2304473, upload-time = "2026-05-14T12:03:09.271Z" },
+    { url = "https://files.pythonhosted.org/packages/08/60/defa5e69641db890a63be281f41345f4c33b157824eaf0b9fad3e08b0dcb/fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c", size = 2356389, upload-time = "2026-05-14T12:03:11.53Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8d/d8fec3dcde2963f8c908fb315e5ff2cd0ac34f82394bbbf73a2aa5145ce3/fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd", size = 2876062, upload-time = "2026-05-14T12:03:32.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59", size = 2424594, upload-time = "2026-05-14T12:03:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/40/e76320afa1df918e146155ef239b1719ee266092e96f5423bfd075affba1/fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d", size = 5024840, upload-time = "2026-05-14T12:03:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68", size = 4975801, upload-time = "2026-05-14T12:03:38.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/26/2cee03d0aa083ab022da5c07aff9ed3f689da1defb81ad6917c9627896da/fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be", size = 4965009, upload-time = "2026-05-14T12:03:41.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/48/cc4b66d9058c0d0982c833fad10127c4b0e9324606aafa41382295ca4102/fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27", size = 5105892, upload-time = "2026-05-14T12:03:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745", size = 2875338, upload-time = "2026-05-14T12:03:50.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03", size = 2422661, upload-time = "2026-05-14T12:03:52.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49", size = 5010526, upload-time = "2026-05-14T12:03:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b", size = 4923946, upload-time = "2026-05-14T12:03:56.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/872e6e233b8c5e8b41413796ff18b7fe479661bd40147e071b450dfad7a1/fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6", size = 4962489, upload-time = "2026-05-14T12:03:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c4/83c24f2ec38b90cfda84bf4b1a1f49df80e84a1db4e7ac6e0d41bf23bc39/fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4", size = 5071870, upload-time = "2026-05-14T12:04:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/3ae22b60ff1d41ce0bd044b31238cdc72cef99f28b976f1e128ebd618c9b/fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616", size = 2295026, upload-time = "2026-05-14T12:04:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5", size = 2347454, upload-time = "2026-05-14T12:04:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4e/652d1580c5f4e39f7d103b0c793e4773129ad633dce4addd0cf4dfebde02/fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001", size = 2958152, upload-time = "2026-05-14T12:04:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/55/ad864c9a9b219f552eb46b32cd7906c466e5a578ba0c3abfcc0fe7413eb6/fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e", size = 2460809, upload-time = "2026-05-14T12:04:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/0aa8db70f18cf52e49b4ed5ecec68547f981160bf5ded3b5aed6faa0a6f9/fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096", size = 5148649, upload-time = "2026-05-14T12:04:12.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/18e4369c25043096f1048e0c9915951adc4f842bd81c6b18155824d6fa99/fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f", size = 4932147, upload-time = "2026-05-14T12:04:14.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3f/67f3eac2ffd8a98446c5022f8ed3864eac878a5ff7af8df4c8286dba16cc/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40", size = 5027237, upload-time = "2026-05-14T12:04:17.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ba/4e6214cb38a7b04779e97bb7636de9a5c7f20af7018d03dee0b64c08510a/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196", size = 5053933, upload-time = "2026-05-14T12:04:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/72feae0b2827ed38013e4307b14f95bf0b3d124adfef4d38a7d57533f7be/fpdf2-2.8.7.tar.gz", hash = "sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9", size = 362351, upload-time = "2026-02-28T05:39:16.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/cf50ecffa1e3747ed9380a3adfc829259f1f86b3fdbd9e505af789003141/fpdf2-2.8.7-py3-none-any.whl", hash = "sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19", size = 327056, upload-time = "2026-02-28T05:39:14.619Z" },
 ]
 
 [[package]]
@@ -1369,11 +1463,13 @@ wheels = [
 
 [[package]]
 name = "mcp-fiscal-brasil"
-version = "0.2.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
+    { name = "brazilfiscalreport" },
     { name = "cachetools" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
@@ -1381,6 +1477,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
+    { name = "signxml" },
     { name = "structlog" },
     { name = "tenacity" },
     { name = "typer" },
@@ -1415,7 +1512,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2.1" },
+    { name = "brazilfiscalreport", specifier = "==1.0.0" },
     { name = "cachetools", specifier = ">=7.0.5" },
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", specifier = ">=0.136.1" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -1428,6 +1527,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "signxml", specifier = ">=4.5.1" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0.1" },
@@ -1782,6 +1882,113 @@ wheels = [
 ]
 
 [[package]]
+name = "phonenumbers"
+version = "9.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/11/ba7611cadc8c99b797416d0dada535c02890dc21b759dfef60a3751d2e20/phonenumbers-9.0.32.tar.gz", hash = "sha256:108ad0237202d2f6cf4b342fac411f22808d85187c3a366152a2af7ed3202a8e", size = 2306598, upload-time = "2026-06-05T05:48:38.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/e9/1ca526105e792b7ed752fd0ff5732ab01185f2deb719ae6f30183fb21143/phonenumbers-9.0.32-py2.py3-none-any.whl", hash = "sha256:fbcd40d3b11920ee77b1d34a54c3b64c6648a90b8e37222eb62e7fafb87db3e7", size = 2595438, upload-time = "2026-06-05T05:48:36.066Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2116,6 +2323,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-barcode"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/f2/4c0b07f100e1e184ba682021322c336bbba6aa7adfabd2616f70eff917d9/python_barcode-0.16.1.tar.gz", hash = "sha256:665ed09516b0088b5593061c5ac8662caa0b08d56bdad328388b1cab39939ac5", size = 233777, upload-time = "2025-08-27T11:05:45.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/34/810885dca784b02e5ad0f71ced9c06ba5e9d33a6493bc886f7470ce82a39/python_barcode-0.16.1-py3-none-any.whl", hash = "sha256:5776567478c9a0dae473374bb86631ba0b5ea99aaf302763b364e367ac51f367", size = 228046, upload-time = "2025-08-27T11:05:42.776Z" },
 ]
 
 [[package]]
@@ -2499,6 +2715,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "signxml"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cryptography" },
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/2e/63f3a26be2a5aba9000bda998197b7e6be700b04a7488ec90d52a5a25423/signxml-4.5.1.tar.gz", hash = "sha256:6378d16cfd79cffc1761b75532e3ce3465ecd0c3a81890398813913d75a0b88a", size = 1615677, upload-time = "2026-06-13T23:51:48.822Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/53/a9047a471b2497b0dcbbb68d32cf99ad15e4a28f5d06a03ab5ff5489731d/signxml-4.5.1-py3-none-any.whl", hash = "sha256:20212c609d84596ec87d66df71af69cc6728c94bdbcd9d67fefefcc5d22b8a2d", size = 60549, upload-time = "2026-06-13T23:51:47.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Resumo

Este PR adiciona o modulo NF-e completo ao mcp-fiscal-brasil, com 5 novas tools MCP e 41 tools no total no servidor.

### As 5 tools NF-e

| Tool | Certificado A1 | Descricao |
|------|---------------|-----------|
| `parse_nfe_xml` | Nao requer | Parseia XML de NF-e/NFC-e (mod 55/65) em dados estruturados (NFeResponse). Extrai emitente, destinatario, itens, totais, Reforma Tributaria (IBS/CBS/IS) e protocolo |
| `gerar_danfe` | Nao requer | Gera DANFE PDF A4 (mod 55) via brazilfiscalreport. Retorna base64. Mod 65 levanta erro explicito |
| `validar_assinatura_nfe` | Nao requer | Valida assinatura XMLDSig/ICP-Brasil. Extrai titular, CNPJ/CPF, validade, AC emissora. ca_bundle opcional para validar cadeia ICP-Brasil completa |
| `baixar_nfe_distribuicao` | **Requer** (opt-in) | NFeDistribuicaoDFe via mTLS com cert A1 local. 3 modos: distNSU (incremental), consNSU (NSU especifico), consChNFe (por chave) |
| `manifestar_nfe` | **Requer** (opt-in) | Eventos de manifestacao do destinatario (210200/210210/210220/210240) via NFeRecepcaoEvento |

**Importante**: apenas `baixar_nfe_distribuicao` e `manifestar_nfe` exigem certificado A1 local (opt-in). As outras 39 tools - incluindo as 3 NF-e acima - seguem o modelo zero-cadastro/zero-certificado do projeto. O certificado nunca e enviado a nenhum servidor externo; toda autenticacao mTLS e assinatura XMLDSig e feita localmente.

### Seguranca

- **Anti-XXE**: todo XML externo parseado via `parse_xml()` (resolve_entities=False, no_network=True)
- **Rate-limit SEFAZ**: limitador conservador de 1 req/s por endpoint aplicado em `_enviar_soap`, compartilhado por `baixar_nfe_distribuicao` e `manifestar_nfe`
- **PEM temporario atomico**: chave privada criada com `os.open(O_CREAT|O_WRONLY|O_EXCL, 0o600)` - sem janela 0644
- **Limite ca_bundle**: `FiscalValidationError` claro para ca_bundle > 1 MB
- **Sem cert embutido + sem ca_bundle**: retorna `assinatura_valida=False` com motivo explicativo em vez de verificar contra CA store do sistema (que aceitaria qualquer cert SSL como valido)
- **Escape de XML**: `xml.sax.saxutils.escape()` aplicado na justificativa antes de interpolar no XML do evento

### Review realizado

Security review e code review realizados antes deste PR (Task #4). Nenhum CRITICAL encontrado. 6 findings de seguranca (HIGH/MEDIUM/LOW) e 6 de qualidade todos corrigidos neste commit.

### Testes

- **407 testes** passando (suite completa)
- **65 testes** no modulo NF-e especificamente
- Novos testes para: sem cert embutido + sem ca_bundle (Fix #4), ca_bundle > 1 MB (Fix #3)
- `ruff check`: sem erros
- `ruff format --check`: 142 arquivos ja formatados
- `mypy src/`: nenhum erro em 95 arquivos

## Test plan

- [ ] Verificar que `parse_nfe_xml` parseia XML de NF-e real com namespace e sem namespace
- [ ] Verificar que `gerar_danfe` retorna base64 valido com um XML de NF-e mod 55
- [ ] Verificar que `gerar_danfe` com mod 65 retorna erro claro (sem crash)
- [ ] Verificar que `validar_assinatura_nfe` retorna `assinatura_valida=True` para NF-e real assinada
- [ ] Verificar que `validar_assinatura_nfe` com XML sem X509Certificate e sem ca_bundle retorna `False`
- [ ] Testar `baixar_nfe_distribuicao` em homologacao com cert A1 de teste (modo distNSU)
- [ ] Testar `manifestar_nfe` evento 210200 (Ciencia) em homologacao
- [ ] Confirmar que o rate-limit de 1 req/s impede flood acidental nos endpoints SEFAZ