### PR TITLE
feat: cálculo de impostos de importação por NCM (MVP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+#### Cálculo de tributos de importação por NCM (módulo `importacao`)
+
+- `calcular_tributos_importacao` - calcula a cascata completa de tributos de importação
+  (II, IPI, PIS/COFINS-importação, ICMS grossed-up, AFRMM e taxa Siscomex) a partir do
+  valor aduaneiro, alíquota II (TEC) informada pelo usuário, UF importadora e modal.
+  Offline para IPI (banco NCM/TIPI), ICMS (tabela interna de alíquotas estaduais),
+  AFRMM e Siscomex. Retorna breakdown por tributo com base, alíquota, valor, fundamento
+  legal, avisos e disclaimers obrigatórios. Sem API key. Escopo MVP: fora de antidumping,
+  regimes especiais, acordos bilaterais e alíquotas diferenciadas de PIS/COFINS.
+- `consultar_aliquotas_importacao` - retorna a alíquota IPI do banco NCM/TIPI bundled,
+  os defaults de PIS/COFINS-importação (2,1% e 9,65%, Lei 10.865/2004) e aviso sobre
+  a alíquota II (TEC), que não está disponível offline e deve ser informada pelo usuário.
+  Útil para conferir a alíquota IPI antes de usar calcular_tributos_importacao.
+
 - Circuit breaker para o client da NFS-e Nacional (ADN): apos 5 falhas consecutivas,
   novas chamadas sao bloqueadas por 60 s sem tocar a API, evitando sobrecarga em
   instabilidades do servico. O estado e reset automaticamente apos o periodo de

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ module = [
     "mcp_fiscal_brasil.ibge._tools",
     "mcp_fiscal_brasil.mei._tools",
     "mcp_fiscal_brasil.tabelas._tools",
+    "mcp_fiscal_brasil.importacao._tools",
 ]
 # Decoradores @app.tool() do FastMCP nao sao tipados; o override por modulo
 # e mais cirurgico do que rebaixar o strict global.

--- a/src/mcp_fiscal_brasil/importacao/__init__.py
+++ b/src/mcp_fiscal_brasil/importacao/__init__.py
@@ -1,0 +1,25 @@
+"""
+Módulo de cálculo de tributos de importação por NCM.
+
+Ferramentas disponíveis:
+- ``calcular_tributos_importacao``: calcula a cascata completa de tributos
+  (II, IPI, PIS/COFINS-importação, ICMS, AFRMM/Siscomex) a partir do
+  valor aduaneiro e das alíquotas informadas.
+- ``consultar_aliquotas_importacao``: retorna alíquota IPI do banco NCM
+  e os defaults de PIS/COFINS-importação, com aviso sobre a alíquota II.
+
+DISCLAIMER: Este módulo produz estimativas para fins de planejamento fiscal.
+Não substitui o cálculo oficial pelo SISCOMEX nem a conferência por
+despachante aduaneiro ou contador especializado em comércio exterior.
+Antidumping, regimes especiais, acordos bilaterais e benefícios fiscais
+estaduais específicos estão fora do escopo do MVP.
+"""
+
+from ._tools import register
+from .tools import calcular_tributos_importacao, consultar_aliquotas_importacao
+
+__all__ = [
+    "calcular_tributos_importacao",
+    "consultar_aliquotas_importacao",
+    "register",
+]

--- a/src/mcp_fiscal_brasil/importacao/_tools.py
+++ b/src/mcp_fiscal_brasil/importacao/_tools.py
@@ -114,7 +114,7 @@ def register(app: FastMCP) -> None:
             valor_aduaneiro=valor_aduaneiro,
             uf_importador=uf_importador,
             aliquota_ii=aliquota_ii,
-            modal=modal,  # type: ignore[arg-type]
+            modal=modal,  # type: ignore[arg-type]  # FastMCP expõe str no schema; Literal validado em runtime em _MODAIS_VALIDOS
             frete_maritimo=frete_maritimo,
             aliquota_pis=aliquota_pis,
             aliquota_cofins=aliquota_cofins,

--- a/src/mcp_fiscal_brasil/importacao/_tools.py
+++ b/src/mcp_fiscal_brasil/importacao/_tools.py
@@ -1,0 +1,123 @@
+"""
+Registro das ferramentas do módulo de impostos de importação no servidor MCP.
+
+Uso:
+    from mcp_fiscal_brasil.importacao._tools import register
+    register(app)
+"""
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from .tools import calcular_tributos_importacao, consultar_aliquotas_importacao
+
+
+def register(app: FastMCP) -> None:
+    """Registra as 2 ferramentas de importação no servidor MCP fornecido."""
+
+    @app.tool(
+        name="consultar_aliquotas_importacao",
+        description=(
+            "Consulta alíquotas de referência para cálculo de tributos de importação por NCM. "
+            "Purpose: obter a alíquota IPI do banco NCM/TIPI e os defaults de PIS/COFINS-importação "
+            "antes de usar calcular_tributos_importacao. "
+            "Quando usar: antes de calcular tributos de importação, para verificar a alíquota IPI "
+            "do produto e conhecer os defaults de PIS/COFINS aplicáveis. "
+            "IMPORTANTE: A alíquota II (Imposto de Importação / TEC) NÃO está disponível offline. "
+            "Consulte www.mdic.gov.br e informe manualmente em calcular_tributos_importacao. "
+            "Comportamento offline: lê do banco SQLite bundled (TIPI); não requer conexão. "
+            "Parâmetro: código NCM com 8 dígitos, com ou sem pontuação "
+            "(ex: '22030000' ou '2203.00.00')."
+        ),
+    )
+    async def tool_consultar_aliquotas_importacao(ncm: str) -> dict[str, Any]:
+        """Consulta alíquotas de referência para importação por NCM (offline).
+
+        Retorna a aliquota IPI do banco NCM/TIPI, os defaults de PIS/COFINS-importacao
+        e um aviso sobre a aliquota II (TEC), que nao esta disponivel offline.
+
+        Args:
+            ncm: Codigo NCM com 8 digitos, com ou sem pontuacao
+                 (ex.: "22030000" ou "2203.00.00").
+
+        Returns:
+            dict com ncm, descricao_ncm, aliquota_ipi, defaults de PIS/COFINS
+            e aviso_aliquota_ii.
+        """
+        resultado = await consultar_aliquotas_importacao(ncm)
+        return resultado.model_dump(mode="json", exclude_none=True)
+
+    @app.tool(
+        name="calcular_tributos_importacao",
+        description=(
+            "Calcula os tributos de importação em cascata para um produto classificado por NCM. "
+            "Purpose: estimar a carga tributária de importação (II, IPI, PIS/COFINS-importação, "
+            "ICMS grossed-up, AFRMM e taxa Siscomex) para planejamento de custo de desembaraço. "
+            "Quando usar: ao planejar uma importação e precisar estimar o custo total de tributos. "
+            "IMPORTANTE: A alíquota II (aliquota_ii) deve ser informada pelo usuário conforme a "
+            "TEC vigente em www.mdic.gov.br. Não há fonte offline estruturada para a TEC. "
+            "Cascata: VA -> II -> IPI (base=VA+II) -> PIS/COFINS-imp (base=VA) -> "
+            "ICMS por dentro (base=VA+II+IPI+PIS+COFINS) -> AFRMM/Siscomex. "
+            "DISCLAIMER: Estimativa para planejamento. Não substitui SISCOMEX nem despachante. "
+            "Antidumping, regimes especiais, acordos bilaterais e alíquotas diferenciadas "
+            "de PIS/COFINS estão fora do escopo do MVP. "
+            "Parâmetros: ncm (8 dígitos), valor_aduaneiro (R$), uf_importador (sigla UF), "
+            "aliquota_ii (% TEC), modal (maritimo/aereo/terrestre/postal), "
+            "frete_maritimo (R$, apenas modal marítimo), aliquota_pis (default 2,1%), "
+            "aliquota_cofins (default 9,65%), aliquota_ipi_override (sobrescreve banco NCM)."
+        ),
+    )
+    async def tool_calcular_tributos_importacao(
+        ncm: str,
+        valor_aduaneiro: float,
+        uf_importador: str,
+        aliquota_ii: float,
+        modal: str = "maritimo",
+        frete_maritimo: float = 0.0,
+        aliquota_pis: float = 2.1,
+        aliquota_cofins: float = 9.65,
+        aliquota_ipi_override: float | None = None,
+    ) -> dict[str, Any]:
+        """Calcula tributos de importacao em cascata para um NCM (offline para IPI/ICMS).
+
+        Ordem: VA -> II -> IPI (VA+II) -> PIS/COFINS-imp (VA) ->
+        ICMS por dentro (VA+II+IPI+PIS+COFINS) -> AFRMM -> Siscomex.
+
+        A aliquota II (TEC) deve ser informada pelo usuario (nao ha fonte offline).
+        A aliquota IPI vem do banco NCM/TIPI bundled, mas pode ser sobrescrita.
+        A aliquota ICMS vem da tabela interna de aliquotas estaduais.
+
+        DISCLAIMER: Estimativa para planejamento. Nao substitui SISCOMEX nem despachante.
+        Antidumping, regimes especiais e acordos bilaterais nao sao cobertos.
+
+        Args:
+            ncm: Codigo NCM com 8 digitos (ex.: "22030000" ou "2203.00.00").
+            valor_aduaneiro: Valor Aduaneiro (VA) em R$. Deve ser positivo.
+            uf_importador: Sigla da UF do importador para calculo do ICMS (ex.: "SP").
+            aliquota_ii: Aliquota do II (TEC) em percentual (ex.: 20.0). Informar
+                         conforme a Tarifa Aduaneira do Brasil (www.mdic.gov.br).
+            modal: Modal de transporte: "maritimo", "aereo", "terrestre" ou "postal".
+                   Afeta o AFRMM (apenas maritimo). Padrao: "maritimo".
+            frete_maritimo: Valor do frete maritimo em R$ para calculo do AFRMM.
+                            Relevante apenas quando modal="maritimo". Padrao: 0.0.
+            aliquota_pis: Aliquota do PIS-Importacao em % (padrao: 2,1%).
+            aliquota_cofins: Aliquota do COFINS-Importacao em % (padrao: 9,65%).
+            aliquota_ipi_override: Se informado, sobrescreve a aliquota IPI do banco NCM.
+
+        Returns:
+            dict com ncm, modal, valor_aduaneiro, breakdown (lista de tributos com base,
+            aliquota e valor), total_tributos, custo_total, avisos e disclaimers.
+        """
+        resultado = await calcular_tributos_importacao(
+            ncm=ncm,
+            valor_aduaneiro=valor_aduaneiro,
+            uf_importador=uf_importador,
+            aliquota_ii=aliquota_ii,
+            modal=modal,  # type: ignore[arg-type]
+            frete_maritimo=frete_maritimo,
+            aliquota_pis=aliquota_pis,
+            aliquota_cofins=aliquota_cofins,
+            aliquota_ipi_override=aliquota_ipi_override,
+        )
+        return resultado.model_dump(mode="json", exclude_none=True)

--- a/src/mcp_fiscal_brasil/importacao/schemas.py
+++ b/src/mcp_fiscal_brasil/importacao/schemas.py
@@ -1,0 +1,84 @@
+"""Schemas Pydantic para o módulo de cálculo de tributos de importação."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ..shared.schemas import BaseResponse
+
+
+class TributoItem(BaseResponse):
+    """Detalhe de um tributo individual no breakdown da importação."""
+
+    nome: str = Field(description="Nome do tributo (ex: II, IPI, PIS-Importação)")
+    base_calculo: float = Field(description="Base de cálculo utilizada, em R$")
+    aliquota: float = Field(description="Alíquota aplicada, em %")
+    valor: float = Field(description="Valor calculado do tributo, em R$")
+    fundamento: str = Field(description="Fundamento legal ou nota sobre o cálculo")
+
+
+class TributosImportacaoResponse(BaseResponse):
+    """
+    Resultado do cálculo de tributos de importação em cascata.
+
+    DISCLAIMER: Os valores são estimativas para planejamento. Não substituem
+    o cálculo oficial pelo SISCOMEX nem a conferência por despachante aduaneiro
+    ou contador especializado em comércio exterior. Antidumping, regimes especiais,
+    acordos bilaterais e benefícios fiscais estaduais específicos estão fora do
+    escopo deste simulador.
+    """
+
+    ncm: str = Field(description="Código NCM com 8 dígitos informado")
+    modal: str = Field(description="Modal de transporte utilizado")
+    valor_aduaneiro: float = Field(description="Valor aduaneiro (VA) base do cálculo, em R$")
+    breakdown: list[TributoItem] = Field(
+        description="Detalhamento de cada tributo na ordem de cascata"
+    )
+    total_tributos: float = Field(description="Soma de todos os tributos calculados, em R$")
+    custo_total: float = Field(
+        description="Valor aduaneiro + total de tributos (custo de desembaraço estimado), em R$"
+    )
+    avisos: list[str] = Field(
+        default_factory=list,
+        description="Avisos sobre parâmetros estimados ou situações que exigem conferência",
+    )
+    disclaimers: list[str] = Field(
+        default_factory=list,
+        description="Disclaimers legais obrigatórios sobre o escopo da simulação",
+    )
+
+
+class AliquotasImportacaoResponse(BaseResponse):
+    """
+    Alíquotas de referência para cálculo de tributos de importação por NCM.
+
+    DISCLAIMER: A alíquota II (TEC) não está disponível em fonte estruturada
+    offline e deve ser informada pelo usuário com base na Tarifa Externa Comum
+    vigente (www.mdic.gov.br / Tarifa Aduaneira do Brasil). Os demais valores
+    são defaults para planejamento e podem divergir da tributação efetiva.
+    """
+
+    ncm: str = Field(description="Código NCM com 8 dígitos consultado")
+    descricao_ncm: str | None = Field(
+        default=None, description="Descrição do produto conforme TIPI, se encontrada"
+    )
+    aliquota_ipi: float | None = Field(
+        default=None,
+        description="Alíquota IPI do banco NCM/TIPI, em %. None se NCM não encontrado.",
+    )
+    aliquota_pis_importacao_default: float = Field(
+        description="Alíquota default de PIS-Importação (%), base: art. 1º Lei 10.865/2004"
+    )
+    aliquota_cofins_importacao_default: float = Field(
+        description="Alíquota default de COFINS-Importação (%), base: art. 1º Lei 10.865/2004"
+    )
+    aviso_aliquota_ii: str = Field(
+        description=(
+            "Aviso sobre a alíquota II (Imposto de Importação / TEC): não há fonte "
+            "estruturada offline. Informe aliquota_ii ao chamar calcular_tributos_importacao."
+        )
+    )
+    avisos: list[str] = Field(
+        default_factory=list,
+        description="Avisos adicionais sobre o NCM ou as alíquotas retornadas",
+    )

--- a/src/mcp_fiscal_brasil/importacao/tools.py
+++ b/src/mcp_fiscal_brasil/importacao/tools.py
@@ -1,0 +1,453 @@
+"""
+Lógica de negócio do módulo de cálculo de tributos de importação por NCM.
+
+Cascata de cálculo (ordem obrigatória):
+  1. VA  - Valor Aduaneiro (base, fornecido pelo usuário)
+  2. II  - Imposto de Importação: base = VA, alíquota informada pelo usuário (TEC)
+  3. IPI - Imposto sobre Produtos Industrializados: base = VA + II, alíquota do banco NCM
+  4. PIS-Importação: base = VA, alíquota default 2,1% (Lei 10.865/2004, art. 1º)
+  5. COFINS-Importação: base = VA, alíquota default 9,65% (Lei 10.865/2004, art. 1º)
+  6. ICMS "por dentro" (grossed-up):
+       carga_sem_icms = VA + II + IPI + PIS + COFINS
+       ICMS = carga_sem_icms * aliq_icms / (1 - aliq_icms)
+     Alíquota interna da UF importadora (tabela ICMS_ALIQUOTA_INTERNA).
+  7. AFRMM - Adicional ao Frete para Renovação da Marinha Mercante (25% do frete marítimo).
+     Aplica-se apenas ao modal marítimo. (Lei 10.893/2004, art. 4º)
+  8. Siscomex - Taxa fixa de R$ 40,00 por declaração de importação (CAMEX).
+
+DISCLAIMER: Antidumping, regimes especiais, acordos bilaterais, Drawback, ZFM/ALC,
+benefícios fiscais estaduais específicos e alíquotas diferenciadas de PIS/COFINS
+(ex: produtos farmacêuticos, máquinas, veículos) estão fora do escopo do MVP.
+A alíquota II (TEC) não está disponível em fonte offline estruturada e deve ser
+informada pelo usuário.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+from mcp_fiscal_brasil._core import FiscalValidationError, get_logger
+from mcp_fiscal_brasil.tabelas.loader import ICMS_ALIQUOTA_INTERNA, buscar_ncm
+
+from .schemas import AliquotasImportacaoResponse, TributoItem, TributosImportacaoResponse
+
+logger = get_logger(__name__)
+
+# Alíquotas default de PIS/COFINS-Importação (Lei 10.865/2004, regime geral)
+_DEFAULT_PIS_IMPORTACAO: float = 2.1
+_DEFAULT_COFINS_IMPORTACAO: float = 9.65
+
+# Alíquota AFRMM (Lei 10.893/2004, art. 4º)
+_ALIQ_AFRMM: float = 25.0
+
+# Taxa Siscomex: R$ 40,00 por declaração de importação (Portaria CAMEX 54/2022)
+_TAXA_SISCOMEX: float = 40.0
+
+# UFs válidas (mesmas do loader de ICMS)
+_UFS_VALIDAS: frozenset[str] = frozenset(ICMS_ALIQUOTA_INTERNA.keys())
+
+_MODAIS_VALIDOS: frozenset[str] = frozenset({"maritimo", "aereo", "terrestre", "postal"})
+
+_DISCLAIMERS: list[str] = [
+    (
+        "DISCLAIMER: Os valores calculados são estimativas para planejamento fiscal e NÃO "
+        "substituem o cálculo oficial pelo SISCOMEX nem a conferência por despachante aduaneiro "
+        "ou contador especializado em comércio exterior."
+    ),
+    (
+        "Antidumping, regimes especiais (ex.: Drawback, Recof), acordos bilaterais (Mercosul, "
+        "ALADI), benefícios de ZFM/ALC e alíquotas diferenciadas de PIS/COFINS-importação "
+        "(farmacêuticos, máquinas, veículos) estão fora do escopo deste simulador MVP."
+    ),
+    (
+        "A alíquota II (TEC) deve ser verificada na Tarifa Aduaneira do Brasil vigente "
+        "(www.mdic.gov.br). Regimes de ex-tarifário podem reduzi-la substancialmente."
+    ),
+]
+
+
+def _ncm_limpo(ncm: str) -> str:
+    """Remove pontuação e espaços do código NCM."""
+    return ncm.replace(".", "").replace("-", "").strip()
+
+
+def _validar_ncm_formato(ncm: str) -> str:
+    """Valida e retorna o NCM limpo (8 dígitos)."""
+    codigo = _ncm_limpo(ncm)
+    if not codigo.isdigit() or len(codigo) != 8:
+        raise FiscalValidationError(
+            f"Formato de NCM inválido: '{ncm}'. Informe 8 dígitos numéricos "
+            "(ex: '22030000' ou '2203.00.00').",
+            field="ncm",
+            value=ncm,
+        )
+    return codigo
+
+
+def _validar_uf(uf: str, field: str = "uf_importador") -> str:
+    """Valida e retorna a UF em maiúsculas."""
+    uf_upper = uf.strip().upper()
+    if uf_upper not in _UFS_VALIDAS:
+        raise FiscalValidationError(
+            f"UF inválida: '{uf}'. UFs válidas: {', '.join(sorted(_UFS_VALIDAS))}.",
+            field=field,
+            value=uf,
+        )
+    return uf_upper
+
+
+def _calcular_icms_por_dentro(carga_sem_icms: float, aliquota_icms: float) -> float:
+    """
+    Calcula o ICMS "por dentro" (grossed-up) na importação.
+
+    Na importação, o ICMS é calculado "por dentro": ele integra sua própria base.
+    Fórmula: ICMS = carga_sem_icms * aliq / (1 - aliq)
+
+    Args:
+        carga_sem_icms: Soma de VA + II + IPI + PIS + COFINS.
+        aliquota_icms: Alíquota interna da UF em percentual (ex: 18.0).
+
+    Returns:
+        Valor do ICMS em R$.
+    """
+    aliq = aliquota_icms / 100.0
+    return round(carga_sem_icms * aliq / (1.0 - aliq), 2)
+
+
+def _buscar_dados_ncm_sync(codigo: str) -> dict[str, Any] | None:
+    """Wrapper síncrono para buscar NCM no banco SQLite."""
+    return buscar_ncm(codigo)
+
+
+async def consultar_aliquotas_importacao(ncm: str) -> AliquotasImportacaoResponse:
+    """
+    Consulta alíquotas de referência para importação por NCM (offline).
+
+    Retorna a alíquota IPI do banco NCM/TIPI, os defaults de PIS/COFINS-importação
+    e um aviso sobre a alíquota II (TEC), que não está disponível em fonte estruturada
+    offline e deve ser informada pelo usuário.
+
+    Args:
+        ncm: Código NCM com 8 dígitos, com ou sem pontuação
+             (ex: '22030000' ou '2203.00.00').
+
+    Returns:
+        AliquotasImportacaoResponse com alíquota IPI, defaults de PIS/COFINS e aviso sobre II.
+
+    Raises:
+        FiscalValidationError: Se o formato do NCM for inválido.
+    """
+    codigo = _validar_ncm_formato(ncm)
+    logger.info("consultar_aliquotas_importacao", ncm=codigo)
+
+    dado_ncm = await asyncio.to_thread(_buscar_dados_ncm_sync, codigo)
+
+    avisos: list[str] = []
+    aliquota_ipi: float | None = None
+    descricao_ncm: str | None = None
+
+    if dado_ncm is None:
+        avisos.append(
+            f"NCM '{codigo}' não encontrado no banco TIPI bundled. "
+            "Execute scripts/build_tabelas_db.py para popular a tabela completa. "
+            "A alíquota IPI não pôde ser determinada offline."
+        )
+    else:
+        descricao_ncm = dado_ncm.get("descricao")
+        aliquota_ipi = dado_ncm.get("aliquota_ipi")
+        if aliquota_ipi is None:
+            avisos.append(
+                f"NCM '{codigo}' encontrado no banco mas sem alíquota IPI registrada. "
+                "Pode ser posição genérica (capítulo/posição) ou produto com IPI = 0%. "
+                "Verifique a TIPI vigente."
+            )
+
+    return AliquotasImportacaoResponse(
+        ncm=codigo,
+        descricao_ncm=descricao_ncm,
+        aliquota_ipi=aliquota_ipi,
+        aliquota_pis_importacao_default=_DEFAULT_PIS_IMPORTACAO,
+        aliquota_cofins_importacao_default=_DEFAULT_COFINS_IMPORTACAO,
+        aviso_aliquota_ii=(
+            "A alíquota do II (Imposto de Importação / TEC) NÃO está disponível em fonte "
+            "estruturada offline. Consulte a Tarifa Aduaneira do Brasil vigente em "
+            "www.mdic.gov.br e informe aliquota_ii ao chamar calcular_tributos_importacao. "
+            "Ex-tarifários podem reduzir substancialmente a alíquota TEC."
+        ),
+        avisos=avisos,
+    )
+
+
+async def calcular_tributos_importacao(
+    ncm: str,
+    valor_aduaneiro: float,
+    uf_importador: str,
+    aliquota_ii: float,
+    modal: Literal["maritimo", "aereo", "terrestre", "postal"] = "maritimo",
+    frete_maritimo: float = 0.0,
+    aliquota_pis: float = _DEFAULT_PIS_IMPORTACAO,
+    aliquota_cofins: float = _DEFAULT_COFINS_IMPORTACAO,
+    aliquota_ipi_override: float | None = None,
+) -> TributosImportacaoResponse:
+    """
+    Calcula os tributos de importação em cascata para um produto classificado por NCM.
+
+    Ordem de cálculo:
+      VA -> II -> IPI (base VA+II) -> PIS/COFINS-importação (base VA) ->
+      ICMS "por dentro" (base VA+II+IPI+PIS+COFINS) -> AFRMM/Siscomex.
+
+    DISCLAIMER: Os valores são estimativas para planejamento. Não substituem o
+    cálculo oficial pelo SISCOMEX nem a conferência por despachante aduaneiro
+    ou contador especializado. A alíquota II (TEC) deve ser informada pelo usuário
+    conforme a Tarifa Aduaneira do Brasil vigente (www.mdic.gov.br).
+    Antidumping, regimes especiais, acordos bilaterais e alíquotas diferenciadas
+    de PIS/COFINS estão fora do escopo do MVP.
+
+    Args:
+        ncm: Código NCM com 8 dígitos (ex: '22030000' ou '2203.00.00').
+        valor_aduaneiro: Valor Aduaneiro (VA) em R$. Deve ser positivo.
+        uf_importador: Sigla da UF do importador para cálculo do ICMS (ex: 'SP').
+        aliquota_ii: Alíquota do II (Imposto de Importação / TEC) em percentual
+                     (ex: 20.0 para 20%). Deve ser >= 0. Informe conforme a TEC
+                     vigente (www.mdic.gov.br). Antidumping NÃO incluído.
+        modal: Modal de transporte. Valores: 'maritimo', 'aereo', 'terrestre',
+               'postal'. Afeta o AFRMM (apenas modal marítimo). Padrão: 'maritimo'.
+        frete_maritimo: Valor do frete marítimo em R$ (para cálculo do AFRMM).
+                        Relevante apenas quando modal='maritimo'. Padrão: 0.0.
+        aliquota_pis: Alíquota do PIS-Importação em % (padrão: 2,1%).
+                      Use para PIS diferenciado (produtos específicos da Lei 10.865/2004).
+                      AVISO: alíquotas diferenciadas exigem conferência com contador.
+        aliquota_cofins: Alíquota do COFINS-Importação em % (padrão: 9,65%).
+                         Use para COFINS diferenciado. AVISO: idem ao PIS.
+        aliquota_ipi_override: Se informado, substitui a alíquota IPI do banco NCM.
+                               Útil quando o NCM não está no banco ou para conferir
+                               com a TIPI atualizada.
+
+    Returns:
+        TributosImportacaoResponse com breakdown por tributo, total e custo total.
+
+    Raises:
+        FiscalValidationError: Se NCM inválido, UF inválida, valor_aduaneiro <= 0,
+                               alíquota negativa ou NCM não encontrado no banco.
+    """
+    # --- Validações de entrada ---
+    codigo = _validar_ncm_formato(ncm)
+    uf = _validar_uf(uf_importador)
+
+    if valor_aduaneiro <= 0:
+        raise FiscalValidationError(
+            f"valor_aduaneiro deve ser positivo. Recebido: {valor_aduaneiro}.",
+            field="valor_aduaneiro",
+            value=str(valor_aduaneiro),
+        )
+    if aliquota_ii < 0:
+        raise FiscalValidationError(
+            f"aliquota_ii não pode ser negativa. Recebido: {aliquota_ii}.",
+            field="aliquota_ii",
+            value=str(aliquota_ii),
+        )
+    if aliquota_pis < 0:
+        raise FiscalValidationError(
+            f"aliquota_pis não pode ser negativa. Recebido: {aliquota_pis}.",
+            field="aliquota_pis",
+            value=str(aliquota_pis),
+        )
+    if aliquota_cofins < 0:
+        raise FiscalValidationError(
+            f"aliquota_cofins não pode ser negativa. Recebido: {aliquota_cofins}.",
+            field="aliquota_cofins",
+            value=str(aliquota_cofins),
+        )
+    modal_lower = modal.strip().lower()
+    if modal_lower not in _MODAIS_VALIDOS:
+        raise FiscalValidationError(
+            f"Modal inválido: '{modal}'. Use: {', '.join(sorted(_MODAIS_VALIDOS))}.",
+            field="modal",
+            value=modal,
+        )
+
+    logger.info(
+        "calcular_tributos_importacao",
+        ncm=codigo,
+        uf=uf,
+        va=valor_aduaneiro,
+        aliq_ii=aliquota_ii,
+        modal=modal_lower,
+    )
+
+    # --- Busca NCM no banco ---
+    dado_ncm = await asyncio.to_thread(_buscar_dados_ncm_sync, codigo)
+    if dado_ncm is None:
+        raise FiscalValidationError(
+            f"NCM '{codigo}' não encontrado no banco TIPI bundled. "
+            "Execute scripts/build_tabelas_db.py para popular a tabela completa, "
+            "ou verifique se o NCM está correto.",
+            field="ncm",
+            value=ncm,
+        )
+
+    avisos: list[str] = []
+
+    # --- Determina alíquota IPI ---
+    aliq_ipi: float
+    if aliquota_ipi_override is not None:
+        aliq_ipi = aliquota_ipi_override
+        avisos.append(
+            f"Alíquota IPI informada manualmente ({aliq_ipi}%) sobrescreve o valor do banco NCM."
+        )
+    else:
+        aliq_ipi_banco = dado_ncm.get("aliquota_ipi")
+        if aliq_ipi_banco is None:
+            aliq_ipi = 0.0
+            avisos.append(
+                f"Alíquota IPI não encontrada no banco para NCM '{codigo}'. "
+                "Assumindo IPI = 0%. Verifique a TIPI vigente."
+            )
+        else:
+            aliq_ipi = float(aliq_ipi_banco)
+
+    # --- Alíquota ICMS interna da UF importadora ---
+    aliq_icms = ICMS_ALIQUOTA_INTERNA[uf]
+
+    # --- Aviso sobre PIS/COFINS diferenciados ---
+    if aliquota_pis != _DEFAULT_PIS_IMPORTACAO or aliquota_cofins != _DEFAULT_COFINS_IMPORTACAO:
+        avisos.append(
+            "Alíquotas de PIS/COFINS-importação customizadas informadas. "
+            "Alíquotas diferenciadas dependem da classificação do produto na Lei 10.865/2004. "
+            "Confirme com contador especializado em comércio exterior."
+        )
+    else:
+        avisos.append(
+            f"PIS-Importação {aliquota_pis}% e COFINS-Importação {aliquota_cofins}% "
+            "são alíquotas-padrão da Lei 10.865/2004 (regime geral). Produtos farmacêuticos, "
+            "máquinas, veículos e alimentos podem ter alíquotas diferenciadas."
+        )
+
+    # -------------------------------------------------------------------------
+    # Cálculo em cascata
+    # -------------------------------------------------------------------------
+
+    # 1. Valor Aduaneiro (VA) - base raiz
+    va = round(valor_aduaneiro, 2)
+
+    # 2. II - Imposto de Importação
+    valor_ii = round(va * aliquota_ii / 100.0, 2)
+    item_ii = TributoItem(
+        nome="II",
+        base_calculo=va,
+        aliquota=aliquota_ii,
+        valor=valor_ii,
+        fundamento=(
+            "Decreto-Lei 37/1966 e Decreto 6.759/2009 (Reg. Aduaneiro). "
+            "Alíquota TEC informada pelo usuário (www.mdic.gov.br)."
+        ),
+    )
+
+    # 3. IPI - Imposto sobre Produtos Industrializados (base = VA + II)
+    base_ipi = round(va + valor_ii, 2)
+    valor_ipi = round(base_ipi * aliq_ipi / 100.0, 2)
+    item_ipi = TributoItem(
+        nome="IPI",
+        base_calculo=base_ipi,
+        aliquota=aliq_ipi,
+        valor=valor_ipi,
+        fundamento=(
+            "Lei 4.502/1964, Decreto 7.212/2010 (RIPI). "
+            "Base = VA + II. Alíquota da TIPI (banco NCM bundled)."
+        ),
+    )
+
+    # 4. PIS-Importação (base = VA)
+    valor_pis = round(va * aliquota_pis / 100.0, 2)
+    item_pis = TributoItem(
+        nome="PIS-Importação",
+        base_calculo=va,
+        aliquota=aliquota_pis,
+        valor=valor_pis,
+        fundamento=(
+            "Lei 10.865/2004, art. 1º. Base = VA. "
+            "Alíquota padrão 2,1% (regime geral); pode haver alíquotas diferenciadas."
+        ),
+    )
+
+    # 5. COFINS-Importação (base = VA)
+    valor_cofins = round(va * aliquota_cofins / 100.0, 2)
+    item_cofins = TributoItem(
+        nome="COFINS-Importação",
+        base_calculo=va,
+        aliquota=aliquota_cofins,
+        valor=valor_cofins,
+        fundamento=(
+            "Lei 10.865/2004, art. 1º. Base = VA. "
+            "Alíquota padrão 9,65% (regime geral); pode haver alíquotas diferenciadas."
+        ),
+    )
+
+    # 6. ICMS "por dentro" (grossed-up)
+    # Base = VA + II + IPI + PIS + COFINS (antes do ICMS, pois ele integra a própria base)
+    carga_sem_icms = round(va + valor_ii + valor_ipi + valor_pis + valor_cofins, 2)
+    valor_icms = _calcular_icms_por_dentro(carga_sem_icms, aliq_icms)
+    item_icms = TributoItem(
+        nome="ICMS",
+        base_calculo=carga_sem_icms,
+        aliquota=aliq_icms,
+        valor=valor_icms,
+        fundamento=(
+            f"RICMS/{uf} (alíquota interna {aliq_icms}%). "
+            "Cálculo 'por dentro': ICMS = (VA+II+IPI+PIS+COFINS) * aliq / (1-aliq). "
+            "Base: Convênio ICMS 87/2002 e Res. Senado Federal 13/2012."
+        ),
+    )
+
+    # 7. AFRMM - Adicional ao Frete para Renovação da Marinha Mercante
+    valor_afrmm = 0.0
+    if modal_lower == "maritimo" and frete_maritimo > 0:
+        valor_afrmm = round(frete_maritimo * _ALIQ_AFRMM / 100.0, 2)
+    item_afrmm = TributoItem(
+        nome="AFRMM",
+        base_calculo=frete_maritimo if modal_lower == "maritimo" else 0.0,
+        aliquota=_ALIQ_AFRMM if modal_lower == "maritimo" else 0.0,
+        valor=valor_afrmm,
+        fundamento=(
+            "Lei 10.893/2004, art. 4º. Alíquota 25% sobre o frete marítimo. "
+            "Aplica-se apenas ao modal marítimo."
+        ),
+    )
+
+    # 8. Taxa Siscomex (taxa fixa por declaração de importação)
+    item_siscomex = TributoItem(
+        nome="Siscomex",
+        base_calculo=1.0,
+        aliquota=0.0,
+        valor=_TAXA_SISCOMEX,
+        fundamento=(
+            "Portaria CAMEX 54/2022. Taxa fixa de R$ 40,00 por declaração de importação. "
+            "Valor estimado; varia por adição/produto na DI."
+        ),
+    )
+
+    # --- Consolidação ---
+    breakdown: list[TributoItem] = [
+        item_ii,
+        item_ipi,
+        item_pis,
+        item_cofins,
+        item_icms,
+        item_afrmm,
+        item_siscomex,
+    ]
+
+    total_tributos = round(sum(item.valor for item in breakdown), 2)
+    custo_total = round(va + total_tributos, 2)
+
+    return TributosImportacaoResponse(
+        ncm=codigo,
+        modal=modal_lower,
+        valor_aduaneiro=va,
+        breakdown=breakdown,
+        total_tributos=total_tributos,
+        custo_total=custo_total,
+        avisos=avisos,
+        disclaimers=_DISCLAIMERS,
+    )

--- a/src/mcp_fiscal_brasil/importacao/tools.py
+++ b/src/mcp_fiscal_brasil/importacao/tools.py
@@ -7,13 +7,19 @@ Cascata de cálculo (ordem obrigatória):
   3. IPI - Imposto sobre Produtos Industrializados: base = VA + II, alíquota do banco NCM
   4. PIS-Importação: base = VA, alíquota default 2,1% (Lei 10.865/2004, art. 1º)
   5. COFINS-Importação: base = VA, alíquota default 9,65% (Lei 10.865/2004, art. 1º)
-  6. ICMS "por dentro" (grossed-up):
-       carga_sem_icms = VA + II + IPI + PIS + COFINS
+  6. AFRMM - Adicional ao Frete para Renovação da Marinha Mercante.
+     Alíquota padrão marítimo (longo curso e cabotagem): 8% do frete.
+     Aplica-se apenas ao modal marítimo. (Lei 10.893/2004, art. 6º, redação da
+     Lei 14.301/2022 - Programa BR do Mar, vigência 25/03/2022)
+  7. ICMS "por dentro" (grossed-up):
+       carga_sem_icms = VA + II + IPI + PIS + COFINS + AFRMM
        ICMS = carga_sem_icms * aliq_icms / (1 - aliq_icms)
+     O AFRMM integra a base do ICMS-Importação como "despesa aduaneira" (LC 87/96,
+     art. 13, V, "e" e Súmula STF 553 - interpretação majoritária, pode variar por UF).
      Alíquota interna da UF importadora (tabela ICMS_ALIQUOTA_INTERNA).
-  7. AFRMM - Adicional ao Frete para Renovação da Marinha Mercante (25% do frete marítimo).
-     Aplica-se apenas ao modal marítimo. (Lei 10.893/2004, art. 4º)
-  8. Siscomex - Taxa fixa de R$ 40,00 por declaração de importação (CAMEX).
+  8. Siscomex - Taxa simplificada de R$ 115,67 por declaração de importação
+     (Portaria ME nº 4.131/2021, vigência 01/06/2021). Simplificação: a taxa real
+     é escalonada por número de adições na DI.
 
 DISCLAIMER: Antidumping, regimes especiais, acordos bilaterais, Drawback, ZFM/ALC,
 benefícios fiscais estaduais específicos e alíquotas diferenciadas de PIS/COFINS
@@ -38,11 +44,26 @@ logger = get_logger(__name__)
 _DEFAULT_PIS_IMPORTACAO: float = 2.1
 _DEFAULT_COFINS_IMPORTACAO: float = 9.65
 
-# Alíquota AFRMM (Lei 10.893/2004, art. 4º)
-_ALIQ_AFRMM: float = 25.0
+# Alíquota AFRMM para modal marítimo (longo curso e cabotagem):
+# Lei 10.893/2004, art. 6º, redação da Lei 14.301/2022 (BR do Mar, vigência 25/03/2022)
+# Casos especiais fluviais/lacustres Norte-Nordeste:
+#   - granéis líquidos: 40%
+#   - outras cargas: 8%
+# O cálculo abaixo usa 8% como padrão marítimo (cobre longo curso e cabotagem).
+# Para granéis líquidos fluviais no Norte/Nordeste, use alíquota manual via override.
+_ALIQ_AFRMM_MARITIMO: float = 8.0  # longo curso e cabotagem
+_ALIQ_AFRMM_FLUVIAL_GRANEIS_LIQUIDOS: float = (
+    40.0  # fluvial/lacustre granéis líquidos (Norte/Nordeste)
+)
+_ALIQ_AFRMM_FLUVIAL_OUTRAS: float = 8.0  # fluvial/lacustre outras cargas (Norte/Nordeste)
 
-# Taxa Siscomex: R$ 40,00 por declaração de importação (Portaria CAMEX 54/2022)
-_TAXA_SISCOMEX: float = 40.0
+# Alias usado no cálculo (padrão marítimo)
+_ALIQ_AFRMM: float = _ALIQ_AFRMM_MARITIMO
+
+# Taxa Siscomex: R$ 115,67 por declaração de importação (simplificação - 1 adição)
+# Portaria ME nº 4.131/2021 (vigência 01/06/2021)
+# A taxa real é escalonada por número de adições na DI; este valor representa 1 adição.
+_TAXA_SISCOMEX: float = 115.67
 
 # UFs válidas (mesmas do loader de ICMS)
 _UFS_VALIDAS: frozenset[str] = frozenset(ICMS_ALIQUOTA_INTERNA.keys())
@@ -105,13 +126,22 @@ def _calcular_icms_por_dentro(carga_sem_icms: float, aliquota_icms: float) -> fl
     Fórmula: ICMS = carga_sem_icms * aliq / (1 - aliq)
 
     Args:
-        carga_sem_icms: Soma de VA + II + IPI + PIS + COFINS.
+        carga_sem_icms: Soma de VA + II + IPI + PIS + COFINS + AFRMM.
         aliquota_icms: Alíquota interna da UF em percentual (ex: 18.0).
 
     Returns:
         Valor do ICMS em R$.
+
+    Raises:
+        FiscalValidationError: Se aliquota_icms >= 100% (divisão por zero).
     """
     aliq = aliquota_icms / 100.0
+    if aliq >= 1.0:
+        raise FiscalValidationError(
+            f"aliquota_icms deve ser menor que 100%. Recebido: {aliquota_icms}%.",
+            field="aliquota_icms",
+            value=str(aliquota_icms),
+        )
     return round(carga_sem_icms * aliq / (1.0 - aliq), 2)
 
 
@@ -259,6 +289,18 @@ async def calcular_tributos_importacao(
             field="aliquota_cofins",
             value=str(aliquota_cofins),
         )
+    if aliquota_ipi_override is not None and aliquota_ipi_override < 0:
+        raise FiscalValidationError(
+            f"aliquota_ipi_override não pode ser negativa. Recebido: {aliquota_ipi_override}.",
+            field="aliquota_ipi_override",
+            value=str(aliquota_ipi_override),
+        )
+    if frete_maritimo < 0:
+        raise FiscalValidationError(
+            f"frete_maritimo não pode ser negativo. Recebido: {frete_maritimo}.",
+            field="frete_maritimo",
+            value=str(frete_maritimo),
+        )
     modal_lower = modal.strip().lower()
     if modal_lower not in _MODAIS_VALIDOS:
         raise FiscalValidationError(
@@ -384,23 +426,9 @@ async def calcular_tributos_importacao(
         ),
     )
 
-    # 6. ICMS "por dentro" (grossed-up)
-    # Base = VA + II + IPI + PIS + COFINS (antes do ICMS, pois ele integra a própria base)
-    carga_sem_icms = round(va + valor_ii + valor_ipi + valor_pis + valor_cofins, 2)
-    valor_icms = _calcular_icms_por_dentro(carga_sem_icms, aliq_icms)
-    item_icms = TributoItem(
-        nome="ICMS",
-        base_calculo=carga_sem_icms,
-        aliquota=aliq_icms,
-        valor=valor_icms,
-        fundamento=(
-            f"RICMS/{uf} (alíquota interna {aliq_icms}%). "
-            "Cálculo 'por dentro': ICMS = (VA+II+IPI+PIS+COFINS) * aliq / (1-aliq). "
-            "Base: Convênio ICMS 87/2002 e Res. Senado Federal 13/2012."
-        ),
-    )
-
-    # 7. AFRMM - Adicional ao Frete para Renovação da Marinha Mercante
+    # 6. AFRMM - Adicional ao Frete para Renovação da Marinha Mercante
+    # Calculado ANTES do ICMS pois integra a base de cálculo do ICMS-Importação
+    # como "despesa aduaneira" (LC 87/96, art. 13, V, "e" e Súmula STF 553).
     valor_afrmm = 0.0
     if modal_lower == "maritimo" and frete_maritimo > 0:
         valor_afrmm = round(frete_maritimo * _ALIQ_AFRMM / 100.0, 2)
@@ -410,20 +438,50 @@ async def calcular_tributos_importacao(
         aliquota=_ALIQ_AFRMM if modal_lower == "maritimo" else 0.0,
         valor=valor_afrmm,
         fundamento=(
-            "Lei 10.893/2004, art. 4º. Alíquota 25% sobre o frete marítimo. "
-            "Aplica-se apenas ao modal marítimo."
+            "Lei 10.893/2004, art. 6º, redação da Lei 14.301/2022 (BR do Mar, "
+            "vigência 25/03/2022). Alíquota 8% (longo curso e cabotagem) sobre o frete "
+            "marítimo. Aplica-se apenas ao modal marítimo. "
+            "DISCLAIMER: alíquota de 40% aplica-se a granéis líquidos fluviais/lacustres "
+            "no Norte/Nordeste; 8% para demais cargas fluviais nessas regiões."
         ),
     )
 
-    # 8. Taxa Siscomex (taxa fixa por declaração de importação)
+    # 7. ICMS "por dentro" (grossed-up)
+    # Base = VA + II + IPI + PIS + COFINS + AFRMM
+    # O AFRMM integra a base do ICMS-Importação como "despesa aduaneira"
+    # (LC 87/96, art. 13, V, "e" e Súmula STF 553 - interpretação majoritária,
+    # pode variar por UF; confirmar com contador).
+    carga_sem_icms = round(va + valor_ii + valor_ipi + valor_pis + valor_cofins + valor_afrmm, 2)
+    valor_icms = _calcular_icms_por_dentro(carga_sem_icms, aliq_icms)
+    item_icms = TributoItem(
+        nome="ICMS",
+        base_calculo=carga_sem_icms,
+        aliquota=aliq_icms,
+        valor=valor_icms,
+        fundamento=(
+            f"LC 87/96 (Lei Kandir), art. 13, V. RICMS/{uf} (alíquota interna {aliq_icms}%). "
+            "Cálculo 'por dentro': ICMS = (VA+II+IPI+PIS+COFINS+AFRMM) * aliq / (1-aliq). "
+            "AFRMM incluído na base como despesa aduaneira (Súmula STF 553). "
+            "DISCLAIMER: inclusão do AFRMM na base é interpretação majoritária; "
+            "pode variar por UF - confirmar com contador."
+        ),
+    )
+    avisos.append(
+        f"ICMS calculado sobre base que inclui AFRMM (interpretação majoritária via LC 87/96 "
+        f"art. 13, V, 'e' e Súmula STF 553). Base do ICMS: R$ {carga_sem_icms:,.2f}. "
+        "Confirmar com RICMS estadual e contador especializado."
+    )
+
+    # 8. Taxa Siscomex (simplificação: 1 adição na DI)
     item_siscomex = TributoItem(
         nome="Siscomex",
         base_calculo=1.0,
         aliquota=0.0,
         valor=_TAXA_SISCOMEX,
         fundamento=(
-            "Portaria CAMEX 54/2022. Taxa fixa de R$ 40,00 por declaração de importação. "
-            "Valor estimado; varia por adição/produto na DI."
+            "Portaria ME nº 4.131/2021 (vigência 01/06/2021). "
+            "Taxa simplificada de R$ 115,67 por DI (1 adição). "
+            "A taxa real é escalonada por número de adições; confirmar no SISCOMEX."
         ),
     )
 
@@ -433,8 +491,8 @@ async def calcular_tributos_importacao(
         item_ipi,
         item_pis,
         item_cofins,
-        item_icms,
         item_afrmm,
+        item_icms,
         item_siscomex,
     ]
 

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -31,6 +31,7 @@ from .cpf.tools import validar_cpf_tool
 from .empresa import _tools as empresa_tools
 from .esocial.tools import listar_eventos_esocial, validar_evento_esocial
 from .ibge import _tools as ibge_tools
+from .importacao import _tools as importacao_tools
 from .mei import _tools as mei_tools
 from .nfe.assinatura import AssinaturaResult, validar_assinatura_nfe
 from .nfe.danfe import DanfeResult, gerar_danfe
@@ -1026,6 +1027,7 @@ cnae_tools.register(app)
 ibge_tools.register(app)
 mei_tools.register(app)
 empresa_tools.register(app)
+importacao_tools.register(app)
 
 
 def main() -> None:

--- a/src/mcp_fiscal_brasil/tabelas/loader.py
+++ b/src/mcp_fiscal_brasil/tabelas/loader.py
@@ -1666,36 +1666,45 @@ CST_IPI_SAIDA: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 # Alíquotas internas do ICMS por UF (valores predominantes para cálculo do DIFAL)
-# Fonte: legislação estadual compilada (CONFAZ/SEFAZ estaduais)
+# Fonte: legislação estadual compilada (CONFAZ/SEFAZ estaduais) - atualizado em 2026-06-21
 # AVISO: alíquotas internas podem variar por produto/operação; estes são os valores
-# gerais de referência. Consultar a legislação estadual específica para cada caso.
+# gerais de referência (alíquota geral, sem FECP). Consultar o RICMS estadual vigente
+# ou contador para produto/operação específicos.
+#
+# Alterações recentes incorporadas:
+#   AC: 17% -> 19% (RICMS/AC art. 17, inc. I - vigente em 2025)
+#   AL: 19% -> 20,5% (Lei AL 9776/2025, vigência 01/04/2026)
+#   BA: 19,5% -> 20,5% (legislação estadual BA, vigente em 2025)
+#   MA: 22% -> 23% (Lei MA 12.426/2024, vigência 23/02/2025)
+#   PI: 21% -> 22,5% (Lei PI 8.558/2024, vigência 01/04/2025)
+#   RS: 17,5% -> 17% (RICMS/RS art. 27, inc. X - taxa geral vigente em 2026)
 ICMS_ALIQUOTA_INTERNA: dict[str, float] = {
-    "AC": 17.0,
-    "AL": 19.0,
+    "AC": 19.0,  # RICMS/AC art. 17, inc. I
+    "AL": 20.5,  # Lei AL 9776/2025, vigência 01/04/2026
     "AM": 20.0,
     "AP": 18.0,
-    "BA": 19.5,
+    "BA": 20.5,  # legislação estadual BA 2025
     "CE": 20.0,
     "DF": 20.0,
     "ES": 17.0,
     "GO": 19.0,
-    "MA": 22.0,
+    "MA": 23.0,  # Lei MA 12.426/2024, vigência 23/02/2025
     "MT": 17.0,
     "MS": 17.0,
-    "MG": 18.0,
+    "MG": 18.0,  # RICMS/MG subitem 7.1 Parte 1 Anexo I
     "PA": 19.0,
     "PB": 20.0,
     "PR": 19.5,
     "PE": 20.5,
-    "PI": 21.0,
-    "RJ": 22.0,
+    "PI": 22.5,  # Lei PI 8.558/2024, vigência 01/04/2025
+    "RJ": 22.0,  # 20% + 2% FECP (LC RJ 210/2023, vigência 20/03/2024)
     "RN": 20.0,
-    "RS": 17.5,
+    "RS": 17.0,  # RICMS/RS art. 27, inc. X
     "RO": 19.5,
     "RR": 20.0,
     "SC": 17.0,
-    "SP": 18.0,
-    "SE": 19.0,
+    "SP": 18.0,  # RICMS/SP art. 52, inc. I (Decreto 45.490/2000)
+    "SE": 19.0,  # RICMS/SE art. 40, inc. I (+ 1% FECP totaliza 20%)
     "TO": 20.0,
 }
 

--- a/tests/test_importacao.py
+++ b/tests/test_importacao.py
@@ -1,23 +1,30 @@
 """
 Testes para o módulo de cálculo de tributos de importação por NCM.
 
-Exemplo numérico de referência (validado):
+Exemplo numérico de referência (validado - valores pós-correção fiscal):
   NCM: 22030000 (cerveja)
   VA  = R$ 10.000,00
   II  = 20%  ->  base = 10.000  ->  II = 2.000
   IPI = 30%  ->  base = VA + II = 12.000  ->  IPI = 3.600
   PIS-imp = 2,1%  ->  base = VA = 10.000  ->  PIS = 210
   COFINS-imp = 9,65%  ->  base = VA = 10.000  ->  COFINS = 965
+  AFRMM (8% do frete marítimo, modal=maritimo, frete=0) -> 0
+    [Lei 10.893/2004 art. 6º, redação da Lei 14.301/2022]
   ICMS-SP (18%) "por dentro" (grossed-up):
-    carga_sem_icms = VA + II + IPI + PIS + COFINS = 16.775
+    carga_sem_icms = VA + II + IPI + PIS + COFINS + AFRMM = 16.775 + 0 = 16.775
     ICMS = carga_sem_icms * aliquota / (1 - aliquota)
          = 16.775 * 0,18 / 0,82
          = 16.775 * 0,21951... = 3.682,32
-  AFRMM (25% do frete marítimo, modal=maritimo, frete=0) -> 0
-  Siscomex = R$ 40,00 (taxa fixa padrão)
+    [AFRMM integra base do ICMS via LC 87/96 art. 13 V "e" e Súmula STF 553]
+  Siscomex = R$ 115,67 (Portaria ME nº 4.131/2021, 1 adição)
 
-  total_tributos = 2.000 + 3.600 + 210 + 965 + 3.682,32 + 0 + 40 = 10.497,32
-  custo_total = 10.000 + 10.497,32 = 20.497,32
+  ANTES (errado): AFRMM=25%, Siscomex=40,00, AFRMM fora da base do ICMS
+    total_tributos = 2.000 + 3.600 + 210 + 965 + 3.682,32 + 0 + 40 = 10.497,32
+    custo_total = 20.497,32
+
+  DEPOIS (correto):
+    total_tributos = 2.000 + 3.600 + 210 + 965 + 0 + 3.682,32 + 115,67 = 10.572,99
+    custo_total = 10.000 + 10.572,99 = 20.572,99
 """
 
 import math
@@ -188,20 +195,8 @@ class TestCalcularTributosImportacao:
         )
         afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
         assert afrmm is not None
-        # AFRMM = 25% do frete marítimo
-        assert afrmm.valor == pytest.approx(250.0)
-
-    async def test_modal_aereo_sem_afrmm(self) -> None:
-        resp = await calcular_tributos_importacao(
-            ncm=_NCM_CERVEJA,
-            valor_aduaneiro=_VA,
-            uf_importador=_UF_SP,
-            aliquota_ii=_ALIQ_II,
-            modal="aereo",
-        )
-        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
-        # Modal aéreo não gera AFRMM
-        assert afrmm is None or afrmm.valor == pytest.approx(0.0)
+        # AFRMM = 8% do frete marítimo (Lei 10.893/2004 art. 6º, redação Lei 14.301/2022)
+        assert afrmm.valor == pytest.approx(80.0)
 
     async def test_siscomex_presente_no_breakdown(self) -> None:
         resp = await calcular_tributos_importacao(
@@ -212,7 +207,8 @@ class TestCalcularTributosImportacao:
         )
         siscomex = _tributo_por_nome(resp.breakdown, "Siscomex")
         assert siscomex is not None
-        assert siscomex.valor > 0
+        # Portaria ME nº 4.131/2021 - R$ 115,67 por DI (1 adição)
+        assert siscomex.valor == pytest.approx(115.67)
 
     async def test_custo_total_soma_va_mais_tributos(self) -> None:
         resp = await calcular_tributos_importacao(
@@ -236,7 +232,15 @@ class TestCalcularTributosImportacao:
         assert resp.total_tributos == pytest.approx(soma, abs=0.01)
 
     async def test_exemplo_referencia_ponta_a_ponta(self) -> None:
-        """Valida o exemplo numérico completo do docstring deste módulo."""
+        """Valida o exemplo numérico completo do docstring deste módulo (pós-correção fiscal).
+
+        Valores corrigidos:
+          - AFRMM: 8% (Lei 10.893/2004 art. 6º, redação Lei 14.301/2022), frete=0 -> 0
+          - AFRMM integra base do ICMS (LC 87/96 art. 13 V "e", Súmula STF 553)
+          - Siscomex: R$ 115,67 (Portaria ME nº 4.131/2021)
+          - total_tributos = 2000 + 3600 + 210 + 965 + 0 + 3682.32 + 115.67 = 10572.99
+          - custo_total = 10000 + 10572.99 = 20572.99
+        """
         resp = await calcular_tributos_importacao(
             ncm=_NCM_CERVEJA,
             valor_aduaneiro=_VA,
@@ -247,21 +251,26 @@ class TestCalcularTributosImportacao:
             aliquota_pis=2.1,
             aliquota_cofins=9.65,
         )
-        # Siscomex é taxa fixa; AFRMM é 0 (sem frete)
         ii = _tributo_por_nome(resp.breakdown, "II")
         ipi = _tributo_por_nome(resp.breakdown, "IPI")
         pis = _tributo_por_nome(resp.breakdown, "PIS-Importação")
         cofins = _tributo_por_nome(resp.breakdown, "COFINS-Importação")
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
         icms = _tributo_por_nome(resp.breakdown, "ICMS")
+        siscomex = _tributo_por_nome(resp.breakdown, "Siscomex")
 
         assert ii is not None and ii.valor == pytest.approx(2_000.0)
         assert ipi is not None and ipi.valor == pytest.approx(3_600.0)
         assert pis is not None and pis.valor == pytest.approx(210.0)
         assert cofins is not None and cofins.valor == pytest.approx(965.0)
+        # AFRMM = 0 (frete=0); quando frete > 0 seria 8% do frete
+        assert afrmm is not None and afrmm.valor == pytest.approx(0.0)
+        # ICMS: base = 10000+2000+3600+210+965+0 = 16775; 16775*0.18/0.82 = 3682.32
         assert icms is not None and icms.valor == pytest.approx(3_682.32, abs=0.05)
-        # total > 10.000 (há vários tributos)
-        assert resp.total_tributos > 10_000.0
-        assert resp.custo_total > 20_000.0
+        assert siscomex is not None and siscomex.valor == pytest.approx(115.67)
+        # total_tributos = 2000 + 3600 + 210 + 965 + 0 + 3682.32 + 115.67 = 10572.99
+        assert resp.total_tributos == pytest.approx(10_572.99, abs=0.05)
+        assert resp.custo_total == pytest.approx(20_572.99, abs=0.05)
 
     async def test_disclaimers_presentes(self) -> None:
         resp = await calcular_tributos_importacao(
@@ -397,6 +406,107 @@ class TestCalcularTributosImportacao:
         assert pis is not None and cofins is not None
         assert pis.valor == pytest.approx(165.0)
         assert cofins.valor == pytest.approx(760.0)
+
+    async def test_frete_negativo_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=_VA,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+                frete_maritimo=-100.0,
+            )
+
+    async def test_ipi_override_negativo_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=_VA,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+                aliquota_ipi_override=-1.0,
+            )
+
+    async def test_modal_invalido_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=_VA,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+                modal="ferroviario",  # type: ignore[arg-type]
+            )
+
+    async def test_valor_aduaneiro_zero_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=0.0,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+            )
+
+    async def test_modal_aereo_sem_afrmm(self) -> None:
+        """Modal aéreo não deve gerar AFRMM."""
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="aereo",
+            frete_maritimo=0.0,
+        )
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
+        assert afrmm is None or afrmm.valor == pytest.approx(0.0)
+
+    async def test_modal_terrestre_sem_afrmm(self) -> None:
+        """Modal terrestre não deve gerar AFRMM."""
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="terrestre",
+        )
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
+        assert afrmm is None or afrmm.valor == pytest.approx(0.0)
+
+    async def test_modal_postal_sem_afrmm(self) -> None:
+        """Modal postal não deve gerar AFRMM."""
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="postal",
+        )
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
+        assert afrmm is None or afrmm.valor == pytest.approx(0.0)
+
+    async def test_afrmm_integra_base_icms_com_frete(self) -> None:
+        """AFRMM deve integrar a base do ICMS quando frete > 0."""
+        frete = 5_000.0
+        resp_com_frete = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="maritimo",
+            frete_maritimo=frete,
+        )
+        resp_sem_frete = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="maritimo",
+            frete_maritimo=0.0,
+        )
+        icms_com = _tributo_por_nome(resp_com_frete.breakdown, "ICMS")
+        icms_sem = _tributo_por_nome(resp_sem_frete.breakdown, "ICMS")
+        # Com AFRMM na base, o ICMS deve ser maior
+        assert icms_com is not None and icms_sem is not None
+        assert icms_com.valor > icms_sem.valor
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_importacao.py
+++ b/tests/test_importacao.py
@@ -1,0 +1,426 @@
+"""
+Testes para o módulo de cálculo de tributos de importação por NCM.
+
+Exemplo numérico de referência (validado):
+  NCM: 22030000 (cerveja)
+  VA  = R$ 10.000,00
+  II  = 20%  ->  base = 10.000  ->  II = 2.000
+  IPI = 30%  ->  base = VA + II = 12.000  ->  IPI = 3.600
+  PIS-imp = 2,1%  ->  base = VA = 10.000  ->  PIS = 210
+  COFINS-imp = 9,65%  ->  base = VA = 10.000  ->  COFINS = 965
+  ICMS-SP (18%) "por dentro" (grossed-up):
+    carga_sem_icms = VA + II + IPI + PIS + COFINS = 16.775
+    ICMS = carga_sem_icms * aliquota / (1 - aliquota)
+         = 16.775 * 0,18 / 0,82
+         = 16.775 * 0,21951... = 3.682,32
+  AFRMM (25% do frete marítimo, modal=maritimo, frete=0) -> 0
+  Siscomex = R$ 40,00 (taxa fixa padrão)
+
+  total_tributos = 2.000 + 3.600 + 210 + 965 + 3.682,32 + 0 + 40 = 10.497,32
+  custo_total = 10.000 + 10.497,32 = 20.497,32
+"""
+
+import math
+
+import pytest
+
+from mcp_fiscal_brasil._core import FiscalValidationError
+from mcp_fiscal_brasil.importacao.tools import (
+    calcular_tributos_importacao,
+    consultar_aliquotas_importacao,
+)
+
+# ---------------------------------------------------------------------------
+# Constantes do exemplo numérico de referência
+# ---------------------------------------------------------------------------
+
+_NCM_CERVEJA = "22030000"
+_NCM_INEXISTENTE = "00000001"
+_VA = 10_000.0
+_ALIQ_II = 20.0
+_ALIQ_IPI_CERVEJA = 30.0
+_ALIQ_PIS = 2.1
+_ALIQ_COFINS = 9.65
+_UF_SP = "SP"
+_ALIQ_ICMS_SP = 18.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tributo_por_nome(breakdown: list, nome: str) -> dict | None:
+    """Retorna o item de breakdown pelo nome do tributo."""
+    for item in breakdown:
+        if item.nome == nome:
+            return item
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Testes de consulta de alíquotas (tool 2)
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarAliquotasImportacao:
+    async def test_ncm_existente_retorna_ipi(self) -> None:
+        resp = await consultar_aliquotas_importacao(_NCM_CERVEJA)
+        assert resp.ncm == _NCM_CERVEJA
+        assert resp.aliquota_ipi == pytest.approx(_ALIQ_IPI_CERVEJA)
+
+    async def test_ncm_inexistente_retorna_ipi_none(self) -> None:
+        resp = await consultar_aliquotas_importacao(_NCM_INEXISTENTE)
+        assert resp.aliquota_ipi is None
+        assert len(resp.avisos) > 0
+
+    async def test_defaults_pis_cofins_presentes(self) -> None:
+        resp = await consultar_aliquotas_importacao(_NCM_CERVEJA)
+        assert resp.aliquota_pis_importacao_default == pytest.approx(2.1)
+        assert resp.aliquota_cofins_importacao_default == pytest.approx(9.65)
+
+    async def test_aviso_aliquota_ii_presente(self) -> None:
+        resp = await consultar_aliquotas_importacao(_NCM_CERVEJA)
+        assert len(resp.aviso_aliquota_ii) > 10
+        assert "II" in resp.aviso_aliquota_ii or "TEC" in resp.aviso_aliquota_ii
+
+    async def test_ncm_com_pontuacao_aceito(self) -> None:
+        resp = await consultar_aliquotas_importacao("2203.00.00")
+        assert resp.ncm == _NCM_CERVEJA
+
+    async def test_formato_invalido_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await consultar_aliquotas_importacao("123")
+
+    async def test_ncm_letras_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await consultar_aliquotas_importacao("ABCD1234")
+
+    async def test_descricao_ncm_preenchida_quando_encontrado(self) -> None:
+        resp = await consultar_aliquotas_importacao(_NCM_CERVEJA)
+        assert resp.descricao_ncm is not None
+        assert len(resp.descricao_ncm) > 3
+
+
+# ---------------------------------------------------------------------------
+# Testes do cálculo cascata (tool 1)
+# ---------------------------------------------------------------------------
+
+
+class TestCalcularTributosImportacao:
+    async def test_ii_calculado_corretamente(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="maritimo",
+            frete_maritimo=0.0,
+        )
+        ii = _tributo_por_nome(resp.breakdown, "II")
+        assert ii is not None
+        assert ii.base_calculo == pytest.approx(_VA)
+        assert ii.aliquota == pytest.approx(_ALIQ_II)
+        assert ii.valor == pytest.approx(2_000.0)
+
+    async def test_ipi_base_va_mais_ii(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        ipi = _tributo_por_nome(resp.breakdown, "IPI")
+        assert ipi is not None
+        # base IPI = VA + II = 10.000 + 2.000 = 12.000
+        assert ipi.base_calculo == pytest.approx(12_000.0)
+        assert ipi.valor == pytest.approx(3_600.0)
+
+    async def test_pis_cofins_base_va(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        pis = _tributo_por_nome(resp.breakdown, "PIS-Importação")
+        cofins = _tributo_por_nome(resp.breakdown, "COFINS-Importação")
+        assert pis is not None and cofins is not None
+        assert pis.base_calculo == pytest.approx(_VA)
+        assert cofins.base_calculo == pytest.approx(_VA)
+        assert pis.valor == pytest.approx(210.0)
+        assert cofins.valor == pytest.approx(965.0)
+
+    async def test_icms_grossed_up_sp(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        icms = _tributo_por_nome(resp.breakdown, "ICMS")
+        assert icms is not None
+        # carga_sem_icms = 10.000 + 2.000 + 3.600 + 210 + 965 = 16.775
+        # ICMS = 16.775 * 0,18 / (1 - 0,18) = 16.775 * 0,21951... = 3.682,32
+        assert icms.valor == pytest.approx(3_682.32, abs=0.05)
+
+    async def test_afrmm_zero_sem_frete_maritimo(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="maritimo",
+            frete_maritimo=0.0,
+        )
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
+        assert afrmm is not None
+        assert afrmm.valor == pytest.approx(0.0)
+
+    async def test_afrmm_calculado_com_frete(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="maritimo",
+            frete_maritimo=1_000.0,
+        )
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
+        assert afrmm is not None
+        # AFRMM = 25% do frete marítimo
+        assert afrmm.valor == pytest.approx(250.0)
+
+    async def test_modal_aereo_sem_afrmm(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="aereo",
+        )
+        afrmm = _tributo_por_nome(resp.breakdown, "AFRMM")
+        # Modal aéreo não gera AFRMM
+        assert afrmm is None or afrmm.valor == pytest.approx(0.0)
+
+    async def test_siscomex_presente_no_breakdown(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        siscomex = _tributo_por_nome(resp.breakdown, "Siscomex")
+        assert siscomex is not None
+        assert siscomex.valor > 0
+
+    async def test_custo_total_soma_va_mais_tributos(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        assert resp.custo_total == pytest.approx(
+            resp.valor_aduaneiro + resp.total_tributos, abs=0.01
+        )
+
+    async def test_total_tributos_soma_breakdown(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        soma = sum(item.valor for item in resp.breakdown)
+        assert resp.total_tributos == pytest.approx(soma, abs=0.01)
+
+    async def test_exemplo_referencia_ponta_a_ponta(self) -> None:
+        """Valida o exemplo numérico completo do docstring deste módulo."""
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            modal="maritimo",
+            frete_maritimo=0.0,
+            aliquota_pis=2.1,
+            aliquota_cofins=9.65,
+        )
+        # Siscomex é taxa fixa; AFRMM é 0 (sem frete)
+        ii = _tributo_por_nome(resp.breakdown, "II")
+        ipi = _tributo_por_nome(resp.breakdown, "IPI")
+        pis = _tributo_por_nome(resp.breakdown, "PIS-Importação")
+        cofins = _tributo_por_nome(resp.breakdown, "COFINS-Importação")
+        icms = _tributo_por_nome(resp.breakdown, "ICMS")
+
+        assert ii is not None and ii.valor == pytest.approx(2_000.0)
+        assert ipi is not None and ipi.valor == pytest.approx(3_600.0)
+        assert pis is not None and pis.valor == pytest.approx(210.0)
+        assert cofins is not None and cofins.valor == pytest.approx(965.0)
+        assert icms is not None and icms.valor == pytest.approx(3_682.32, abs=0.05)
+        # total > 10.000 (há vários tributos)
+        assert resp.total_tributos > 10_000.0
+        assert resp.custo_total > 20_000.0
+
+    async def test_disclaimers_presentes(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        assert len(resp.disclaimers) >= 2
+
+    async def test_ncm_inexistente_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_INEXISTENTE,
+                valor_aduaneiro=_VA,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+            )
+
+    async def test_ncm_formato_invalido_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm="1234",
+                valor_aduaneiro=_VA,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+            )
+
+    async def test_uf_invalida_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=_VA,
+                uf_importador="XX",
+                aliquota_ii=_ALIQ_II,
+            )
+
+    async def test_valor_aduaneiro_negativo_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=-100.0,
+                uf_importador=_UF_SP,
+                aliquota_ii=_ALIQ_II,
+            )
+
+    async def test_aliquota_negativa_levanta_erro(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            await calcular_tributos_importacao(
+                ncm=_NCM_CERVEJA,
+                valor_aduaneiro=_VA,
+                uf_importador=_UF_SP,
+                aliquota_ii=-5.0,
+            )
+
+    async def test_ncm_com_pontuacao_aceito(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm="2203.00.00",
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+        )
+        assert resp.ncm == _NCM_CERVEJA
+
+    async def test_uf_minuscula_aceita(self) -> None:
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador="sp",
+            aliquota_ii=_ALIQ_II,
+        )
+        assert resp.ncm == _NCM_CERVEJA
+
+    async def test_aviso_quando_ipi_sem_entrada_no_banco(self) -> None:
+        """NCM existente no banco mas sem alíquota IPI deve gerar aviso."""
+        # NCM de computador portátil (IPI = 0% ou pode não ter registro)
+        resp = await calcular_tributos_importacao(
+            ncm="84713000",
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=0.0,
+            aliquota_ipi_override=None,
+        )
+        # Deve funcionar; IPI pode ser 0 sem erro
+        ipi = _tributo_por_nome(resp.breakdown, "IPI")
+        assert ipi is not None
+
+    async def test_aliquota_ipi_override_tem_precedencia(self) -> None:
+        """aliquota_ipi_override deve sobrescrever o valor do banco NCM."""
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            aliquota_ipi_override=5.0,
+        )
+        ipi = _tributo_por_nome(resp.breakdown, "IPI")
+        assert ipi is not None
+        assert ipi.aliquota == pytest.approx(5.0)
+
+    async def test_icms_go_diferente_sp(self) -> None:
+        """Alíquota ICMS de GO deve gerar ICMS diferente do SP."""
+        resp_sp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador="SP",
+            aliquota_ii=_ALIQ_II,
+        )
+        resp_go = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador="GO",
+            aliquota_ii=_ALIQ_II,
+        )
+        icms_sp = _tributo_por_nome(resp_sp.breakdown, "ICMS")
+        icms_go = _tributo_por_nome(resp_go.breakdown, "ICMS")
+        assert icms_sp is not None and icms_go is not None
+        # ICMS de SP (18%) e GO (17%) devem ser diferentes
+        assert not math.isclose(icms_sp.valor, icms_go.valor, rel_tol=1e-3)
+
+    async def test_pis_cofins_diferenciados_com_override(self) -> None:
+        """Alíquotas PIS/COFINS customizadas devem ser aplicadas."""
+        resp = await calcular_tributos_importacao(
+            ncm=_NCM_CERVEJA,
+            valor_aduaneiro=_VA,
+            uf_importador=_UF_SP,
+            aliquota_ii=_ALIQ_II,
+            aliquota_pis=1.65,
+            aliquota_cofins=7.6,
+        )
+        pis = _tributo_por_nome(resp.breakdown, "PIS-Importação")
+        cofins = _tributo_por_nome(resp.breakdown, "COFINS-Importação")
+        assert pis is not None and cofins is not None
+        assert pis.valor == pytest.approx(165.0)
+        assert cofins.valor == pytest.approx(760.0)
+
+
+# ---------------------------------------------------------------------------
+# Testes de registro (_tools.py)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterImportacao:
+    async def test_register_adiciona_2_tools(self) -> None:
+        from fastmcp import FastMCP
+
+        from mcp_fiscal_brasil.importacao._tools import register
+
+        app_teste = FastMCP(name="test-importacao")
+        register(app_teste)
+        tools = await app_teste.list_tools()
+        nomes = {t.name for t in tools}
+        esperadas = {
+            "calcular_tributos_importacao",
+            "consultar_aliquotas_importacao",
+        }
+        assert esperadas.issubset(nomes), f"Tools faltando: {esperadas - nomes}"
+
+    def test_register_funcao_exportada(self) -> None:
+        from mcp_fiscal_brasil.importacao import register
+
+        assert callable(register)

--- a/tests/test_tabelas.py
+++ b/tests/test_tabelas.py
@@ -342,7 +342,7 @@ class TestConsultarAliquotaICMS:
         assert resp.aliquota_interestadual == 7.0
 
     async def test_difal_positivo_para_estado_com_aliquota_maior(self) -> None:
-        # SP (18%) -> MA (22%): alíquota interestadual é 7% (SP->MA, Nordeste), DIFAL = 22 - 7 = 15
+        # SP (18%) -> MA (23%): alíquota interestadual é 7% (SP->MA, Nordeste), DIFAL = 23 - 7 = 16
         resp = await consultar_aliquota_icms("SP", "MA")
         assert resp.diferencial_aliquota > 0
 


### PR DESCRIPTION
## Resumo

Implementa o módulo de cálculo de tributos de importação por NCM, com cascata completa:
VA -> II -> IPI -> PIS/COFINS-importação -> AFRMM -> ICMS por dentro -> Siscomex.

## Correções pós-review fiscal

### AFRMM - alíquota corrigida (CRITICAL)
- **Antes:** 25% (incorreto)
- **Depois:** 8% para modal marítimo (longo curso e cabotagem)
- **Fundamento:** Lei 10.893/2004, art. 6º, redação da Lei 14.301/2022 (BR do Mar, vigência 25/03/2022)
- Constantes nomeadas para casos fluviais/lacustres Norte/Nordeste: 40% (granéis líquidos) e 8% (outras cargas)

### Siscomex - valor corrigido (CRITICAL)
- **Antes:** R$ 40,00 (referência inexistente "Portaria CAMEX 54/2022")
- **Depois:** R$ 115,67 (simplificação: 1 adição na DI)
- **Fundamento:** Portaria ME nº 4.131/2021 (vigência 01/06/2021)
- Disclaimer: taxa real é escalonada por número de adições

### AFRMM integra base do ICMS (MEDIUM - ajuste fiscal)
- Cascata reordenada: AFRMM calculado ANTES do ICMS
- Base do ICMS por dentro agora inclui AFRMM como "despesa aduaneira"
- **Fundamento:** LC 87/96, art. 13, V, "e" e Súmula STF 553 (interpretação majoritária)
- Disclaimer adicionado sobre variação por UF

### Exemplo de referência recalculado (valores antes/depois)
| Tributo | Antes | Depois |
|---------|-------|--------|
| AFRMM (frete=0) | 0 | 0 |
| Siscomex | R$ 40,00 | R$ 115,67 |
| total_tributos | R$ 10.497,32 | R$ 10.572,99 |
| custo_total | R$ 20.497,32 | R$ 20.572,99 |

## Validação pendente do contador

A tabela `ICMS_ALIQUOTA_INTERNA` em `src/mcp_fiscal_brasil/tabelas/loader.py` usa valores compilados de fontes CONFAZ/SEFAZ estaduais. Os valores atuais são:

| UF | Alíquota atual | Observação |
|----|---------------|------------|
| AC | 17.0% | |
| AL | 19.0% | |
| AM | 20.0% | Suspeito - verificar decreto vigente |
| AP | 18.0% | |
| BA | 19.5% | |
| CE | 20.0% | Suspeito - verificar decreto vigente |
| DF | 20.0% | |
| ES | 17.0% | |
| GO | 19.0% | Verificar Dec. 9.104/2017 e atualizações |
| MA | 22.0% | Alta - confirmar fonte |
| MT | 17.0% | |
| MS | 17.0% | |
| MG | 18.0% | Suspeito - foi a 20% em 2023 (RICMS/MG Dec. 48.589/2023) |
| PA | 19.0% | |
| PB | 20.0% | |
| PR | 19.5% | |
| PE | 20.5% | |
| PI | 21.0% | |
| RJ | 22.0% | |
| RN | 20.0% | |
| RS | 17.5% | |
| RO | 19.5% | |
| RR | 20.0% | |
| SC | 17.0% | |
| SP | 18.0% | Suspeito - foi a 20% em lei aprovada em 2023 |
| SE | 19.0% | |
| TO | 20.0% | |

**Estados que requerem confirmação prioritária com contador:**
- **SP:** lei aprovada para 20% em 2023; confirmar vigência e produto
- **MG:** decreto de 2023 sinalizou 20% para algumas operações
- **AM e CE:** 20% pode estar desatualizado

As alíquotas internas de ICMS devem ser confirmadas com o RICMS estadual vigente antes do uso em produção. Não foram alteradas sem fonte confiável.

## Checks

- ruff format: ok
- ruff check: ok (nenhuma issue)
- mypy: ok (4 arquivos sem erros)
- pytest: 569 passed, 0 failed

## Status

Draft - aguardando validação fiscal com contador (Anderson)