### PR TITLE
docs: secao Como acompanhar (Discussions, releases, newsletter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,18 @@ ReceitaWS       estaduais municipais Federal  local   local  governamentais
 
 ---
 
+## Como acompanhar
+
+[![GitHub Discussions](https://img.shields.io/github/discussions/DeHor-Labs/mcp-fiscal-brasil)](https://github.com/DeHor-Labs/mcp-fiscal-brasil/discussions)
+[![GitHub Stars](https://img.shields.io/github/stars/DeHor-Labs/mcp-fiscal-brasil)](https://github.com/DeHor-Labs/mcp-fiscal-brasil/stargazers)
+
+- **Releases**: clique em **Watch -> Releases** no topo do repositório para ser notificado a cada versão nova
+- **Discussions**: [github.com/DeHor-Labs/mcp-fiscal-brasil/discussions](https://github.com/DeHor-Labs/mcp-fiscal-brasil/discussions) - canal para sugestões de feature, dúvidas fiscais e técnicas, e casos de uso. Sugestões feitas aqui entram no roadmap de verdade
+- **Newsletter**: acompanhe os releases comentados na LinkedIn Newsletter mcp-fiscal-brasil <!-- TODO: inserir link da newsletter LinkedIn apos criacao --> - cada numero explica o que chegou, o que foi corrigido e o que vem por ai
+- **Issues**: bugs com contexto completo (versão, XML de exemplo sem dados reais, comportamento esperado vs. obtido)
+
+---
+
 ## 🤝 Contribuindo
 
 Contribuições são bem-vindas!


### PR DESCRIPTION
Adiciona a seção **Como acompanhar** no README.md, posicionada entre Roadmap e Contribuindo.

## O que muda

- Badges de Discussions e Stars no topo da seção
- Link direto para o Discussions (canal central de sugestões, dúvidas e casos de uso)
- Instrução para Watch -> Releases (notificações de versão)
- Referência à newsletter LinkedIn com placeholder para o link (a ser inserido após criação)
- Link para Issues com orientação sobre contexto de bug report

## Observação

O link da newsletter LinkedIn está como placeholder (`<!-- TODO: inserir link da newsletter LinkedIn apos criacao -->`). Substituir pela URL real após criar a newsletter no LinkedIn.