### PR TITLE
fix: corrige erros de mypy preexistentes em nfe/

### DIFF
--- a/src/mcp_fiscal_brasil/nfe/assinatura.py
+++ b/src/mcp_fiscal_brasil/nfe/assinatura.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from lxml import etree
-from signxml import XMLVerifier  # type: ignore[attr-defined]
+from signxml import XMLVerifier
 
 from .._core.errors import FiscalValidationError
 from .._core.logging import get_logger

--- a/src/mcp_fiscal_brasil/nfe/distribuicao.py
+++ b/src/mcp_fiscal_brasil/nfe/distribuicao.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Literal
 
 import httpx
 from lxml import etree
-from signxml import XMLSigner  # type: ignore[attr-defined]
+from signxml import XMLSigner
 
 from .._core.errors import FiscalHTTPError, FiscalValidationError
 from .._core.logging import get_logger


### PR DESCRIPTION
## Problema

O `mypy` strict reportava dois erros no modulo `nfe/` que estavam presentes desde a v0.4.0:

```
src/mcp_fiscal_brasil/nfe/assinatura.py:13: error: Unused "type: ignore" comment  [unused-ignore]
src/mcp_fiscal_brasil/nfe/distribuicao.py:33: error: Unused "type: ignore" comment  [unused-ignore]
```

## Causa raiz

Os comentarios `# type: ignore[attr-defined]` foram adicionados originalmente porque a biblioteca `signxml` nao fornecia tipagens proprias (sem `py.typed`). A partir da versao 4.x, o pacote adicionou o marcador `py.typed` (PEP 561) e passou a exportar `XMLVerifier` e `XMLSigner` com tipagens inline. Com isso, o mypy consegue resolver os atributos corretamente e os `type: ignore` ficaram obsoletos - daí o erro `unused-ignore` no modo `strict`.

## Por que o CI passava antes

O CI roda com `pip install -e ".[dev]"` sem fixar a versao do `signxml`. A versao instalada no momento em que os ignores foram adicionados nao tinha `py.typed`, entao eram necessarios. Com atualizacoes de dependencias (Dependabot com auto-merge configurado), o signxml foi atualizado para a versao com `py.typed`, mas os ignores nao foram removidos junto.

## Correcoes

- `nfe/assinatura.py:13` - remove `# type: ignore[attr-defined]` da importacao de `XMLVerifier`
- `nfe/distribuicao.py:33` - remove `# type: ignore[attr-defined]` da importacao de `XMLSigner`

Alteracoes minimas: apenas 2 linhas. Sem mudanca de comportamento em runtime.

## Nao e bug de runtime

Os erros eram puramente de tipagem (ignores obsoletos). Nenhum dos dois casos mascara um bug real - o codigo funcionava e continua funcionando identicamente.

## Checks

- `mypy src/` - OK, 97 arquivos, zero erros
- `ruff format --check` - OK
- `ruff check` - OK
- `pytest` - 529/529 testes passando