### PR TITLE
ci: release notes automaticas com release-drafter (motor de newsletter via GitHub)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,43 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Novas funcionalidades"
+    semver-increment: minor
+    when:
+      labels:
+        - feature
+        - enhancement
+  - title: "Correcoes"
+    semver-increment: patch
+    when:
+      labels:
+        - fix
+        - bug
+  - title: "Documentacao"
+    when:
+      labels:
+        - docs
+  - title: "Manutencao"
+    when:
+      labels:
+        - chore
+        - ci
+        - deps
+        - dependencies
+
+change-template: "- $TITLE por @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+no-changes-template: "- Sem alteracoes neste ciclo"
+
+template: |
+  ## O que mudou em $RESOLVED_VERSION
+
+  $CHANGES
+
+  ---
+
+  Obrigado a todos os contribuidores desta versao: $CONTRIBUTORS
+
+  Para acompanhar proximas novidades, acesse as [Discussions](https://github.com/$OWNER/$REPOSITORY/discussions) do projeto.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## O que esse PR faz

Adiciona o [release-drafter](https://github.com/release-drafter/release-drafter) como motor automatico de release notes, habilitando um fluxo de **newsletter via GitHub** sem custo adicional.

## Arquivos criados

- `.github/release-drafter.yml` - configuracao do template de release notes em pt-BR
- `.github/workflows/release-drafter.yml` - workflow que dispara a cada merge na `main`

## Como funciona o fluxo de newsletter via GitHub

1. **Cada PR mergeado alimenta o draft automaticamente.** O release-drafter categoriza o PR com base nos labels (feature/enhancement -> "Novas funcionalidades", fix/bug -> "Correcoes", docs -> "Documentacao", chore/ci/deps -> "Manutencao") e atualiza um rascunho de release no GitHub Releases.

2. **Ao publicar a release, GitHub envia email automatico.** Qualquer pessoa que clicar em "Watch -> Custom -> Releases" no repositorio recebe o email com as release notes prontas, incluindo lista de mudancas por categoria e contribuidores.

3. **Novidades maiores viram post no Discussions.** Para releases com features significativas, o dono cria um post na categoria Announcements do Discussions (ou usa a integracao automatica de release -> discussion disponivel nas configuracoes do repo), atingindo quem acompanha o projeto mas nao configurou Watch para releases.

4. **Post no LinkedIn aponta pro repo.** O dono cola o link da release no LinkedIn com um resumo, direcionando a audiencia externa para o GitHub onde encontra o detalhamento completo.

## Como o dono usa no dia a dia

A cada ciclo de entregas, as notas ja vem prontas no rascunho de release. O dono so precisa revisar, ajustar o titulo da versao e clicar em "Publish release". O email sai automaticamente para todos os watchers.

## Labels criadas (via `gh label create`)

- `feature` - Nova funcionalidade (azul)
- `fix` - Correcao de bug (vermelho)
- `docs` - Documentacao (azul escuro)
- `chore` - Manutencao geral (amarelo)
- `ci` - Integracao continua e pipelines (roxo)
- `deps` - Atualizacao de dependencias (azul escuro)

As labels `bug`, `enhancement` e `dependencies` ja existiam e sao reconhecidas pelo template.