### PR TITLE
fix: render do README no PyPI (imagem com URL absoluta + numero de tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil
 
 <p align="center">
-  <img src="assets/banner.svg" width="800" alt="MCP Fiscal Brasil">
+  <img src="https://raw.githubusercontent.com/DeHor-Labs/mcp-fiscal-brasil/main/assets/banner.svg" width="800" alt="MCP Fiscal Brasil">
 </p>
 
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "mcp-fiscal-brasil"
 version = "0.4.0"
-description = "MCP fiscal brasileiro - 41 ferramentas, zero API key. CNPJ, NF-e, Reforma Tributaria IBS/CBS, ICMS, Simples Nacional, NCM/CFOP, indexadores BCB."
+description = "MCP fiscal brasileiro - 44 ferramentas, zero API key. CNPJ, NF-e, Reforma Tributaria IBS/CBS, ICMS, Simples Nacional, NCM/CFOP, indexadores BCB."
 authors = [
     { name = "Nikolas de Hor" }
 ]


### PR DESCRIPTION
## O que muda

- **README.md** - `assets/banner.svg` convertido para URL absoluta (`https://raw.githubusercontent.com/DeHor-Labs/mcp-fiscal-brasil/main/assets/banner.svg`). O PyPI nao resolve URLs relativas de imagem, causando o banner quebrado na pagina do pacote.
- **pyproject.toml** - descricao corrigida de 41 para 44 ferramentas, refletindo a contagem atual: 31 `@app.tool` em `server.py` + 13 em modulos `_tools.py` (bcb, cep, cnae, empresa, ibge, importacao, mei, tabelas) = 44 total.

## Como contar

```bash
grep -rc "@app.tool" src/
```

Resultado: 44 ocorrencias em todos os arquivos Python do pacote.

## Nota

A versao v0.4.0 ja publicada no PyPI nao sera afetada (releases sao imutaveis). A correcao aparece na proxima release.