### PR TITLE
ci: CodeQL focado em seguranca (security-extended)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          queries: security-extended
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## Resumo

Troca a query suite do CodeQL de `security-and-quality` para `security-extended`.

- Remove ~40 alertas de qualidade (py/unused-import, py/not-equal-on-exception, etc.) que sao ruido redundante com o ruff ja configurado no CI
- Mantem cobertura de seguranca completa - `security-extended` cobre todos os CWEs do `security-and-quality` mais queries adicionais de seguranca avancada
- Sem impacto em nenhum alerta de seguranca real existente

## Plano de teste

- [ ] CI CodeQL passa no verde nesta PR
- [ ] Re-scan da main apos merge mostra ~40 alertas de qualidade como `fixed`
- [ ] Nenhum alerta de seguranca real removido inadvertidamente