### PR TITLE
ci: pina actions por SHA (supply chain, CodeQL)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |


### PR DESCRIPTION
## Resumo

Pina todas as GitHub Actions de terceiros por SHA completo (40 chars) para fechar os alertas do CodeQL de supply chain (`actions/unpinned-tag`).

- `release-drafter/release-drafter@v7` - pinado em `ed4bc48` (alertas #17)
- `pypa/gh-action-pypi-publish@release/v1` - pinado em `cef2210` (alerta #18)
- `dependabot/fetch-metadata@v3` - pinado em `25dd0e3` (alerta #56)
- `actions/first-interaction@v3` - pinado em `1c46889` (encontrado na varredura adicional de todos os workflows)

Comentarios com a versao original (`# v7`, `# release/v1`, etc.) foram mantidos para o Dependabot reconhecer e atualizar os SHAs automaticamente quando novas versoes forem publicadas. O ecossistema `github-actions` ja esta configurado no `.github/dependabot.yml`.

## Plano de teste

- [ ] CI verde neste PR
- [ ] Verificar que o CodeQL nao aponta mais `actions/unpinned-tag` apos merge
- [ ] Confirmar que o Dependabot consegue abrir PRs de atualizacao de SHA normalmente