### PR TITLE
fix: harden fiscal validation and release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      - name: Check release metadata
+        run: python scripts/check_release_metadata.py
+
       - name: Lint (ruff)
         run: ruff check src/ tests/
 

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-fiscal-brasil",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Node.js wrapper para o CLI Python mcp-fiscal-brasil. Consultas fiscais brasileiras (CNPJ, NFe, SPED) em JS/TS.",
   "type": "module",
   "main": "dist/index.js",

--- a/npm-wrapper/src/cli.ts
+++ b/npm-wrapper/src/cli.ts
@@ -7,7 +7,33 @@
  */
 import { spawn } from "node:child_process";
 
-const args = process.argv.slice(2);
+const SETOR_CLI_MAP: Readonly<Record<string, string>> = Object.freeze({
+  comercio: "comércio",
+  serviços: "serviços",
+  servicos: "serviços",
+  industria: "indústria",
+  comércio: "comércio",
+  indústria: "indústria",
+});
+
+function normalizeSetorValue(value: string): string {
+  return Object.hasOwn(SETOR_CLI_MAP, value) ? SETOR_CLI_MAP[value] : value;
+}
+
+function normalizeSetorArgs(args: string[]): string[] {
+  return args.map((arg, index) => {
+    if (args[index - 1] === "--setor") {
+      return normalizeSetorValue(arg);
+    }
+    if (arg.startsWith("--setor=")) {
+      const value = arg.slice("--setor=".length);
+      return `--setor=${normalizeSetorValue(value)}`;
+    }
+    return arg;
+  });
+}
+
+const args = normalizeSetorArgs(process.argv.slice(2));
 const proc = spawn("mcp-fiscal", args, { stdio: "inherit" });
 
 proc.on("error", (err: Error) => {

--- a/npm-wrapper/src/index.ts
+++ b/npm-wrapper/src/index.ts
@@ -40,11 +40,32 @@ export interface RegimesComparison {
   observacoes: string;
 }
 
+export type SetorRegime =
+  | "comércio"
+  | "comercio"
+  | "serviços"
+  | "servicos"
+  | "indústria"
+  | "industria";
+
+const SETOR_CLI_MAP: Record<SetorRegime, "comércio" | "serviços" | "indústria"> = {
+  comércio: "comércio",
+  comercio: "comércio",
+  serviços: "serviços",
+  servicos: "serviços",
+  indústria: "indústria",
+  industria: "indústria",
+};
+
 export class MCPFiscalError extends Error {
   constructor(message: string, public exitCode: number, public stderr: string) {
     super(message);
     this.name = "MCPFiscalError";
   }
+}
+
+function normalizeSetorForCli(setor: SetorRegime): string {
+  return SETOR_CLI_MAP[setor];
 }
 
 function runCli(args: string[]): Promise<unknown> {
@@ -115,7 +136,7 @@ export async function scoreSupplier(
 /** Compara regimes tributarios. */
 export async function compareRegimes(params: {
   faturamento: number;
-  setor: "comercio" | "servicos" | "industria";
+  setor: SetorRegime;
   folha?: number;
 }): Promise<RegimesComparison> {
   const args = [
@@ -123,7 +144,7 @@ export async function compareRegimes(params: {
     "--faturamento",
     String(params.faturamento),
     "--setor",
-    params.setor,
+    normalizeSetorForCli(params.setor),
   ];
   if (params.folha !== undefined) {
     args.push("--folha", String(params.folha));

--- a/npm-wrapper/tsconfig.json
+++ b/npm-wrapper/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DeHor-Labs/mcp-fiscal-brasil",
   "title": "MCP Fiscal Brasil",
   "description": "Ferramentas fiscais brasileiras: CNPJ, NF-e, IBS/CBS, ICMS, Simples Nacional, NCM/CFOP. Sem API key.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/DeHor-Labs/mcp-fiscal-brasil",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-fiscal-brasil",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/mcp_fiscal_brasil/_core/logging.py
+++ b/src/mcp_fiscal_brasil/_core/logging.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
+from collections.abc import Mapping
 from typing import Final, cast
 
 import structlog
@@ -13,10 +15,25 @@ __all__ = ["get_logger"]
 
 _ENV_VAR: Final = "MCP_FISCAL_ENV"
 _PRODUCTION_ENV: Final = "production"
+_LOG_LEVEL_VAR: Final = "MCP_FISCAL_LOG_LEVEL"
+_DEFAULT_LOG_LEVEL: Final = "INFO"
+_LOG_LEVELS: Final[Mapping[str, int]] = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
 
 
 def _is_production() -> bool:
     return os.getenv(_ENV_VAR, "").strip().lower() == _PRODUCTION_ENV
+
+
+def _log_level() -> int:
+    configured = os.getenv(_LOG_LEVEL_VAR, _DEFAULT_LOG_LEVEL).strip().upper()
+    return _LOG_LEVELS.get(configured, logging.INFO)
 
 
 def _processors(json_output: bool) -> list[Processor]:
@@ -42,7 +59,7 @@ def _configure_structlog() -> None:
         processors=_processors(json_output),
         context_class=dict,
         logger_factory=structlog.WriteLoggerFactory(file=sys.stderr),
-        wrapper_class=structlog.BoundLogger,
+        wrapper_class=structlog.make_filtering_bound_logger(_log_level()),
         cache_logger_on_first_use=False,
     )
 

--- a/src/mcp_fiscal_brasil/agentic/nfe.py
+++ b/src/mcp_fiscal_brasil/agentic/nfe.py
@@ -73,7 +73,7 @@ async def validate_nfe_full(xml_path: str | Path) -> NFeValidationReport:
     if chave_acesso:
         try:
             chave_result = await validar_chave_nfe(chave_acesso)
-            chave_consistente = bool(chave_result.get("válida", False))
+            chave_consistente = bool(chave_result.get("válido", chave_result.get("válida", False)))
             if not chave_consistente:
                 issues.append(
                     NFeValidationIssue(

--- a/src/mcp_fiscal_brasil/nfe/assinatura.py
+++ b/src/mcp_fiscal_brasil/nfe/assinatura.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from lxml import etree
-from signxml import XMLVerifier  # type: ignore[attr-defined]
+from signxml import XMLVerifier  # type: ignore[attr-defined, unused-ignore]
 
 from .._core.errors import FiscalValidationError
 from .._core.logging import get_logger

--- a/src/mcp_fiscal_brasil/nfe/distribuicao.py
+++ b/src/mcp_fiscal_brasil/nfe/distribuicao.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Literal
 
 import httpx
 from lxml import etree
-from signxml import XMLSigner  # type: ignore[attr-defined]
+from signxml import XMLSigner  # type: ignore[attr-defined, unused-ignore]
 
 from .._core.errors import FiscalHTTPError, FiscalValidationError
 from .._core.logging import get_logger

--- a/src/mcp_fiscal_brasil/nfe/xml_parser.py
+++ b/src/mcp_fiscal_brasil/nfe/xml_parser.py
@@ -242,6 +242,14 @@ def parse_nfe_xml(xml_content: str | bytes, chave: str) -> NFeResponse:
         nfe_el = root
 
     inf_nfe = _find_any(nfe_el, ".//nfe:infNFe", ".//infNFe", ns)
+    chave_acesso = "".join(char for char in chave if char.isdigit())
+    if len(chave_acesso) != 44:
+        raw_id = cast(str, inf_nfe.get("Id", "")) if inf_nfe is not None else ""
+        chave_id = raw_id.removeprefix("NFe")
+        if len(chave_id) == 44 and chave_id.isdigit():
+            chave_acesso = chave_id
+        else:
+            chave_acesso = chave
 
     ide = _find_any(inf_nfe, "nfe:ide", "ide", ns)
     emit = _find_any(inf_nfe, "nfe:emit", "emit", ns)
@@ -320,7 +328,7 @@ def parse_nfe_xml(xml_content: str | bytes, chave: str) -> NFeResponse:
         )
 
     return NFeResponse(
-        chave_acesso=chave,
+        chave_acesso=chave_acesso,
         número=_xpath_text_any(ide, "nfe:nNF/text()", "nNF/text()", ns),
         serie=_xpath_text_any(ide, "nfe:serie/text()", "serie/text()", ns),
         modelo=_xpath_text_any(ide, "nfe:mod/text()", "mod/text()", ns) or "55",

--- a/src/mcp_fiscal_brasil/nfse/tools.py
+++ b/src/mcp_fiscal_brasil/nfse/tools.py
@@ -1,6 +1,7 @@
 """Ferramentas MCP para NFSe."""
 
 import logging
+import unicodedata
 
 from mcp_fiscal_brasil.nfse.client import NFSeNacionalClient, NFSeNacionalUnavailableError
 from mcp_fiscal_brasil.shared.validators import validate_cnpj
@@ -31,6 +32,13 @@ def _validar_uf_nfse(uf: str) -> str:
     if len(uf_limpa) != 2 or not uf_limpa.isalpha():
         raise ValueError("uf deve ser uma sigla com 2 letras")
     return uf_limpa
+
+
+def _normalizar_chave_municipio(municipio: str) -> str:
+    sem_acentos = "".join(
+        char for char in unicodedata.normalize("NFKD", municipio) if not unicodedata.combining(char)
+    )
+    return " ".join(sem_acentos.upper().split())
 
 
 def _validar_cnpj_prestador(cnpj_prestador: str | None) -> str | None:
@@ -236,7 +244,7 @@ async def consultar_nfse(
         },
     }
 
-    municipio_upper = municipio.upper()
+    municipio_upper = _normalizar_chave_municipio(municipio)
 
     # Tenta buscar com formato "MUNICIPIO/UF"
     chave = f"{municipio_upper}/{uf_upper}"

--- a/src/mcp_fiscal_brasil/shared/http_client.py
+++ b/src/mcp_fiscal_brasil/shared/http_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 import httpx
@@ -10,9 +11,18 @@ from .exceptions import APIError, RateLimitError, TimeoutError
 from .rate_limiter import SlidingWindowRateLimiter
 
 logger = logging.getLogger(__name__)
+_PACKAGE_NAME = "mcp-fiscal-brasil"
 
 # Timeout padrao (segundos): connect=5, read=30, write=10
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+
+
+def _default_user_agent() -> str:
+    try:
+        package_version = version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        package_version = "0.0.0"
+    return f"{_PACKAGE_NAME}/{package_version}"
 
 
 class FiscalHTTPClient:
@@ -40,7 +50,7 @@ class FiscalHTTPClient:
         self.rate_limiter = rate_limiter
         self._default_headers = {
             "Accept": "application/json",
-            "User-Agent": "mcp-fiscal-brasil/0.1.0",
+            "User-Agent": _default_user_agent(),
             **(headers or {}),
         }
         self._client: httpx.AsyncClient | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,9 @@ def cpf_invalido() -> str:
 @pytest.fixture
 def chave_nfe_valida() -> str:
     """Chave NFe válida para testes (chave publica de exemplo)."""
-    # Chave: cUF=35(SP) AAMM=2301 CNPJ=12345678901234 mod=55 serie=001 nNF=000000001 tpEmis=1 cNF=00000001 cDV=?
-    # Usamos uma chave real conhecida para testes
-    return "35230112345678901234550010000000011000000018"
+    # cUF=35(SP) AAMM=2301 CNPJ=12345678000190 mod=55 serie=001
+    # nNF=000000001 tpEmis=1 cNF=00000001 cDV=8.
+    return "35230112345678000190550010000000011000000018"
 
 
 @pytest.fixture

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -13,6 +13,7 @@ from mcp_fiscal_brasil.agentic import (
     compare_tax_regimes,
     consultar_empresas_lote,
     risk_score_supplier,
+    validate_nfe_full,
 )
 from mcp_fiscal_brasil.agentic.regimes import (
     _calc_lucro_presumido,
@@ -76,6 +77,53 @@ def _cnpj_baixado() -> CNPJResponse:
         qsa=[],
         origem="BrasilAPI",
     )
+
+
+@pytest.mark.asyncio
+async def test_validate_nfe_full_extrai_chave_do_xml_e_marca_consistente(
+    tmp_path, chave_nfe_valida: str
+) -> None:
+    xml_path = tmp_path / "nfe.xml"
+    xml_path.write_text(
+        f"""
+        <NFe>
+          <infNFe Id="NFe{chave_nfe_valida}">
+            <ide>
+              <mod>55</mod>
+              <serie>1</serie>
+              <nNF>1</nNF>
+              <dhEmi>2023-01-01T10:00:00-03:00</dhEmi>
+            </ide>
+            <emit>
+              <CNPJ>12345678000190</CNPJ>
+              <xNome>EMPRESA TESTE LTDA</xNome>
+            </emit>
+            <dest>
+              <CNPJ>33000167000101</CNPJ>
+              <xNome>CLIENTE TESTE SA</xNome>
+            </dest>
+            <total>
+              <ICMSTot>
+                <vNF>100.00</vNF>
+              </ICMSTot>
+            </total>
+          </infNFe>
+        </NFe>
+        """,
+        encoding="utf-8",
+    )
+
+    with patch("mcp_fiscal_brasil.agentic.nfe.CNPJClient") as mock_cnpj_class:
+        cnpj_inst = MagicMock()
+        cnpj_inst.consultar = AsyncMock(return_value=_cnpj_ativo())
+        mock_cnpj_class.return_value = cnpj_inst
+
+        report = await validate_nfe_full(xml_path)
+
+    assert report.chave_acesso == chave_nfe_valida
+    assert report.chave_consistente is True
+    assert report.valida_estruturalmente is True
+    assert report.issues == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core_logging.py
+++ b/tests/test_core_logging.py
@@ -1,0 +1,25 @@
+"""Testes para configuracao de logging estruturado."""
+
+from mcp_fiscal_brasil._core import get_logger
+
+
+def test_get_logger_respeita_mcp_fiscal_log_level(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("MCP_FISCAL_LOG_LEVEL", "ERROR")
+
+    logger = get_logger("tests.logging")
+    logger.info("evento_oculto")
+    logger.error("evento_visivel")
+
+    captured = capsys.readouterr()
+    assert "evento_visivel" in captured.err
+    assert "evento_oculto" not in captured.err
+
+
+def test_get_logger_log_level_invalido_cai_para_info(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("MCP_FISCAL_LOG_LEVEL", "NIVEL_INEXISTENTE")
+
+    logger = get_logger("tests.logging")
+    logger.info("evento_info")
+
+    captured = capsys.readouterr()
+    assert "evento_info" in captured.err

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,5 +1,6 @@
 """Testes para shared/http_client.py (FiscalHTTPClient)."""
 
+from importlib.metadata import version
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -55,6 +56,14 @@ def test_init_custom_headers():
     client = FiscalHTTPClient("https://api.example.com", headers={"X-Token": "abc"})
     assert client._default_headers["X-Token"] == "abc"
     assert client._default_headers["Accept"] == "application/json"
+
+
+def test_init_default_user_agent_usa_versao_do_pacote():
+    client = FiscalHTTPClient("https://api.example.com")
+
+    assert client._default_headers["User-Agent"] == (
+        f"mcp-fiscal-brasil/{version('mcp-fiscal-brasil')}"
+    )
 
 
 def test_init_with_rate_limiter():

--- a/tests/test_nfe_xml_parser.py
+++ b/tests/test_nfe_xml_parser.py
@@ -69,3 +69,21 @@ def test_parse_nfe_xml_without_namespace_extracts_basic_fields() -> None:
     assert response.itens[0].valor_total == 100.0
     assert response.totais is not None
     assert response.totais.valor_nota == 100.0
+
+
+def test_parse_nfe_xml_extrai_chave_do_id_quando_chave_vazia() -> None:
+    xml = """
+    <NFe>
+      <infNFe Id="NFe35240112345678000195550010000001231000000012">
+        <ide>
+          <mod>55</mod>
+          <serie>1</serie>
+          <nNF>123</nNF>
+        </ide>
+      </infNFe>
+    </NFe>
+    """
+
+    response = parse_nfe_xml(xml, "")
+
+    assert response.chave_acesso == "35240112345678000195550010000001231000000012"

--- a/tests/test_nfse.py
+++ b/tests/test_nfse.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from mcp_fiscal_brasil.nfse.tools import consultar_nfse
@@ -20,6 +22,19 @@ async def test_consultar_nfse_normaliza_entrada() -> None:
     assert resultado["municipio"] == "São Paulo"
     assert resultado["uf"] == "SP"
     assert resultado["status"] == "consulta_manual_necessaria"
+
+
+@pytest.mark.asyncio
+async def test_consultar_nfse_municipio_com_acento_encontra_portal() -> None:
+    with patch("mcp_fiscal_brasil.nfse.tools.NFSeNacionalClient") as mock_client_class:
+        client = MagicMock()
+        client.consultar_por_chave = AsyncMock(return_value=None)
+        mock_client_class.return_value = client
+
+        resultado = await consultar_nfse(numero="123", municipio="Goiânia", uf="GO")
+
+    assert resultado["portal_municipio"] == "https://nfse.goiania.go.gov.br/"
+    assert resultado["sistema_nfse"] == "ABRASF"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix `validate_nfe_full` so it extracts the NFe access key from `infNFe@Id` and reads the actual `validar_chave_nfe` result key.
- Normalize accented NFS-e municipalities and Node wrapper regime sectors before calling the Python CLI.
- Align `server.json` and npm wrapper metadata with `0.4.0`, then add CI coverage for `scripts/check_release_metadata.py`.
- Respect `MCP_FISCAL_LOG_LEVEL` and derive the HTTP User-Agent from installed package metadata.
- Remove stale `signxml` type ignores so current `mypy` stays green.

## Tests

- `.venv/bin/pytest -q` - 585 passed, 33 warnings
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `.venv/bin/python scripts/check_release_metadata.py`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.4.0

* **New Features**
  * Adicionado suporte para configuração dinâmica do nível de log via variável de ambiente
  * CLI agora normaliza automaticamente variações do parâmetro setor
  
* **Bug Fixes**
  * Melhorada extração e validação da chave de acesso de NFe
  * Corrigido tratamento de nomes de municípios com acentuação
  * Aprimorada validação de consistência de chaves NFe
  
* **Improvements**
  * Cabeçalho User-Agent do cliente HTTP agora inclui versão do pacote dinamicamente
  
* **Tests**
  * Adicionados testes para configuração de logging, cliente HTTP e processamento de NFe

<!-- end of auto-generated comment: release notes by coderabbit.ai -->