### PR TITLE
docs: fix SPED docstring indentation

### DIFF
--- a/src/mcp_fiscal_brasil/sped/tools.py
+++ b/src/mcp_fiscal_brasil/sped/tools.py
@@ -239,9 +239,9 @@ async def listar_registros_sped(
     Returns:
         Lista de dicionários com os campos de cada ocorrência do registro.
         Cada dicionário contém:
-          - "registro": código do registro (string)
-          - "campos": lista de campos (excluindo REG), indexável por posição
-          - "raw": linha original intacta (string)
+        - "registro": código do registro (string)
+        - "campos": lista de campos (excluindo REG), indexável por posição
+        - "raw": linha original intacta (string)
     """
     tipo_registro = tipo_registro.upper().strip()
     resultado: list[dict[str, str | list[str]]] = []


### PR DESCRIPTION
## Summary

- Fix `listar_registros_sped` docstring list indentation so `griffe`/MkDocs strict builds do not emit confusing-indentation warnings.

## Context

- Follow-up to #99 after the post-merge Docs workflow failed on `main`.

## Tests

- `uv run mkdocs build --strict`
