### PR TITLE
docs: limpa cabeçalho do README (oculta mcp-name + corrige badge de downloads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil
+<!-- mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil -->
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/DeHor-Labs/mcp-fiscal-brasil/main/assets/banner.svg" width="800" alt="MCP Fiscal Brasil">
@@ -10,7 +10,7 @@ mcp-name: io.github.DeHor-Labs/mcp-fiscal-brasil
 
 <p align="center">
   <a href="https://pypi.org/project/mcp-fiscal-brasil/"><img src="https://img.shields.io/pypi/v/mcp-fiscal-brasil?color=009c3b&label=PyPI" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/mcp-fiscal-brasil/"><img src="https://img.shields.io/pypi/dm/mcp-fiscal-brasil?color=009c3b&label=downloads%2Fmês" alt="PyPI downloads"></a>
+  <a href="https://pypi.org/project/mcp-fiscal-brasil/"><img src="https://img.shields.io/pypi/dm/mcp-fiscal-brasil?color=009c3b&label=downloads%2Fm%C3%AAs" alt="PyPI downloads"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-002776?logo=python&logoColor=white" alt="Python 3.10+"></a>
   <a href="https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/workflows/ci.yml"><img src="https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/licenca-MIT-FFDF00?labelColor=002776" alt="License MIT"></a>


### PR DESCRIPTION
## Resumo

- `mcp-name` movido para comentário HTML (`<!-- mcp-name: ... -->`): some do README renderizado mantendo a validação de posse no MCP Registry. Formato aceito explicitamente no código-fonte do registry ([`internal/validators/registries/mcpname.go`](https://github.com/modelcontextprotocol/registry)) e documentado em `docs/modelcontextprotocol-io/package-types.mdx`.

- Badge de downloads do PyPI corrigido: o caractere `ê` de `downloads/mês` estava literal na URL (não percent-encoded), fazendo o shields.io retornar HTTP 400 e o badge aparecer como `?`. Corrigido para `%C3%AA`. URL nova confirmada com HTTP 200 e SVG válido.

## Mudanças

Apenas 2 linhas no `README.md`, nenhuma mudança de código ou lógica.

## Verificação

- `curl` nas URLs dos 8 badges do cabeçalho: todos retornam HTTP 200
- Registry: comentário HTML validado nos testes do registry (`<!-- mcp-name: io.github.acme/widget-->` = `true`)