### PR TITLE
docs: adiciona link da LinkedIn Newsletter no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ ReceitaWS       estaduais municipais Federal  local   local  governamentais
 
 - **Releases**: clique em **Watch -> Releases** no topo do repositório para ser notificado a cada versão nova
 - **Discussions**: [github.com/DeHor-Labs/mcp-fiscal-brasil/discussions](https://github.com/DeHor-Labs/mcp-fiscal-brasil/discussions) - canal para sugestões de feature, dúvidas fiscais e técnicas, e casos de uso. Sugestões feitas aqui entram no roadmap de verdade
-- **Newsletter**: acompanhe os releases comentados na LinkedIn Newsletter mcp-fiscal-brasil <!-- TODO: inserir link da newsletter LinkedIn apos criacao --> - cada numero explica o que chegou, o que foi corrigido e o que vem por ai
+- **Newsletter**: acompanhe os releases comentados na [LinkedIn Newsletter MCP Fiscal Brasil](https://www.linkedin.com/newsletters/7474668338875494400/) - cada edição explica o que chegou, o que foi corrigido e o que vem por ai. [Assinar agora](https://www.linkedin.com/build-relation/newsletter-follow?entityUrn=7474668338875494400)
 - **Issues**: bugs com contexto completo (versão, XML de exemplo sem dados reais, comportamento esperado vs. obtido)
 
 ---


### PR DESCRIPTION
## Resumo

- Substitui o placeholder `<!-- TODO: inserir link da newsletter LinkedIn apos criacao -->` pelo link markdown real da newsletter
- Link canonico: https://www.linkedin.com/newsletters/7474668338875494400/
- CTA de assinatura (follow direto) adicionado ao final da linha
- Palavra "numero" trocada por "edicao" para manter acentuacao correta em pt-BR

## Alteracao

**Antes:**
```
- **Newsletter**: acompanhe os releases comentados na LinkedIn Newsletter mcp-fiscal-brasil <!-- TODO: inserir link da newsletter LinkedIn apos criacao --> - cada numero explica o que chegou, o que foi corrigido e o que vem por ai
```

**Depois:**
```
- **Newsletter**: acompanhe os releases comentados na [LinkedIn Newsletter MCP Fiscal Brasil](https://www.linkedin.com/newsletters/7474668338875494400/) - cada edicao explica o que chegou, o que foi corrigido e o que vem por ai. [Assinar agora](https://www.linkedin.com/build-relation/newsletter-follow?entityUrn=7474668338875494400)
```

## Checklist

- [x] Unico arquivo alterado: README.md (linha 541)
- [x] Nenhum outro TODO/placeholder de newsletter encontrado no repo
- [x] Links verificados manualmente
- [x] Sem referencias a AI ou Co-Authored-By