### PR TITLE
fix: corrige ferramentas que liam endpoints de objeto como lista

### DIFF
--- a/src/mcp_fiscal_brasil/cnae/client.py
+++ b/src/mcp_fiscal_brasil/cnae/client.py
@@ -1,9 +1,31 @@
+from typing import Any
+
 from mcp_fiscal_brasil._core import FiscalNotFoundError, HTTPClient, get_logger, settings
 from mcp_fiscal_brasil._core.errors import FiscalHTTPError
 
 from .schemas import CNAEActivity, CNAEClass
 
 logger = get_logger(__name__)
+
+
+def _cnae_class_from_item(item: dict[str, Any]) -> CNAEClass:
+    """Constroi CNAEClass a partir de um item JSON da API IBGE CNAE."""
+    grupo_raw = item.get("grupo")
+    grupo: str | None = None
+    divisao: str | None = None
+
+    if isinstance(grupo_raw, dict):
+        grupo = grupo_raw.get("descricao")
+        divisao_raw = grupo_raw.get("divisao")
+        if isinstance(divisao_raw, dict):
+            divisao = divisao_raw.get("descricao")
+
+    return CNAEClass(
+        código=str(item.get("id", "")),
+        descrição=item.get("descricao", ""),
+        grupo=grupo,
+        divisao=divisao,
+    )
 
 
 class CNAEClient:
@@ -78,28 +100,7 @@ class CNAEClient:
                     ) from exc
                 raise
 
-        result = []
-        for item in data:
-            grupo = (
-                item.get("grupo", {}).get("descricao")
-                if isinstance(item.get("grupo"), dict)
-                else None
-            )
-            divisao = (
-                item.get("grupo", {}).get("divisao", {}).get("descricao")
-                if isinstance(item.get("grupo"), dict)
-                and isinstance(item.get("grupo").get("divisao"), dict)
-                else None
-            )
-            result.append(
-                CNAEClass(
-                    código=str(item.get("id", "")),
-                    descrição=item.get("descricao", ""),
-                    grupo=grupo,
-                    divisao=divisao,
-                )
-            )
-        return result
+        return [_cnae_class_from_item(item) for item in data]
 
     async def get_class(self, code: str) -> CNAEClass:
         """Consulta uma classe específica por código."""
@@ -109,25 +110,7 @@ class CNAEClient:
             try:
                 # /classes/{code} retorna objeto, nao lista
                 item = await client.get(f"/classes/{code_clean}")
-
-                grupo = (
-                    item.get("grupo", {}).get("descricao")
-                    if isinstance(item.get("grupo"), dict)
-                    else None
-                )
-                divisao = (
-                    item.get("grupo", {}).get("divisao", {}).get("descricao")
-                    if isinstance(item.get("grupo"), dict)
-                    and isinstance(item.get("grupo").get("divisao"), dict)
-                    else None
-                )
-
-                return CNAEClass(
-                    código=str(item.get("id", "")),
-                    descrição=item.get("descricao", ""),
-                    grupo=grupo,
-                    divisao=divisao,
-                )
+                return _cnae_class_from_item(item)
             except FiscalHTTPError as exc:
                 if exc.status_code == 404:
                     raise FiscalNotFoundError(

--- a/src/mcp_fiscal_brasil/cnae/client.py
+++ b/src/mcp_fiscal_brasil/cnae/client.py
@@ -25,18 +25,9 @@ class CNAEClient:
         if search:
             params["busca"] = search
 
-        try:
-            async with self._http_client() as client:
-                data = await client.get_list("/subclasses", params=params)
-        except Exception:
-            pass
-
-        # Let's fix this properly. The prompt explicitly says GET /atividades.
-        # But IBGE API has /classes and /subclasses. Let's use /subclasses to be safe or what the prompt says.
-        # Actually I will just use /subclasses for get_activities since CNAE Activity is 7 digits.
+        # /subclasses (sem codigo) retorna lista
         async with self._http_client() as client:
             try:
-                # Let's use what the prompt said literally: GET /atividades
                 data = await client.get_list("/subclasses", params=params)
             except FiscalHTTPError as exc:
                 if exc.status_code == 404:
@@ -46,7 +37,7 @@ class CNAEClient:
                 raise
 
         return [
-            CNAEActivity(código=item.get("id", ""), descrição=item.get("descrição", ""))
+            CNAEActivity(código=str(item.get("id", "")), descrição=item.get("descricao", ""))
             for item in data
         ]
 
@@ -56,14 +47,12 @@ class CNAEClient:
         code_clean = "".join(c for c in code if c.isdigit())
         async with self._http_client() as client:
             try:
-                data = await client.get_list(f"/subclasses/{code_clean}")
-                if not data:
-                    raise FiscalNotFoundError(
-                        f"CNAE activity {code_clean} not found", "Recurso", "desconhecido"
-                    )
-                # IBGE often returns a list with one item for specific queries
-                item = data[0] if isinstance(data, list) else data
-                return CNAEActivity(código=item.get("id", ""), descrição=item.get("descrição", ""))
+                # /subclasses/{code} retorna objeto, nao lista
+                item = await client.get(f"/subclasses/{code_clean}")
+                return CNAEActivity(
+                    código=str(item.get("id", "")),
+                    descrição=item.get("descricao", ""),
+                )
             except FiscalHTTPError as exc:
                 if exc.status_code == 404:
                     raise FiscalNotFoundError(
@@ -78,6 +67,7 @@ class CNAEClient:
         if search:
             params["busca"] = search
 
+        # /classes (sem codigo) retorna lista
         async with self._http_client() as client:
             try:
                 data = await client.get_list("/classes", params=params)
@@ -91,20 +81,20 @@ class CNAEClient:
         result = []
         for item in data:
             grupo = (
-                item.get("grupo", {}).get("descrição")
+                item.get("grupo", {}).get("descricao")
                 if isinstance(item.get("grupo"), dict)
                 else None
             )
             divisao = (
-                item.get("grupo", {}).get("divisao", {}).get("descrição")
+                item.get("grupo", {}).get("divisao", {}).get("descricao")
                 if isinstance(item.get("grupo"), dict)
                 and isinstance(item.get("grupo").get("divisao"), dict)
                 else None
             )
             result.append(
                 CNAEClass(
-                    código=item.get("id", ""),
-                    descrição=item.get("descrição", ""),
+                    código=str(item.get("id", "")),
+                    descrição=item.get("descricao", ""),
                     grupo=grupo,
                     divisao=divisao,
                 )
@@ -117,28 +107,24 @@ class CNAEClient:
         code_clean = "".join(c for c in code if c.isdigit())
         async with self._http_client() as client:
             try:
-                data = await client.get_list(f"/classes/{code_clean}")
-                if not data:
-                    raise FiscalNotFoundError(
-                        f"CNAE class {code_clean} not found", "Recurso", "desconhecido"
-                    )
-                item = data[0] if isinstance(data, list) else data
+                # /classes/{code} retorna objeto, nao lista
+                item = await client.get(f"/classes/{code_clean}")
 
                 grupo = (
-                    item.get("grupo", {}).get("descrição")
+                    item.get("grupo", {}).get("descricao")
                     if isinstance(item.get("grupo"), dict)
                     else None
                 )
                 divisao = (
-                    item.get("grupo", {}).get("divisao", {}).get("descrição")
+                    item.get("grupo", {}).get("divisao", {}).get("descricao")
                     if isinstance(item.get("grupo"), dict)
                     and isinstance(item.get("grupo").get("divisao"), dict)
                     else None
                 )
 
                 return CNAEClass(
-                    código=item.get("id", ""),
-                    descrição=item.get("descrição", ""),
+                    código=str(item.get("id", "")),
+                    descrição=item.get("descricao", ""),
                     grupo=grupo,
                     divisao=divisao,
                 )

--- a/src/mcp_fiscal_brasil/ibge/client.py
+++ b/src/mcp_fiscal_brasil/ibge/client.py
@@ -1,9 +1,33 @@
+from typing import Any
+
 from mcp_fiscal_brasil._core import FiscalNotFoundError, HTTPClient, get_logger, settings
 from mcp_fiscal_brasil._core.errors import FiscalHTTPError
 
 from .schemas import Estado, Municipio
 
 logger = get_logger(__name__)
+
+
+def _municipio_from_item(item: dict[str, Any]) -> Municipio:
+    """Constroi Municipio a partir de um item JSON da API IBGE Localidades."""
+    microrregiao_raw = item.get("microrregiao")
+    microrregiao_nome: str | None = None
+    estado_sigla: str | None = None
+
+    if isinstance(microrregiao_raw, dict):
+        microrregiao_nome = microrregiao_raw.get("nome")
+        mesorregiao = microrregiao_raw.get("mesorregiao")
+        if isinstance(mesorregiao, dict):
+            uf = mesorregiao.get("UF")
+            if isinstance(uf, dict):
+                estado_sigla = uf.get("sigla")
+
+    return Municipio(
+        id=item["id"],
+        nome=item["nome"],
+        microrregiao=microrregiao_nome,
+        estado=estado_sigla,
+    )
 
 
 class IBGEClient:
@@ -41,6 +65,7 @@ class IBGEClient:
         logger.info("ibge_get_state_started", uf=uf)
         async with self._http_client() as client:
             try:
+                # /estados/{uf} retorna objeto, nao lista
                 item = await client.get(f"/estados/{uf}")
                 return Estado(
                     id=item["id"],
@@ -64,46 +89,16 @@ class IBGEClient:
         async with self._http_client() as client:
             data = await client.get_list(path)
 
-        return [
-            Municipio(
-                id=item["id"],
-                nome=item["nome"],
-                microrregiao=item.get("microrregiao", {}).get("nome")
-                if isinstance(item.get("microrregiao"), dict)
-                else None,
-                estado=item.get("microrregiao", {})
-                .get("mesorregiao", {})
-                .get("UF", {})
-                .get("sigla")
-                if isinstance(item.get("microrregiao"), dict)
-                and isinstance(item.get("microrregiao").get("mesorregiao"), dict)
-                and isinstance(item.get("microrregiao").get("mesorregiao").get("UF"), dict)
-                else None,
-            )
-            for item in data
-        ]
+        return [_municipio_from_item(item) for item in data]
 
     async def get_municipality(self, code: int) -> Municipio:
         """Consulta um município específico por código."""
         logger.info("ibge_get_municipality_started", code=code)
         async with self._http_client() as client:
             try:
+                # /municipios/{code} retorna objeto, nao lista
                 item = await client.get(f"/municipios/{code}")
-                return Municipio(
-                    id=item["id"],
-                    nome=item["nome"],
-                    microrregiao=item.get("microrregiao", {}).get("nome")
-                    if isinstance(item.get("microrregiao"), dict)
-                    else None,
-                    estado=item.get("microrregiao", {})
-                    .get("mesorregiao", {})
-                    .get("UF", {})
-                    .get("sigla")
-                    if isinstance(item.get("microrregiao"), dict)
-                    and isinstance(item.get("microrregiao").get("mesorregiao"), dict)
-                    and isinstance(item.get("microrregiao").get("mesorregiao").get("UF"), dict)
-                    else None,
-                )
+                return _municipio_from_item(item)
             except FiscalHTTPError as exc:
                 if exc.status_code == 404:
                     raise FiscalNotFoundError(

--- a/src/mcp_fiscal_brasil/ibge/client.py
+++ b/src/mcp_fiscal_brasil/ibge/client.py
@@ -41,12 +41,7 @@ class IBGEClient:
         logger.info("ibge_get_state_started", uf=uf)
         async with self._http_client() as client:
             try:
-                data = await client.get_list(f"/estados/{uf}")
-                if not data:
-                    raise FiscalNotFoundError(
-                        f"Estado {uf} não encontrado", "Recurso", "desconhecido"
-                    )
-                item = data[0] if isinstance(data, list) else data
+                item = await client.get(f"/estados/{uf}")
                 return Estado(
                     id=item["id"],
                     sigla=item["sigla"],
@@ -93,12 +88,7 @@ class IBGEClient:
         logger.info("ibge_get_municipality_started", code=code)
         async with self._http_client() as client:
             try:
-                data = await client.get_list(f"/municipios/{code}")
-                if not data:
-                    raise FiscalNotFoundError(
-                        f"Município {code} não encontrado", "Recurso", "desconhecido"
-                    )
-                item = data[0] if isinstance(data, list) else data
+                item = await client.get(f"/municipios/{code}")
                 return Municipio(
                     id=item["id"],
                     nome=item["nome"],

--- a/tests/test_cnae.py
+++ b/tests/test_cnae.py
@@ -13,16 +13,32 @@ def client():
 
 @pytest.mark.asyncio
 async def test_get_activities_success(client):
+    """get_activities usa get_list pois /subclasses (sem codigo) retorna lista."""
     with patch("mcp_fiscal_brasil._core.http.HTTPClient.get_list") as mock_get:
-        mock_get.return_value = [{"id": "0111301", "descrição": "Cultivo de arroz"}]
+        # A API IBGE retorna 'descricao' sem acento
+        mock_get.return_value = [{"id": "0111301", "descricao": "Cultivo de arroz"}]
         result = await client.get_activities()
         assert len(result) == 1
         assert result[0].código == "0111301"
+        assert result[0].descrição == "Cultivo de arroz"
+
+
+@pytest.mark.asyncio
+async def test_get_activity_success(client):
+    """get_activity usa get() pois /subclasses/{code} retorna objeto, nao lista."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.return_value = {
+            "id": "6201501",
+            "descricao": "DESENVOLVIMENTO DE PROGRAMAS DE COMPUTADOR SOB ENCOMENDA",
+        }
+        result = await client.get_activity("6201501")
+        assert result.código == "6201501"
+        assert "COMPUTADOR" in result.descrição
 
 
 @pytest.mark.asyncio
 async def test_get_activity_not_found(client):
-    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get_list") as mock_get:
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
         mock_get.side_effect = FiscalHTTPError("Not found", 404, "http://test")
         with pytest.raises(FiscalNotFoundError):
             await client.get_activity("9999999")
@@ -30,24 +46,49 @@ async def test_get_activity_not_found(client):
 
 @pytest.mark.asyncio
 async def test_get_classes_success(client):
+    """get_classes usa get_list pois /classes (sem codigo) retorna lista."""
     with patch("mcp_fiscal_brasil._core.http.HTTPClient.get_list") as mock_get:
         mock_get.return_value = [
             {
                 "id": "01113",
-                "descrição": "Cultivo de cereais",
-                "grupo": {"descrição": "Grupo 1", "divisao": {"descrição": "Divisao 1"}},
+                "descricao": "Cultivo de cereais",
+                "grupo": {"descricao": "Grupo 1", "divisao": {"descricao": "Divisao 1"}},
             }
         ]
         result = await client.get_classes()
         assert len(result) == 1
         assert result[0].código == "01113"
+        assert result[0].descrição == "Cultivo de cereais"
         assert result[0].grupo == "Grupo 1"
         assert result[0].divisao == "Divisao 1"
 
 
 @pytest.mark.asyncio
 async def test_get_class_success(client):
-    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get_list") as mock_get:
-        mock_get.return_value = [{"id": "01113", "descrição": "Cultivo de cereais"}]
-        result = await client.get_class("01113")
-        assert result.código == "01113"
+    """get_class usa get() pois /classes/{code} retorna objeto, nao lista."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.return_value = {
+            "id": "62015",
+            "descricao": "DESENVOLVIMENTO DE PROGRAMAS DE COMPUTADOR SOB ENCOMENDA",
+            "grupo": {
+                "id": "620",
+                "descricao": "ATIVIDADES DOS SERVICOS DE TI",
+                "divisao": {
+                    "id": "62",
+                    "descricao": "ATIVIDADES DOS SERVICOS DE TI",
+                },
+            },
+        }
+        result = await client.get_class("62015")
+        assert result.código == "62015"
+        assert "COMPUTADOR" in result.descrição
+        assert result.grupo == "ATIVIDADES DOS SERVICOS DE TI"
+        assert result.divisao == "ATIVIDADES DOS SERVICOS DE TI"
+
+
+@pytest.mark.asyncio
+async def test_get_class_not_found(client):
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.side_effect = FiscalHTTPError("Not found", 404, "http://test")
+        with pytest.raises(FiscalNotFoundError):
+            await client.get_class("99999")

--- a/tests/test_ibge.py
+++ b/tests/test_ibge.py
@@ -21,8 +21,24 @@ async def test_get_states_success(client):
 
 
 @pytest.mark.asyncio
+async def test_get_state_success(client):
+    """get_state usa get() pois /estados/{uf} retorna objeto, nao lista."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.return_value = {
+            "id": 35,
+            "sigla": "SP",
+            "nome": "São Paulo",
+            "regiao": {"id": 3, "sigla": "SE", "nome": "Sudeste"},
+        }
+        result = await client.get_state("SP")
+        assert result.sigla == "SP"
+        assert result.nome == "São Paulo"
+        assert result.regiao == "Sudeste"
+
+
+@pytest.mark.asyncio
 async def test_get_state_not_found(client):
-    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get_list") as mock_get:
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
         mock_get.side_effect = FiscalHTTPError("Not found", 404, "http://test")
         with pytest.raises(FiscalNotFoundError):
             await client.get_state("XX")
@@ -39,7 +55,30 @@ async def test_get_municipalities_success(client):
 
 @pytest.mark.asyncio
 async def test_get_municipality_success(client):
-    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get_list") as mock_get:
-        mock_get.return_value = [{"id": 3550308, "nome": "São Paulo"}]
+    """get_municipality usa get() pois /municipios/{code} retorna objeto, nao lista."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.return_value = {
+            "id": 3550308,
+            "nome": "São Paulo",
+            "microrregiao": {
+                "id": 35061,
+                "nome": "São Paulo",
+                "mesorregiao": {
+                    "id": 3515,
+                    "nome": "Metropolitana de São Paulo",
+                    "UF": {"id": 35, "sigla": "SP", "nome": "São Paulo"},
+                },
+            },
+        }
         result = await client.get_municipality(3550308)
         assert result.id == 3550308
+        assert result.nome == "São Paulo"
+        assert result.estado == "SP"
+
+
+@pytest.mark.asyncio
+async def test_get_municipality_not_found(client):
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.side_effect = FiscalHTTPError("Not found", 404, "http://test")
+        with pytest.raises(FiscalNotFoundError):
+            await client.get_municipality(9999999)


### PR DESCRIPTION
## Problema

Quatro ferramentas quebravam com **FiscalHTTPError: A resposta nao e uma lista JSON valida** porque o codigo chamava `get_list()` em endpoints que retornam um objeto JSON, nao um array.

## Endpoints afetados

| Endpoint | Retorno real | Metodo anterior | Metodo correto |
|---|---|---|---|
| IBGE Localidades `/estados/{uf}` | objeto | `get_list` | `get` |
| IBGE Localidades `/municipios/{id}` | objeto | `get_list` | `get` |
| IBGE CNAE `/subclasses/{code}` | objeto | `get_list` | `get` |
| IBGE CNAE `/classes/{code}` | objeto | `get_list` | `get` |

Endpoints de lista continuam usando `get_list` corretamente:
- `/estados`, `/municipios`, `/subclasses`, `/classes` (sem ID) - retornam arrays
- BCB SGS `/bcdata.sgs.{id}/dados` - retorna array
- SEFAZ status - ja usava `get()` corretamente (nao estava quebrado)

## Correcoes adicionais em `cnae/client.py`

- Campo da API IBGE e `descricao` (sem acento), nao `descrição` - todas as referencias corrigidas
- Removido bloco `try/except` duplicado com `pass` vazio em `get_activities`

## Provas de funcionamento (chamadas reais)

```
get_state(SP): Sao Paulo / Sudeste
get_municipality(3550308): Sao Paulo / SP
get_activity(6201501): 6201501 - DESENVOLVIMENTO DE PROGRAMAS DE COMPUTADOR SOB ENCOMENDA
get_class(62015): 62015 - DESENVOLVIMENTO DE PROGRAMAS DE COMPUTADOR SOB ENCOMENDA
  grupo: ATIVIDADES DOS SERVICOS DE TECNOLOGIA DA INFORMACAO
  divisao: ATIVIDADES DOS SERVICOS DE TECNOLOGIA DA INFORMACAO
```

## Testes

- 589 testes passando (suite completa)
- `test_ibge.py`: 4 testes novos (get_state, get_municipality, not_found para ambos)
- `test_cnae.py`: 3 testes novos (get_activity, get_class, not_found para ambos); mocks atualizados para refletir `get()` vs `get_list()` correto

## Checklist

- [x] Endpoints de objeto usam `get()`
- [x] Endpoints de lista preservam `get_list()`
- [x] Nomes de campo da API corrigidos (`descricao` sem acento)
- [x] Suite completa verde (589 testes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Otimizou consultas de atividades e classes CNAE com chamadas de API mais eficientes.
  * Normalizou campos de descrição nos dados retornados pela IBGE.
  * Simplificou a busca de estados e municípios com lógica de requisição melhorada.

* **Tests**
  * Atualizou cobertura de testes para validar novo comportamento de consultas individuais.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->