### PR TITLE
docs: adiciona badge de cobertura de testes (85%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://pypi.org/project/mcp-fiscal-brasil/"><img src="https://img.shields.io/pypi/dm/mcp-fiscal-brasil?color=009c3b&label=downloads%2Fm%C3%AAs" alt="PyPI downloads"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-002776?logo=python&logoColor=white" alt="Python 3.10+"></a>
   <a href="https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/workflows/ci.yml"><img src="https://github.com/DeHor-Labs/mcp-fiscal-brasil/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <img src="https://img.shields.io/badge/cobertura-85%25-009c3b?labelColor=002776" alt="Cobertura de testes 85%">
   <a href="LICENSE"><img src="https://img.shields.io/badge/licenca-MIT-FFDF00?labelColor=002776" alt="License MIT"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatível-7c3aed" alt="MCP Compatible"></a>
   <img src="https://img.shields.io/github/stars/DeHor-Labs/mcp-fiscal-brasil?style=flat&color=009c3b" alt="Stars">


### PR DESCRIPTION
## Resumo

- Adiciona badge shields.io de cobertura ao bloco de badges do README
- Valor exibido: **85%** (medido por pytest-cov - valor real do projeto)
- Badge posicionado logo apos o badge de CI, antes do badge de licenca

## Por que 85% e nao outro valor

A medicao real com `pytest --cov=src --cov-report=term-missing` retornou 85%. O valor anterior citado em algumas descricoes (92%) estava incorreto e nao havia sido publicado no README - esta PR garante que o numero publico reflete a realidade.

## Checklist

- [x] Apenas README.md modificado (mudanca cosmética/doc)
- [x] Nenhuma alteracao em codigo Python
- [x] Badge estatico shields.io (sem dependencia externa de servico de coverage)