### PR TITLE
docs: corrige link de workflows no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="https://dehor-labs.github.io/mcp-fiscal-brasil/">📚 Documentação</a> ·
   <a href="#-instalação">Instalação</a> ·
   <a href="#-ferramentas-disponíveis">Ferramentas</a> ·
-  <a href="#-workflows-agênticos">Workflows</a> ·
+  <a href="#workflows-que-vendem-sozinho">Workflows</a> ·
   <a href="#-roadmap">Roadmap</a> ·
   <a href="#-contribuindo">Contribuindo</a>
 </p>


### PR DESCRIPTION
## Problema

O link "Workflows" no topo do README apontava para uma âncora inexistente (`#-workflows-agênticos`).

## Solução

Atualizei o `href` para a seção real `### Workflows que vendem sozinho`.

## Validação

- Checagem local confirmou 1 link para `#workflows-que-vendem-sozinho` e 1 seção de destino correspondente.
- `/opt/homebrew/bin/ruff check src tests scripts` passou.
- `git diff --check` passou.

## Riscos

Baixo: alteração apenas documental em um link interno do README.

## Fora de escopo

Não atualizei dependências, lockfile, release, deploy nem outros textos do README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Ajuste no sumário da documentação para levar diretamente à seção **“Workflows que vendem sozinho”**.
  * O link de navegação foi corrigido para abrir a âncora correta, melhorando a usabilidade e evitando redirecionamentos incorretos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->