### PR TITLE
docs: alinha comandos de contribuição com CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,9 +570,11 @@ pre-commit install
 git checkout -b feature/meu-recurso
 
 # 4. Implemente, teste e verifique
-pytest
-ruff check src/
+python scripts/check_release_metadata.py
+ruff check src/ tests/
+ruff format --check src/ tests/
 mypy src/
+pytest
 
 # 5. Abra um Pull Request
 ```


### PR DESCRIPTION
## Problema

O bloco de contribuição do README orientava `ruff check src/`, mas a CI valida `src/ tests/`, também roda `ruff format --check` e checa metadados de release.

## Solução

Atualizei apenas o bloco de comandos de verificação no README para refletir a sequência principal da CI.

## Validação

- `git diff --check`
- `python scripts/check_release_metadata.py`
- `rg -n "python scripts/check_release_metadata.py|ruff check src/ tests/|ruff format --check src/ tests/|mypy src/|pytest" README.md .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ci.yml`

## Riscos e fora de escopo

Mudança apenas documental. Não alterei código runtime, dependências, lockfile, release, deploy, publicação, certificados, dados fiscais ou automações de produção.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Atualizado o checklist de contribuição com uma nova ordem para as verificações locais.
  * Agora as validações recomendadas seguem uma sequência mais clara: checagem de metadados, análise de código, formatação, tipagem e, por fim, testes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->