### PR TITLE
fix: status SEFAZ real + correções portadas do fork Italo9

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,30 @@
 # Host/interface de bind quando o transporte e HTTP ou SSE.
 # Ignorado no modo stdio. Padrao: 0.0.0.0 (escuta em todas as interfaces).
 # HOST=0.0.0.0
+
+# Certificado digital A1 (e-CNPJ), necessario para consultar o status real das
+# SEFAZ (NfeStatusServico4) e para manifestacao/distribuicao de NF-e via API REST.
+# Sem estas variaveis, o servico funciona normalmente, mas GET /v1/nfe/status-sefaz
+# responde HTTP 503 (certificado A1 nao configurado - exigencia de transporte mTLS).
+#
+# NUNCA defina NFE_CERTIFICADO_SENHA em texto plano num .env versionado ou num
+# ambiente compartilhado. Em producao (Cloud Run/Fly.io), configure como secret
+# montado como arquivo/variavel, nunca como env var visivel em `docker inspect`
+# ou no console do provedor.
+
+# Caminho absoluto do arquivo .pfx/.p12 do certificado A1, montado no container
+# (ex: Cloud Run secret volume, Fly.io secret file).
+# NFE_CERTIFICADO_PATH=/secrets/certificado.pfx
+
+# Senha do certificado. Deve vir de um secret manager (Secret Manager, Fly secrets),
+# nunca de um .env em disco em producao.
+# NFE_CERTIFICADO_SENHA=
+
+# CNPJ do titular do certificado (14 digitos, opcional). Quando definido, todo
+# certificado carregado (status, distribuicao, manifestacao) e conferido contra
+# esse CNPJ; carregar um certificado de outro titular levanta erro em vez de
+# seguir silenciosamente com o certificado errado.
+# NFE_EMITENTE_CNPJ=
+
+# Ambiente SEFAZ: producao ou homologacao. Padrao: producao.
+# NFE_AMBIENTE=producao

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## Unreleased
+
+Correções originadas do fork de Italo9 (github.com/Italo9/mcp-fiscal-brasil),
+portadas seletivamente para o repositório canônico.
+
+### BREAKING CHANGES
+
+* `consultar_status_sefaz` agora consulta o webservice real da SEFAZ
+  (NfeStatusServico4, mTLS) em vez do proxy da BrasilAPI, e por isso passa a
+  exigir certificado digital A1 configurado (`NFE_CERTIFICADO_PATH` /
+  `NFE_CERTIFICADO_SENHA`). Sem certificado, a tool levanta
+  `FiscalConfigurationError`; o endpoint REST `GET /v1/nfe/status-sefaz`
+  responde 503 em vez de fingir sucesso com lista vazia.
+
+### Novas funcionalidades
+
+* consulta real de status da SEFAZ via NfeStatusServico4 (mTLS), substituindo
+  o antigo proxy da BrasilAPI que retornava 404 para toda UF
+* endpoint `GET /v1/fiscal/certificado/status` informa apenas
+  configurado/válido/validade_fim - sem titular nem CNPJ, para não permitir
+  reconhecimento de identidade em um endpoint sem autenticação - sem nunca
+  expor o arquivo ou a senha do certificado
+* endpoint `GET /v1/nfe/status-sefaz` consolidado, consultando as 27 UFs em
+  paralelo quando nenhuma UF específica é informada, com cache em memória de
+  60 segundos por UF para conter o fan-out de chamadas mTLS reais ao
+  certificado do operador; falha pontual de rede em uma UF é omitida da
+  resposta (sem derrubar a chamada inteira), mas certificado ausente responde
+  503 e não mais lista vazia
+* `POST /v1/nfe/validate` aceita conteúdo XML inline (campo `xml`), além do
+  `xml_path` (caminho de arquivo) já existente
+* configuração de certificado digital A1 via `NFE_CERTIFICADO_PATH`,
+  `NFE_CERTIFICADO_SENHA`, `NFE_EMITENTE_CNPJ` e `NFE_AMBIENTE`; quando
+  `NFE_EMITENTE_CNPJ` está definido, todo certificado carregado é conferido
+  contra esse CNPJ
+* nova exceção `FiscalConfigurationError` para integrações fiscais que
+  exigem configuração ausente no deploy (distinta de erro de validação de
+  input ou de falha do serviço externo)
+
+### Correções
+
+* healthcheck do Dockerfile passa a detectar automaticamente o modo do
+  container (stdio vs. REST API vs. MCP HTTP/SSE), evitando falso "unhealthy"
+  permanente; o servidor MCP passa a expor `GET /health` nos transportes
+  http/sse (antes só existia `/mcp`, então o healthcheck sempre falhava
+  nesses modos)
+* `GET /v1/nfe/status-sefaz` não engole mais `FiscalConfigurationError` como
+  sucesso vazio (200); certificado ausente agora responde 503 com detail
+  claro. Degradação silenciosa (log + omissão da UF) fica restrita a falha
+  pontual de rede (`FiscalHTTPError`)
+* `GET /v1/fiscal/certificado/status` deixa de expor titular e CNPJ do
+  certificado configurado (recon desnecessário em endpoint sem autenticação)
+
+### Refatoração
+
+* helpers de carregamento de certificado A1 e envio SOAP com mTLS
+  (`carregar_pkcs12`, `criar_ssl_context_em_memoria`, `enviar_soap`)
+  extraídos para `nfe/_soap_mtls.py` e compartilhados entre distribuição,
+  manifestação e consulta de status
+* `_endpoint_para_uf` (status_sefaz.py) passa a levantar
+  `FiscalValidationError` para UF sem endpoint mapeado, em vez de
+  `FiscalConfigurationError` (reservada a certificado A1 ausente)
+
+### Notas
+
+* Follow-up conhecido (pré-existente ao port, fora de escopo desta entrega):
+  as rotas REST deste serviço não possuem autenticação nem rate limit por
+  cliente. Avaliar API key e/ou rate limit por cliente em versão futura.
+
 ## [0.5.1](https://github.com/DeHor-Labs/mcp-fiscal-brasil/compare/v0.5.0...v0.5.1) (2026-06-21)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY --from=builder /build/dist/*.whl ./
+COPY scripts/docker_healthcheck.py ./docker_healthcheck.py
 
 RUN pip install --no-cache-dir *.whl && \
     rm -f *.whl && \
@@ -54,8 +55,12 @@ USER app
 
 EXPOSE 8000
 
+# O CMD padrao (mcp-fiscal-brasil, stdio) nao abre porta HTTP. O healthcheck
+# detecta automaticamente qual modo esta rodando: se a porta estiver
+# escutando, valida via GET /health; caso contrario, confirma so que o
+# pacote importa (modo stdio). Ver scripts/docker_healthcheck.py.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import mcp_fiscal_brasil; print('ok')" || exit 1
+    CMD python docker_healthcheck.py || exit 1
 
 # Comando padrao: servidor MCP via stdio (uso por clientes MCP nativos).
 # Sobrescreva para REST API: docker run ... mcp-fiscal-api

--- a/README.md
+++ b/README.md
@@ -213,11 +213,11 @@ Funcionam 100% sem chaves de API. Instale e use imediatamente.
 | CNPJ | `consultar_cnpj` | Dados completos: razão social, sócios, CNAE, endereço | BrasilAPI (grátis) |
 | CNPJ | `consultar_simples_nacional` | Optante Simples/MEI com datas de entrada e exclusão | BrasilAPI (grátis) |
 | NFe | `validar_chave_nfe` | Valida dígito + extrai UF, CNPJ, data, número | Offline |
-| NFe | `consultar_status_sefaz` | Status do webservice SEFAZ por estado | BrasilAPI (grátis) |
 | NFe | `consultar_nfe` | Consulta NFe completa pela chave de 44 dígitos | BrasilAPI (grátis) |
 | NFe | `parse_nfe_xml` | Parseia XML bruto de NF-e/NFC-e e retorna dados estruturados | Offline |
 | NFe | `gerar_danfe` | Gera DANFE PDF (A4) a partir do XML de NF-e (mod 55) | Offline |
 | NFe | `validar_assinatura_nfe` | Valida assinatura XMLDSig e extrai dados do certificado | Offline |
+| NFe | `consultar_status_sefaz` | Status real do webservice SEFAZ por estado via NfeStatusServico4 (requer cert A1) | SEFAZ (mTLS) |
 | NFe | `baixar_nfe_distribuicao` | Baixa documentos via NFeDistribuicaoDFe (requer cert A1 local) | SEFAZ (mTLS) |
 | NFe | `manifestar_nfe` | Manifesta destinatario em NF-e via NFeRecepcaoEvento (requer cert A1) | SEFAZ (mTLS) |
 | CPF | `validar_cpf` | Validação de dígito verificador | Offline |
@@ -242,13 +242,40 @@ Retornam URLs e instruções - exigem ação manual nos portais governamentais.
 
 ### 🔐 Ferramentas com Certificado A1 (opt-in)
 
-As tools `baixar_nfe_distribuicao` e `manifestar_nfe` requerem um certificado
-digital A1 (`.pfx`/`.p12`) **instalado localmente no seu computador**.
+As tools `baixar_nfe_distribuicao`, `manifestar_nfe` e `consultar_status_sefaz`
+requerem um certificado digital A1 (`.pfx`/`.p12`). mTLS é exigência de
+transporte de todo webservice SEFAZ, inclusive a consulta de status - não há
+como consultar o status real sem certificado.
 
-- O certificado e a senha **nunca sao enviados a nenhum servidor externo**.
-- A autenticacao mTLS e a assinatura XMLDSig sao feitas localmente.
-- Estas tools se conectam diretamente aos webservices da SEFAZ (Ambiente Nacional).
-- Todas as demais tools (parse, DANFE, assinatura, consultas) funcionam sem certificado.
+- O certificado e a senha **nunca são enviados a nenhum servidor externo**.
+- A autenticação mTLS e a assinatura XMLDSig são feitas localmente.
+- `baixar_nfe_distribuicao` e `manifestar_nfe` recebem o caminho do certificado
+  como parâmetro da própria tool (`.pfx`/`.p12` local).
+- `consultar_status_sefaz` (via servidor MCP/API REST) usa o certificado
+  configurado nas variáveis de ambiente abaixo, e se conecta ao webservice
+  próprio da UF consultada ou ao ambiente virtual (SVRS/SVAN) quando a UF não
+  tem infraestrutura própria.
+- As demais tools (parse, DANFE, assinatura, consultas de CNPJ/NFe via
+  BrasilAPI) funcionam sem certificado.
+
+**Configuração** (variáveis em `.env` ou secret do provedor de deploy - ver
+`.env.example`):
+
+| Variável | Descrição |
+|----------|-----------|
+| `NFE_CERTIFICADO_PATH` | Caminho absoluto do `.pfx`/`.p12` montado no container |
+| `NFE_CERTIFICADO_SENHA` | Senha do certificado (sempre via gestor de segredos, nunca em `.env` versionado) |
+| `NFE_EMITENTE_CNPJ` | CNPJ do titular do certificado (14 dígitos, opcional) |
+| `NFE_AMBIENTE` | `producao` ou `homologacao` (padrão `producao`) |
+
+Sem `NFE_CERTIFICADO_PATH`/`NFE_CERTIFICADO_SENHA`, `consultar_status_sefaz`
+levanta `FiscalConfigurationError` e o endpoint HTTP `GET /v1/nfe/status-sefaz`
+responde 503 - o chamador deve tratar isso como "sem certificado configurado",
+não como SEFAZ fora do ar (falha pontual de rede em uma UF especifica, essa
+sim, degrada omitindo a UF em vez de derrubar a chamada). `GET
+/v1/fiscal/certificado/status` informa apenas se há certificado configurado e
+válido (sem titular nem CNPJ - endpoint sem autenticação, não deve permitir
+reconhecimento de identidade), sem nunca expor o arquivo ou a senha.
 
 ---
 

--- a/scripts/docker_healthcheck.py
+++ b/scripts/docker_healthcheck.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Healthcheck do container Docker do mcp-fiscal-brasil.
+
+O CMD padrao da imagem roda o servidor MCP via stdio (sem porta HTTP), mas o
+mesmo container tambem pode ser usado para a REST API (`mcp-fiscal-api`) ou o
+transporte MCP HTTP. Um HEALTHCHECK fixo em HTTP falharia sempre no modo
+stdio; um HEALTHCHECK fixo em import nao detectaria a API travada.
+
+Este script degrada automaticamente: se a porta configurada estiver
+escutando, valida via HTTP GET /health; caso contrario, confirma apenas que o
+pacote importa (suficiente para o modo stdio, que nao abre porta).
+
+Exit 0 = saudavel, exit 1 = nao saudavel.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import urllib.request
+
+PORT = int(os.environ.get("PORT", "8000"))
+_TIMEOUT_SECONDS = 3.0
+
+
+def _porta_aberta() -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1.0)
+        return sock.connect_ex(("127.0.0.1", PORT)) == 0
+
+
+def main() -> int:
+    if _porta_aberta():
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{PORT}/health", timeout=_TIMEOUT_SECONDS
+            ) as resp:
+                return 0 if resp.status == 200 else 1
+        except Exception as exc:
+            print(f"Erro no healthcheck HTTP: {exc}", file=sys.stderr)
+            return 1
+
+    try:
+        import mcp_fiscal_brasil  # noqa: F401
+    except Exception as exc:
+        print(f"Erro no import do pacote: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mcp_fiscal_brasil/_core/__init__.py
+++ b/src/mcp_fiscal_brasil/_core/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import Settings, settings
 from .errors import (
+    FiscalConfigurationError,
     FiscalError,
     FiscalHTTPError,
     FiscalNotFoundError,
@@ -12,6 +13,7 @@ from .http import HTTPClient
 from .logging import get_logger
 
 __all__ = [
+    "FiscalConfigurationError",
     "FiscalError",
     "FiscalHTTPError",
     "FiscalNotFoundError",

--- a/src/mcp_fiscal_brasil/_core/config.py
+++ b/src/mcp_fiscal_brasil/_core/config.py
@@ -19,6 +19,15 @@ class Settings(BaseSettings):
     ibge_localidades_base_url: str = "https://servicodados.ibge.gov.br/api/v1/localidades"
     bcb_sgs_base_url: str = "https://api.bcb.gov.br/dados/serie"
 
+    # Certificado digital A1 (e-CNPJ) para consultas mTLS aos webservices SEFAZ
+    # (status de servico, distribuicao, manifestacao). Configurado via secret/volume
+    # montado no deploy (Cloud Run --set-secrets, Fly.io secrets ou volume Docker),
+    # nunca em texto plano no .env de producao.
+    nfe_certificado_path: str = ""
+    nfe_certificado_senha: str = ""
+    nfe_emitente_cnpj: str = ""
+    nfe_ambiente: str = "producao"
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 

--- a/src/mcp_fiscal_brasil/_core/errors.py
+++ b/src/mcp_fiscal_brasil/_core/errors.py
@@ -123,7 +123,18 @@ class FiscalNotFoundError(FiscalError):
         return fields
 
 
+class FiscalConfigurationError(FiscalError):
+    """Exception raised when a required fiscal integration is not configured.
+
+    Distinct from FiscalValidationError (bad input) and FiscalHTTPError
+    (upstream reachable but failed): this means the deployment itself is
+    missing a prerequisite (e.g. no A1 certificate configured), not a
+    request-level or upstream failure.
+    """
+
+
 __all__ = [
+    "FiscalConfigurationError",
     "FiscalError",
     "FiscalHTTPError",
     "FiscalNotFoundError",

--- a/src/mcp_fiscal_brasil/api.py
+++ b/src/mcp_fiscal_brasil/api.py
@@ -14,16 +14,19 @@ OpenAPI docs em http://localhost:8000/docs (Swagger UI).
 
 from __future__ import annotations
 
+import asyncio
 import os
+import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
+from cachetools import TTLCache
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 from . import __version__
-from ._core import get_logger
+from ._core import FiscalHTTPError, get_logger
 from ._core.config import settings
 from .agentic import (
     analyze_cnpj_compliance,
@@ -36,7 +39,8 @@ from .cep.client import CEPClient
 from .cnpj.tools import consultar_cnpj
 from .cpf.tools import validar_cpf_tool
 from .ibge.client import IBGEClient
-from .nfe.tools import validar_chave_nfe
+from .nfe.status_sefaz import obter_status_certificado
+from .nfe.tools import UFS_VALIDAS, consultar_status_sefaz, validar_chave_nfe
 from .shared.validators import validate_cnpj
 from .simples.client import SimplesClient
 
@@ -194,15 +198,164 @@ async def nfe_chave_validate(chave: str) -> dict[str, Any]:
     return await validar_chave_nfe(chave)
 
 
+_STATUS_SEFAZ_CACHE_TTL_SEGUNDOS = 60
+
+# Cache in-memory por UF (nao distribuido - ponytail: um pod novo comeca frio,
+# suficiente para o caso de uso atual de mitigar fan-out por instancia). Reduz
+# o disparo repetido das ~27 chamadas mTLS reais ao certificado do operador em
+# rajadas de requisicoes ao endpoint dentro da mesma janela de 60s.
+_status_sefaz_cache: TTLCache[str, dict[str, Any]] = TTLCache(
+    maxsize=len(UFS_VALIDAS), ttl=_STATUS_SEFAZ_CACHE_TTL_SEGUNDOS
+)
+
+
+def _certificado_configurado() -> bool:
+    return bool(settings.nfe_certificado_path and settings.nfe_certificado_senha)
+
+
+async def _consultar_status_sefaz_cache(uf: str) -> dict[str, Any] | None:
+    """Consulta o status SEFAZ de uma UF, com cache de 60s e degradacao por falha pontual.
+
+    FiscalHTTPError (falha de rede ou rejeicao da SEFAZ) e tratado como
+    degradacao silenciosa (log + omite a UF). Qualquer outro erro propaga.
+    """
+    cacheado = _status_sefaz_cache.get(uf)
+    if cacheado is not None:
+        return cacheado
+
+    try:
+        resultado = await consultar_status_sefaz(uf)
+    except FiscalHTTPError as exc:
+        logger.warning("sefaz_status_failed", uf=uf, error=str(exc))
+        return None
+
+    data = resultado.model_dump(mode="json", exclude_none=True)
+    _status_sefaz_cache[uf] = data
+    return data
+
+
+@app.get(
+    "/v1/nfe/status-sefaz",
+    tags=["nfe"],
+    summary="Status operacional das SEFAZ (requer certificado A1)",
+)
+async def nfe_status_sefaz(
+    uf: str | None = Query(
+        None,
+        description="UF especifica (2 letras). Sem esse parametro, consulta todas as UFs.",
+    ),
+) -> dict[str, Any]:
+    """Consulta o status operacional dos webservices SEFAZ (NfeStatusServico4).
+
+    Requer certificado digital A1 configurado no servidor (NFE_CERTIFICADO_PATH /
+    NFE_CERTIFICADO_SENHA) - mTLS é exigência de transporte de todo webservice
+    SEFAZ, inclusive consulta de status. Sem certificado configurado, responde
+    503 (indisponibilidade de configuração, não uma falha de UF). Em caso de
+    falha pontual de rede em uma UF específica, essa UF é omitida da resposta
+    em vez de derrubar a chamada inteira com 500.
+
+    O resultado por UF é cacheado em memória por até 60 segundos: dentro dessa
+    janela, chamadas repetidas não disparam nova consulta mTLS real à SEFAZ.
+    """
+    # Erro de input do chamador (UF invalida) precede a checagem de config do
+    # servidor: 400 antes de 503, na ordem usual de validacao HTTP.
+    if uf:
+        uf_upper = uf.upper().strip()
+        if uf_upper not in UFS_VALIDAS:
+            raise HTTPException(status_code=400, detail="UF inválida")
+
+    if not _certificado_configurado():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Certificado digital A1 não configurado no servidor "
+                "(NFE_CERTIFICADO_PATH / NFE_CERTIFICADO_SENHA). "
+                "Consulta de status SEFAZ exige certificado."
+            ),
+        )
+
+    if uf:
+        resultado = await _consultar_status_sefaz_cache(uf_upper)
+        return {"ufs": [resultado] if resultado is not None else []}
+
+    tarefas = [_consultar_status_sefaz_cache(u) for u in sorted(UFS_VALIDAS)]
+    concluidos = await asyncio.gather(*tarefas)
+    return {"ufs": [r for r in concluidos if r is not None]}
+
+
+class CertificadoStatusResponse(BaseModel):
+    configurado: bool
+    valido: bool | None = None
+    validade_fim: str | None = None
+
+
+@app.get(
+    "/v1/fiscal/certificado/status",
+    response_model=CertificadoStatusResponse,
+    tags=["nfe"],
+    summary="Estado do certificado digital A1 configurado no servidor fiscal",
+)
+async def fiscal_certificado_status() -> CertificadoStatusResponse:
+    """
+    Informa se há certificado A1 configurado, sem expor identidade do titular.
+
+    Endpoint sem autenticação: retorna apenas configurado/válido/validade_fim.
+    Nunca expõe o arquivo do certificado, a senha, o titular ou o CNPJ -
+    reconhecimento (recon) de identidade não é necessário para o chamador
+    saber se "há certificado configurado e válido".
+    """
+    resultado = obter_status_certificado(
+        caminho_certificado=settings.nfe_certificado_path,
+        senha=settings.nfe_certificado_senha,
+        ambiente=settings.nfe_ambiente,
+    )
+    return CertificadoStatusResponse(
+        configurado=resultado.configurado,
+        valido=resultado.valido,
+        validade_fim=resultado.validade_fim.isoformat() if resultado.validade_fim else None,
+    )
+
+
+_MAX_XML_INLINE_BYTES = 5 * 1024 * 1024  # 5 MB, generoso para NF-e completa com muitos itens
+
+
 class NFeValidateRequest(BaseModel):
-    xml_path: str = Field(description="Caminho absoluto para arquivo XML da NFe.")
+    xml: str | None = Field(default=None, description="Conteúdo XML da NFe (string).")
+    xml_path: str | None = Field(
+        default=None, description="Caminho absoluto para arquivo XML da NFe (legado)."
+    )
 
 
 @app.post("/v1/nfe/validate", tags=["nfe", "agentic"], summary="Validacao consolidada de NFe")
 async def nfe_validate_full(req: NFeValidateRequest) -> dict[str, Any]:
-    """Parse XML + válida chave + verifica situacao do emissor."""
-    xml_path = _validated_input_file(req.xml_path, label="Arquivo XML")
-    resultado = await validate_nfe_full(xml_path)
+    """Parse XML + válida chave + verifica situação do emissor.
+
+    Aceita `xml` (conteúdo XML inline) ou `xml_path` (caminho de arquivo, legado).
+    """
+    if req.xml is not None:
+        xml_bytes = req.xml.encode("utf-8")
+        if len(xml_bytes) > _MAX_XML_INLINE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail="Conteúdo XML excede o tamanho máximo permitido (5 MB)",
+            )
+        base_dir = _allowed_file_base_dir()
+        fd, tmp_name = tempfile.mkstemp(suffix=".xml", dir=base_dir)
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as tmp_file:
+                tmp_file.write(xml_bytes)
+            resultado = await validate_nfe_full(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    elif req.xml_path:
+        xml_path = _validated_input_file(req.xml_path, label="Arquivo XML")
+        resultado = await validate_nfe_full(xml_path)
+    else:
+        raise HTTPException(
+            status_code=400, detail="Forneça 'xml' (conteúdo) ou 'xml_path' (caminho)"
+        )
+
     return resultado.model_dump(mode="json", exclude_none=True)
 
 
@@ -394,6 +547,9 @@ def run() -> None:
     """Entry point para o comando `mcp-fiscal-api`."""
     import uvicorn
 
+    # Default seguro fora de container e loopback. Em Docker, o Dockerfile ja
+    # define ENV HOST=0.0.0.0 na imagem - a exposicao externa vem da camada de
+    # deploy (container/proxy), nao de um default aberto aqui.
     host = os.environ.get("HOST", "127.0.0.1")
     port = int(os.environ.get("PORT", "8000"))
     uvicorn.run("mcp_fiscal_brasil.api:app", host=host, port=port, reload=False)

--- a/src/mcp_fiscal_brasil/nfe/_soap_mtls.py
+++ b/src/mcp_fiscal_brasil/nfe/_soap_mtls.py
@@ -1,0 +1,237 @@
+"""
+Helpers compartilhados para chamadas SOAP com mTLS aos webservices SEFAZ.
+
+Usado por distribuicao.py (NFeDistribuicaoDFe, NFeRecepcaoEvento) e
+status_sefaz.py (NfeStatusServico4). Centraliza carregamento de certificado
+A1 (.pfx/.p12), montagem do SSLContext e envio do envelope SOAP.
+
+SEGURANCA:
+- Senha do .pfx e chave privada NUNCA aparecem em logs, excecoes ou disco
+  persistente.
+- Arquivos PEM temporarios sao criados com permissao 0600 e apagados no
+  bloco finally.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import ssl
+import tempfile
+
+import httpx
+from lxml import etree
+
+from .._core.config import settings
+from .._core.errors import (
+    FiscalConfigurationError,
+    FiscalHTTPError,
+    FiscalValidationError,
+)
+from ..shared.rate_limiter import SlidingWindowRateLimiter
+from ..shared.xml_utils import build_soap_envelope, extract_soap_body
+
+# Rate limiter conservador para endpoints SEFAZ (~1 req/s por endpoint), para
+# nao misturar cotas entre distribuicao, eventos e status.
+sefaz_rate_limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=1.0)
+
+_CNPJ_DIGITS_RE = re.compile(r"\D")
+
+
+def _validar_emitente_cnpj(cert_pem: bytes) -> None:
+    """
+    Confere que o certificado carregado pertence ao NFE_EMITENTE_CNPJ configurado.
+
+    Nao faz nada se NFE_EMITENTE_CNPJ nao estiver configurado (opt-in: tools que
+    recebem caminho_certificado/senha diretamente por parametro continuam
+    funcionando sem essa variavel, comportamento legado preservado).
+
+    Raises:
+        FiscalConfigurationError: se NFE_EMITENTE_CNPJ estiver configurado e o
+            certificado carregado pertencer a outro CNPJ.
+    """
+    esperado = _CNPJ_DIGITS_RE.sub("", settings.nfe_emitente_cnpj or "")
+    if not esperado:
+        return
+
+    from cryptography import x509
+
+    from .assinatura import _extrair_cn, _extrair_cnpj_cpf
+
+    cert = x509.load_pem_x509_certificate(cert_pem)
+    cnpj_certificado = _extrair_cnpj_cpf(_extrair_cn(cert))
+
+    if cnpj_certificado != esperado:
+        raise FiscalConfigurationError(
+            message=(
+                "O certificado carregado nao corresponde ao NFE_EMITENTE_CNPJ "
+                "configurado. Confira se o arquivo montado e o CNPJ esperado "
+                "sao do mesmo titular."
+            )
+        )
+
+
+def carregar_pkcs12(
+    caminho_certificado: str,
+    senha: str,
+) -> tuple[bytes, bytes, list[bytes]]:
+    """
+    Carrega um arquivo PKCS12 (.pfx/.p12) e retorna (chave_pem, cert_pem, chain_pem).
+
+    SEGURANCA: a senha NAO e logada nem incluida em mensagens de excecao.
+
+    Raises:
+        FiscalValidationError: caminho invalido, senha incorreta ou certificado corrompido.
+        FiscalConfigurationError: NFE_EMITENTE_CNPJ configurado e divergente do
+            CNPJ do certificado carregado.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.serialization import pkcs12
+
+    try:
+        with open(caminho_certificado, "rb") as f:
+            pfx_data = f.read()
+    except OSError as exc:
+        raise FiscalValidationError(
+            message=f"Nao foi possivel abrir o certificado: {exc.strerror}. Verifique o caminho.",
+            field="caminho_certificado",
+            value=caminho_certificado,
+        ) from exc
+
+    try:
+        private_key, certificate, additional_certs = pkcs12.load_key_and_certificates(
+            pfx_data, senha.encode("utf-8")
+        )
+    except Exception as exc:
+        exc_str = str(exc)
+        if "password" in exc_str.lower() or "senha" in exc_str.lower():
+            motivo = "Senha incorreta ou certificado corrompido."
+        else:
+            motivo = f"Erro ao carregar certificado PKCS12: {exc.__class__.__name__}"
+        raise FiscalValidationError(
+            message=motivo,
+            field="caminho_certificado",
+            value=caminho_certificado,
+        ) from exc
+
+    if private_key is None or certificate is None:
+        raise FiscalValidationError(
+            message="Certificado ou chave privada ausente no arquivo PKCS12.",
+            field="caminho_certificado",
+            value=caminho_certificado,
+        )
+
+    chave_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    cert_pem = certificate.public_bytes(serialization.Encoding.PEM)
+    chain_pem = [c.public_bytes(serialization.Encoding.PEM) for c in additional_certs or []]
+
+    _validar_emitente_cnpj(cert_pem)
+
+    return chave_pem, cert_pem, chain_pem
+
+
+def _escrever_pem_atomico(suffix: str, conteudo: bytes) -> str:
+    """
+    Cria um arquivo PEM temporario com permissao 0600 de forma atomica.
+
+    Usa tempfile.mkstemp(), que cria o arquivo atomicamente com permissao 0600
+    (sem janela de exposicao em 0644). Retorna o caminho do arquivo criado;
+    o chamador e responsavel por apagar o arquivo no bloco finally.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    try:
+        os.write(fd, conteudo)
+    finally:
+        os.close(fd)
+    return path
+
+
+def criar_ssl_context_em_memoria(
+    chave_pem: bytes,
+    cert_pem: bytes,
+    chain_pem: list[bytes],
+) -> ssl.SSLContext:
+    """
+    Monta um ssl.SSLContext usando arquivos PEM temporarios com permissao 0600.
+
+    Usa ssl.create_default_context() - forma recomendada pela stdlib para
+    validacao de certificado (CERT_REQUIRED + check_hostname habilitados e
+    CAs do sistema carregadas), em vez de instanciar SSLContext manualmente
+    e setar os atributos de seguranca um a um. Sobre esse contexto e
+    carregado o certificado de cliente (mTLS) via load_cert_chain().
+
+    Os arquivos sao criados via tempfile.mkstemp() (_escrever_pem_atomico),
+    que abre o arquivo atomicamente (O_CREAT|O_EXCL) ja com permissao
+    restrita 0600, sem janela de exposicao com permissao mais aberta. Sao
+    apagados no bloco finally. A chave privada nunca e logada.
+    """
+    ctx = ssl.create_default_context()
+
+    tmp_key: str | None = None
+    tmp_cert: str | None = None
+
+    try:
+        tmp_key = _escrever_pem_atomico("_key.pem", chave_pem)
+        tmp_cert = _escrever_pem_atomico("_cert.pem", cert_pem + b"".join(chain_pem))
+
+        ctx.load_cert_chain(certfile=tmp_cert, keyfile=tmp_key)
+    finally:
+        if tmp_key and os.path.exists(tmp_key):
+            os.unlink(tmp_key)
+        if tmp_cert and os.path.exists(tmp_cert):
+            os.unlink(tmp_cert)
+
+    return ctx
+
+
+async def enviar_soap(
+    url: str,
+    soap_body_content: str,
+    ssl_ctx: ssl.SSLContext,
+    namespace: str,
+    timeout: float = 30.0,
+) -> etree._Element:
+    """Envia requisicao SOAP via mTLS e retorna o elemento Body da resposta.
+
+    Rate limit: maximo 1 req/s por endpoint SEFAZ (conservador para evitar
+    bloqueio por flood). O limitador e aplicado por URL de endpoint.
+    """
+    await sefaz_rate_limiter.acquire(url)
+
+    envelope = build_soap_envelope(soap_body_content, namespace=namespace)
+
+    headers = {
+        "Content-Type": "application/soap+xml; charset=utf-8",
+        "SOAPAction": "",
+    }
+
+    try:
+        async with httpx.AsyncClient(verify=ssl_ctx, timeout=timeout) as client:
+            response = await client.post(url, content=envelope.encode("utf-8"), headers=headers)
+    except httpx.RequestError as exc:
+        raise FiscalHTTPError(
+            message=f"Falha de conexao com a SEFAZ: {exc.__class__.__name__}",
+            status_code=0,
+            url=url,
+        ) from exc
+
+    if response.status_code != 200:
+        raise FiscalHTTPError(
+            message=f"SEFAZ retornou HTTP {response.status_code}",
+            status_code=response.status_code,
+            url=url,
+        )
+
+    return extract_soap_body(response.text)
+
+
+__all__ = [
+    "carregar_pkcs12",
+    "criar_ssl_context_em_memoria",
+    "enviar_soap",
+    "sefaz_rate_limiter",
+]

--- a/src/mcp_fiscal_brasil/nfe/client.py
+++ b/src/mcp_fiscal_brasil/nfe/client.py
@@ -12,6 +12,7 @@ from mcp_fiscal_brasil._core import (
 
 from ..shared.constants import CODIGO_UF
 from .schemas import NFeResponse, StatusSEFAZResponse
+from .status_sefaz import consultar_status_real
 from .xml_parser import parse_nfe_xml
 
 logger = get_logger(__name__)
@@ -194,29 +195,31 @@ class NFEClient:
         )
 
     async def consultar_status_servico(
-        self, uf: str, ambiente: str = "producao"
+        self, uf: str, ambiente: str | None = None
     ) -> StatusSEFAZResponse:
         """
-        Look up the SEFAZ service status for a state.
+        Consulta o status real do webservice SEFAZ da UF via NfeStatusServico4 (mTLS).
 
-        BrasilAPI acts as a proxy for the state SEFAZ webservice.
+        Exige certificado digital A1 configurado (NFE_CERTIFICADO_PATH /
+        NFE_CERTIFICADO_SENHA) - mTLS é exigência de transporte de todo webservice
+        SEFAZ, inclusive consulta de status. Sem certificado, propaga
+        FiscalConfigurationError; o chamador decide como tratar (api.py, por
+        exemplo, omite a UF da resposta em vez de fabricar um status falso).
         """
-        logger.info("sefaz_status_lookup_started", uf=uf, ambiente=ambiente)
+        ambiente_efetivo = ambiente or settings.nfe_ambiente
+        logger.info("sefaz_status_lookup_started", uf=uf, ambiente=ambiente_efetivo)
 
-        async with self._http_client(settings.brasilapi_base_url) as client:
-            try:
-                data = await client.get(f"/nfe/v1/status/{uf.upper()}")
-                return StatusSEFAZResponse(
-                    uf=uf.upper(),
-                    status=data.get("status", "Desconhecido"),
-                    descrição=data.get("descrição", ""),
-                    código=data.get("cStat"),
-                    ambiente=ambiente,
-                )
-            except Exception:
-                return StatusSEFAZResponse(
-                    uf=uf.upper(),
-                    status="Indisponível",
-                    descrição="Não foi possível consultar o status do serviço SEFAZ.",
-                    ambiente=ambiente,
-                )
+        resultado = await consultar_status_real(
+            uf.upper(),
+            caminho_certificado=settings.nfe_certificado_path,
+            senha=settings.nfe_certificado_senha,
+            ambiente="homologacao" if ambiente_efetivo == "homologacao" else "producao",
+        )
+
+        return StatusSEFAZResponse(
+            uf=resultado.uf,
+            status=resultado.status,
+            descrição=resultado.descricao or "",
+            código=resultado.codigo,
+            ambiente=ambiente_efetivo,
+        )

--- a/src/mcp_fiscal_brasil/nfe/distribuicao.py
+++ b/src/mcp_fiscal_brasil/nfe/distribuicao.py
@@ -17,37 +17,30 @@ SEGURANCA:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import gzip
-import os
 import re
-import ssl
-import tempfile
 import xml.sax.saxutils
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
-import httpx
 from lxml import etree
 from signxml import XMLSigner  # type: ignore[attr-defined, unused-ignore]
 
 from .._core.errors import FiscalHTTPError, FiscalValidationError
 from .._core.logging import get_logger
-from ..shared.rate_limiter import SlidingWindowRateLimiter
 from ..shared.validators import validate_chave_nfe
-from ..shared.xml_utils import build_soap_envelope, extract_soap_body, parse_xml
+from ..shared.xml_utils import parse_xml
+from ._soap_mtls import carregar_pkcs12, criar_ssl_context_em_memoria
+from ._soap_mtls import enviar_soap as _enviar_soap_mtls
 from .xml_parser import parse_nfe_xml
 
 if TYPE_CHECKING:
     from .schemas import NFeResponse
 
 logger = get_logger(__name__)
-
-# Rate limiter conservador para endpoints SEFAZ (~1 req/s).
-# Distribui a cota por chave de endpoint para nao misturar
-# distribuicao e recepcao de eventos.
-_sefaz_nfe_limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=1.0)
 
 # Tipo de ambiente SEFAZ
 Ambiente = Literal["producao", "homologacao"]
@@ -229,115 +222,6 @@ def _validar_chave(chave: str) -> str:
             value=chave,
         )
     return chave_limpa
-
-
-def _carregar_pkcs12(
-    caminho_certificado: str,
-    senha: str,
-) -> tuple[bytes, bytes, list[bytes]]:
-    """
-    Carrega um arquivo PKCS12 (.pfx/.p12) e retorna (chave_pem, cert_pem, chain_pem).
-
-    SEGURANCA: a senha NAO e logada nem incluida em mensagens de excecao.
-    """
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.serialization import pkcs12
-
-    try:
-        with open(caminho_certificado, "rb") as f:
-            pfx_data = f.read()
-    except OSError as exc:
-        raise FiscalValidationError(
-            message=f"Nao foi possivel abrir o certificado: {exc.strerror}. Verifique o caminho.",
-            field="caminho_certificado",
-            value=caminho_certificado,
-        ) from exc
-
-    try:
-        private_key, certificate, additional_certs = pkcs12.load_key_and_certificates(
-            pfx_data, senha.encode("utf-8")
-        )
-    except Exception as exc:
-        # Evitar vazar a senha na mensagem
-        exc_str = str(exc)
-        if "password" in exc_str.lower() or "senha" in exc_str.lower():
-            motivo = "Senha incorreta ou certificado corrompido."
-        else:
-            motivo = f"Erro ao carregar certificado PKCS12: {exc.__class__.__name__}"
-        raise FiscalValidationError(
-            message=motivo,
-            field="caminho_certificado",
-            value=caminho_certificado,
-        ) from exc
-
-    if private_key is None or certificate is None:
-        raise FiscalValidationError(
-            message="Certificado ou chave privada ausente no arquivo PKCS12.",
-            field="caminho_certificado",
-            value=caminho_certificado,
-        )
-
-    chave_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    cert_pem = certificate.public_bytes(serialization.Encoding.PEM)
-    chain_pem = []
-    for c in additional_certs or []:
-        chain_pem.append(c.public_bytes(serialization.Encoding.PEM))
-
-    return chave_pem, cert_pem, chain_pem
-
-
-def _escrever_pem_atomico(suffix: str, conteudo: bytes) -> str:
-    """
-    Cria um arquivo PEM temporario com permissao 0600 de forma atomica.
-
-    Usa tempfile.mkstemp(), que cria o arquivo atomicamente com permissao 0600
-    (sem janela de exposicao em 0644). Retorna o caminho do arquivo criado;
-    o chamador e responsavel por apagar o arquivo no bloco finally.
-    """
-    fd, path = tempfile.mkstemp(suffix=suffix)
-    try:
-        os.write(fd, conteudo)
-    finally:
-        os.close(fd)
-    return path
-
-
-def _criar_ssl_context_em_memoria(
-    chave_pem: bytes,
-    cert_pem: bytes,
-    chain_pem: list[bytes],
-) -> ssl.SSLContext:
-    """
-    Monta um ssl.SSLContext usando arquivos PEM temporarios com permissao 0600.
-
-    Os arquivos sao criados com os.open (O_CREAT|O_WRONLY|O_EXCL, 0o600)
-    para que ja nascam com a permissao restrita, sem janela 0644. Sao
-    apagados no bloco finally. A chave privada nunca e logada.
-    """
-    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    ctx.check_hostname = True
-    ctx.verify_mode = ssl.CERT_REQUIRED
-    ctx.load_default_certs()
-
-    tmp_key: str | None = None
-    tmp_cert: str | None = None
-
-    try:
-        tmp_key = _escrever_pem_atomico("_key.pem", chave_pem)
-        tmp_cert = _escrever_pem_atomico("_cert.pem", cert_pem + b"".join(chain_pem))
-
-        ctx.load_cert_chain(certfile=tmp_cert, keyfile=tmp_key)
-    finally:
-        if tmp_key and os.path.exists(tmp_key):
-            os.unlink(tmp_key)
-        if tmp_cert and os.path.exists(tmp_cert):
-            os.unlink(tmp_cert)
-
-    return ctx
 
 
 def _descompactar_doc_zip(doc_zip_b64: str) -> bytes:
@@ -557,47 +441,6 @@ def _parse_retorno_dist(body_el: etree._Element) -> DistribuicaoResult:
     )
 
 
-async def _enviar_soap(
-    url: str,
-    soap_body_content: str,
-    ssl_ctx: ssl.SSLContext,
-    timeout: float = 30.0,
-) -> etree._Element:
-    """Envia requisicao SOAP via mTLS e retorna o elemento Body da resposta.
-
-    Rate limit: maximo 1 req/s por endpoint SEFAZ (conservador para evitar
-    bloqueio por flood). O limitador e aplicado por URL de endpoint.
-    """
-    # Aplica rate-limit por endpoint antes de enviar a requisicao
-    await _sefaz_nfe_limiter.acquire(url)
-
-    envelope = build_soap_envelope(soap_body_content, namespace=_NS_NFE)
-
-    headers = {
-        "Content-Type": "application/soap+xml; charset=utf-8",
-        "SOAPAction": "",
-    }
-
-    try:
-        async with httpx.AsyncClient(verify=ssl_ctx, timeout=timeout) as client:
-            response = await client.post(url, content=envelope.encode("utf-8"), headers=headers)
-    except httpx.RequestError as exc:
-        raise FiscalHTTPError(
-            message=f"Falha de conexao com a SEFAZ: {exc.__class__.__name__}",
-            status_code=0,
-            url=url,
-        ) from exc
-
-    if response.status_code != 200:
-        raise FiscalHTTPError(
-            message=f"SEFAZ retornou HTTP {response.status_code}",
-            status_code=response.status_code,
-            url=url,
-        )
-
-    return extract_soap_body(response.text)
-
-
 # ---------------------------------------------------------------------------
 # Funcoes publicas
 # ---------------------------------------------------------------------------
@@ -650,9 +493,12 @@ async def baixar_nfe_distribuicao(
     uf_str = str(uf).strip()
     uf_codigo = _UF_CODIGOS.get(uf_str.upper(), uf_str)
 
-    # Carrega o certificado A1
-    chave_pem, cert_pem, chain_pem = _carregar_pkcs12(caminho_certificado, senha)
-    ssl_ctx = _criar_ssl_context_em_memoria(chave_pem, cert_pem, chain_pem)
+    # Carrega o certificado A1 (I/O de disco + criptografia sincronos: roda em
+    # thread separada para nao bloquear o event loop).
+    chave_pem, cert_pem, chain_pem = await asyncio.to_thread(
+        carregar_pkcs12, caminho_certificado, senha
+    )
+    ssl_ctx = await asyncio.to_thread(criar_ssl_context_em_memoria, chave_pem, cert_pem, chain_pem)
 
     # Monta o corpo SOAP conforme o modo
     endpoint = _ENDPOINTS_DISTRIBUICAO[ambiente]
@@ -688,7 +534,9 @@ async def baixar_nfe_distribuicao(
             value=modo,
         )
 
-    body_el = await _enviar_soap(endpoint, body_content, ssl_ctx, timeout)
+    body_el = await _enviar_soap_mtls(
+        endpoint, body_content, ssl_ctx, namespace=_NS_NFE, timeout=timeout
+    )
     return _parse_retorno_dist(body_el)
 
 
@@ -866,8 +714,12 @@ async def manifestar_nfe(
     ambiente_codigo = "1" if ambiente == "producao" else "2"
     endpoint = _ENDPOINTS_EVENTO[ambiente]
 
-    chave_pem, cert_pem, chain_pem = _carregar_pkcs12(caminho_certificado, senha)
-    ssl_ctx = _criar_ssl_context_em_memoria(chave_pem, cert_pem, chain_pem)
+    # I/O de disco + criptografia sincronos: roda em thread separada para nao
+    # bloquear o event loop.
+    chave_pem, cert_pem, chain_pem = await asyncio.to_thread(
+        carregar_pkcs12, caminho_certificado, senha
+    )
+    ssl_ctx = await asyncio.to_thread(criar_ssl_context_em_memoria, chave_pem, cert_pem, chain_pem)
 
     evento_el = _montar_xml_evento(
         chave=chave_norm,
@@ -881,7 +733,9 @@ async def manifestar_nfe(
     signed_el = _assinar_evento(evento_el, chave_pem, cert_pem)
     body_content = etree.tostring(signed_el, encoding="unicode")
 
-    body_el = await _enviar_soap(endpoint, body_content, ssl_ctx, timeout)
+    body_el = await _enviar_soap_mtls(
+        endpoint, body_content, ssl_ctx, namespace=_NS_NFE, timeout=timeout
+    )
     return _parse_retorno_evento(body_el, chave_norm, tipo_evento)
 
 

--- a/src/mcp_fiscal_brasil/nfe/status_sefaz.py
+++ b/src/mcp_fiscal_brasil/nfe/status_sefaz.py
@@ -1,0 +1,348 @@
+"""
+Consulta real de status operacional das SEFAZ via NfeStatusServico4.
+
+Cada UF delega a autorizacao de NF-e a um de tres grupos de webservice:
+- Estado com estrutura propria (AM, BA, GO, MG, MS, MT, PE, PR, RS, SP).
+- SVRS (Sefaz Virtual do Rio Grande do Sul): AC, AL, AP, CE, DF, ES, PA, PB,
+  PI, RJ, RN, RO, RR, SC, SE, TO.
+- SVAN (Sefaz Virtual do Ambiente Nacional): MA.
+
+Fonte dos endpoints: config publica mantida pelo projeto sped-nfe
+(nfephp-org/sped-nfe, storage/wsnfe_4.00_mod55.xml), conferida URL por URL
+contra o arquivo atual do repositorio antes de aceitar. Uma divergencia real
+foi corrigida durante essa conferencia: RS tem webservice proprio
+(nfe.sefazrs.rs.gov.br), distinto do SVRS (nfe.svrs.rs.gov.br, que RS opera
+para OUTRAS UFs sem infraestrutura propria) - RS nao deve ser tratado como
+membro do grupo SVRS. Todas as chamadas exigem mTLS com certificado A1 (nao
+ha consulta de status sem certificado - e uma exigencia da camada de
+transporte dos webservices SEFAZ, nao apenas de operacoes que gravam dados).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Literal
+
+from lxml import etree
+
+from .._core.errors import (
+    FiscalConfigurationError,
+    FiscalHTTPError,
+    FiscalValidationError,
+)
+from .._core.logging import get_logger
+from ..shared.constants import UF_CODES
+from ._soap_mtls import carregar_pkcs12, criar_ssl_context_em_memoria
+from ._soap_mtls import enviar_soap as _enviar_soap_mtls
+
+logger = get_logger(__name__)
+
+Ambiente = Literal["producao", "homologacao"]
+
+_NS_NFE = "http://www.portalfiscal.inf.br/nfe"
+
+# Endpoints NfeStatusServico4 por grupo autorizador (producao, homologacao).
+# Conferidos contra nfephp-org/sped-nfe (storage/wsnfe_4.00_mod55.xml) em 2026-07-18.
+_ENDPOINTS_GRUPO: dict[str, dict[Ambiente, str]] = {
+    "AM": {
+        "producao": "https://nfe.sefaz.am.gov.br/services2/services/NfeStatusServico4",
+        "homologacao": "https://homnfe.sefaz.am.gov.br/services2/services/NfeStatusServico4",
+    },
+    "BA": {
+        "producao": "https://nfe.sefaz.ba.gov.br/webservices/NFeStatusServico4/NFeStatusServico4.asmx",
+        "homologacao": "https://hnfe.sefaz.ba.gov.br/webservices/NFeStatusServico4/NFeStatusServico4.asmx",
+    },
+    "GO": {
+        "producao": "https://nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4",
+        "homologacao": "https://homolog.sefaz.go.gov.br/nfe/services/NFeStatusServico4",
+    },
+    "MG": {
+        "producao": "https://nfe.fazenda.mg.gov.br/nfe2/services/NFeStatusServico4",
+        "homologacao": "https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeStatusServico4",
+    },
+    "MS": {
+        "producao": "https://nfe.sefaz.ms.gov.br/ws/NFeStatusServico4",
+        "homologacao": "https://hom.nfe.sefaz.ms.gov.br/ws/NFeStatusServico4",
+    },
+    "MT": {
+        "producao": "https://nfe.sefaz.mt.gov.br/nfews/v2/services/NfeStatusServico4",
+        "homologacao": "https://homologacao.sefaz.mt.gov.br/nfews/v2/services/NfeStatusServico4",
+    },
+    "PE": {
+        "producao": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4",
+        "homologacao": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4",
+    },
+    "PR": {
+        "producao": "https://nfe.sefa.pr.gov.br/nfe/NFeStatusServico4",
+        "homologacao": "https://homologacao.nfe.sefa.pr.gov.br/nfe/NFeStatusServico4",
+    },
+    # RS tem webservice proprio (dominio sefazrs.rs.gov.br), diferente do SVRS
+    # (dominio svrs.rs.gov.br) que RS opera em nome de outras UFs.
+    "RS": {
+        "producao": "https://nfe.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx",
+        "homologacao": "https://nfe-homologacao.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx",
+    },
+    "SP": {
+        "producao": "https://nfe.fazenda.sp.gov.br/ws/nfestatusservico4.asmx",
+        "homologacao": "https://homologacao.nfe.fazenda.sp.gov.br/ws/nfestatusservico4.asmx",
+    },
+    "SVRS": {
+        "producao": "https://nfe.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx",
+        "homologacao": "https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx",
+    },
+    "SVAN": {
+        "producao": "https://www.sefazvirtual.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx",
+        "homologacao": "https://hom.sefazvirtual.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx",
+    },
+}
+
+# UF -> grupo autorizador. UFs ausentes daqui usam sua propria sigla como grupo
+# (ou seja, tem estrutura propria - ver _ENDPOINTS_GRUPO).
+_UF_PARA_GRUPO: dict[str, str] = {
+    "MA": "SVAN",
+    "AC": "SVRS",
+    "AL": "SVRS",
+    "AP": "SVRS",
+    "CE": "SVRS",
+    "DF": "SVRS",
+    "ES": "SVRS",
+    "PA": "SVRS",
+    "PB": "SVRS",
+    "PI": "SVRS",
+    "RJ": "SVRS",
+    "RN": "SVRS",
+    "RO": "SVRS",
+    "RR": "SVRS",
+    "SC": "SVRS",
+    "SE": "SVRS",
+    "TO": "SVRS",
+}
+
+# cStat de retorno da consulta de status (Manual de Orientacao do Contribuinte NFe).
+_CSTAT_OPERACIONAL = 107
+_CSTAT_INSTAVEL = 108
+_CSTAT_INDISPONIVEL = 109
+
+
+def _endpoint_para_uf(uf: str, ambiente: Ambiente) -> str:
+    grupo = _UF_PARA_GRUPO.get(uf, uf)
+    endpoints = _ENDPOINTS_GRUPO.get(grupo)
+    if endpoints is None:
+        # UF invalida e um erro de input do chamador, nao uma falta de
+        # configuracao do servidor - por isso FiscalValidationError, nao
+        # FiscalConfigurationError (reservada a certificado A1 ausente).
+        raise FiscalValidationError(
+            message=f"Nenhum endpoint NfeStatusServico4 mapeado para UF '{uf}' (grupo '{grupo}').",
+            field="uf",
+            value=uf,
+        )
+    return endpoints[ambiente]
+
+
+@lru_cache(maxsize=1)
+def _obter_ssl_context(caminho_certificado: str, senha: str) -> ssl.SSLContext:
+    """Monta (e cacheia) o SSLContext do certificado A1 para a vida do processo.
+
+    lru_cache evita recarregar o .pfx do disco a cada UF consultada (uma
+    varredura completa consulta ~11 endpoints distintos). Cache por processo:
+    um certificado novo exige reiniciar o servico (ou chamar
+    ``_obter_ssl_context.cache_clear()`` em testes).
+    """
+    chave_pem, cert_pem, chain_pem = carregar_pkcs12(caminho_certificado, senha)
+    return criar_ssl_context_em_memoria(chave_pem, cert_pem, chain_pem)
+
+
+def _montar_body(uf: str, ambiente: Ambiente) -> str:
+    tp_amb = "1" if ambiente == "producao" else "2"
+    cod_uf = UF_CODES.get(uf)
+    if cod_uf is None:
+        # SVRS/SVAN sao grupos de webservice (_endpoint_para_uf), nao UFs -
+        # cUF no XML sempre exige a UF real solicitante, nunca o grupo.
+        raise FiscalValidationError(
+            message=f"UF '{uf}' nao possui codigo IBGE mapeado para consulta de status.",
+            field="uf",
+            value=uf,
+        )
+    return (
+        f'<consStatServ versao="4.00" xmlns="{_NS_NFE}">'
+        f"<tpAmb>{tp_amb}</tpAmb>"
+        f"<cUF>{cod_uf}</cUF>"
+        "<xServ>STATUS</xServ>"
+        "</consStatServ>"
+    )
+
+
+def _texto(root: etree._Element, tag: str) -> str | None:
+    el = root.find(f"{{{_NS_NFE}}}{tag}")
+    return el.text if el is not None else None
+
+
+@dataclass(frozen=True)
+class StatusSefazReal:
+    """Resultado de uma consulta real de status a um webservice SEFAZ."""
+
+    uf: str
+    status: Literal["OPERACIONAL", "INSTAVEL", "INDISPONIVEL"]
+    codigo: int | None
+    descricao: str | None
+    data_recebimento: str | None
+    tempo_medio_ms: str | None
+
+
+async def consultar_status_real(
+    uf: str,
+    caminho_certificado: str,
+    senha: str,
+    ambiente: Ambiente = "producao",
+    timeout: float = 15.0,
+) -> StatusSefazReal:
+    """
+    Consulta o status real do webservice SEFAZ de uma UF via NfeStatusServico4.
+
+    Requer certificado digital A1 configurado (mTLS e exigencia de transporte
+    de todos os webservices SEFAZ, incluindo consulta de status).
+
+    Raises:
+        FiscalConfigurationError: certificado digital A1 nao configurado.
+        FiscalValidationError: UF sem endpoint mapeado, ou certificado invalido
+            (senha errada, arquivo corrompido).
+        FiscalHTTPError: falha de rede ou cStat de rejeicao inesperado.
+    """
+    if not caminho_certificado or not senha:
+        raise FiscalConfigurationError(
+            message=(
+                "Certificado digital A1 nao configurado (NFE_CERTIFICADO_PATH / "
+                "NFE_CERTIFICADO_SENHA). Consulta de status SEFAZ exige certificado."
+            )
+        )
+
+    endpoint = _endpoint_para_uf(uf, ambiente)
+    # _obter_ssl_context e sincrono (carrega .pfx do disco + monta SSLContext);
+    # roda em thread separada para nao bloquear o event loop na primeira
+    # chamada por processo (lru_cache evita repetir o custo nas seguintes).
+    ssl_ctx = await asyncio.to_thread(_obter_ssl_context, caminho_certificado, senha)
+    body_content = _montar_body(uf, ambiente)
+
+    logger.info("sefaz_status_real_started", uf=uf, ambiente=ambiente, endpoint=endpoint)
+
+    body_el = await _enviar_soap_mtls(
+        endpoint, body_content, ssl_ctx, namespace=_NS_NFE, timeout=timeout
+    )
+
+    cstat_raw = _texto(body_el, "cStat")
+    if cstat_raw is None:
+        raise FiscalHTTPError(
+            message="Resposta da SEFAZ sem cStat.",
+            status_code=200,
+            url=endpoint,
+        )
+
+    cstat = int(cstat_raw)
+    xmotivo = _texto(body_el, "xMotivo")
+    dh_recbto = _texto(body_el, "dhRecbto")
+    t_med = _texto(body_el, "tMed")
+
+    if cstat == _CSTAT_OPERACIONAL:
+        status: Literal["OPERACIONAL", "INSTAVEL", "INDISPONIVEL"] = "OPERACIONAL"
+    elif cstat == _CSTAT_INSTAVEL:
+        status = "INSTAVEL"
+    elif cstat == _CSTAT_INDISPONIVEL:
+        status = "INDISPONIVEL"
+    else:
+        raise FiscalHTTPError(
+            message=f"SEFAZ retornou cStat inesperado para consulta de status: {cstat} ({xmotivo}).",
+            status_code=200,
+            url=endpoint,
+            detail={"cStat": cstat, "xMotivo": xmotivo},
+        )
+
+    return StatusSefazReal(
+        uf=uf,
+        status=status,
+        codigo=cstat,
+        descricao=xmotivo,
+        data_recebimento=dh_recbto,
+        tempo_medio_ms=t_med,
+    )
+
+
+@dataclass(frozen=True)
+class StatusCertificado:
+    """Estado do certificado digital A1 configurado no servidor fiscal."""
+
+    configurado: bool
+    ambiente: str
+    cnpj: str | None = None
+    titular: str | None = None
+    validade_fim: datetime | None = None
+    valido: bool | None = None
+    erro: str | None = None
+
+
+def obter_status_certificado(
+    caminho_certificado: str,
+    senha: str,
+    ambiente: str,
+) -> StatusCertificado:
+    """
+    Retorna metadados do certificado A1 configurado, sem expor a chave privada.
+
+    Usado pelo endpoint GET /v1/fiscal/certificado/status: o chamador so ve
+    "configurado / titular / validade", nunca o arquivo ou a senha.
+    """
+    if not caminho_certificado or not senha:
+        return StatusCertificado(configurado=False, ambiente=ambiente)
+
+    from cryptography import x509
+
+    from .assinatura import _extrair_cn, _extrair_cnpj_cpf
+
+    try:
+        _, cert_pem, _ = carregar_pkcs12(caminho_certificado, senha)
+        cert = x509.load_pem_x509_certificate(cert_pem)
+    except Exception as exc:
+        logger.warning(
+            "certificado_status_load_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return StatusCertificado(configurado=True, ambiente=ambiente, erro=str(exc))
+
+    cn = _extrair_cn(cert)
+    cnpj = _extrair_cnpj_cpf(cn)
+
+    try:
+        validade_fim: datetime | None = cert.not_valid_after_utc
+    except AttributeError:
+        try:
+            validade_fim = cert.not_valid_after
+        except Exception as exc:
+            logger.warning("certificado_not_valid_after_indisponivel", error=str(exc))
+            validade_fim = None
+
+    valido: bool | None = None
+    if validade_fim is not None:
+        if validade_fim.tzinfo is None:
+            validade_fim = validade_fim.replace(tzinfo=timezone.utc)
+        valido = validade_fim > datetime.now(timezone.utc)
+
+    return StatusCertificado(
+        configurado=True,
+        ambiente=ambiente,
+        cnpj=cnpj,
+        titular=cn,
+        validade_fim=validade_fim,
+        valido=valido,
+    )
+
+
+__all__ = [
+    "StatusCertificado",
+    "StatusSefazReal",
+    "consultar_status_real",
+    "obter_status_certificado",
+]

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -9,6 +9,8 @@ import unicodedata
 from typing import Any, Literal
 
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from . import __version__
 from .agentic import (
@@ -89,6 +91,18 @@ app = FastMCP(
         "Dados obtidos de fontes públicas: BrasilAPI, ReceitaWS, SEFAZ."
     ),
 )
+
+
+@app.custom_route("/health", methods=["GET"], include_in_schema=False)
+async def health(_request: Request) -> JSONResponse:
+    """Healthcheck HTTP para os transportes http/sse (FastMCP so expoe /mcp por padrao).
+
+    Consumido por scripts/docker_healthcheck.py quando o container roda em
+    modo --transport http/sse. No modo stdio (padrao), essa rota nunca e
+    montada, e o healthcheck do container degrada para "pacote importa".
+    """
+    return JSONResponse({"status": "ok"})
+
 
 # ---------------------------------------------------------------------------
 # CNPJ
@@ -236,22 +250,33 @@ async def tool_validar_chave_nfe(chave_acesso: str) -> dict[str, Any]:
 @app.tool(
     name="consultar_status_sefaz",
     description=(
-        "Consulta o status atual do serviço SEFAZ de um estado brasileiro. "
-        "Verifica se o webservice da SEFAZ para emissão de NFe está operacional. "
-        "Útil para diagnosticar falhas de transmissão de notas fiscais."
+        "Consulta o status real do serviço SEFAZ de um estado brasileiro via "
+        "NfeStatusServico4 (mTLS). Verifica se o webservice da SEFAZ para emissão "
+        "de NFe está operacional. Útil para diagnosticar falhas de transmissão de "
+        "notas fiscais. Requer certificado digital A1 configurado no servidor "
+        "(NFE_CERTIFICADO_PATH / NFE_CERTIFICADO_SENHA) - mTLS é exigência de "
+        "transporte de todo webservice SEFAZ, inclusive consulta de status."
     ),
 )
 async def tool_consultar_status_sefaz(uf: str) -> dict[str, Any]:
-    """Consulta o status do servico de autorizacao de NF-e da SEFAZ de uma UF.
+    """Consulta o status real do servico de autorizacao de NF-e da SEFAZ de uma UF.
 
     Indica se o webservice da SEFAZ do estado esta operacional, util para diagnosticar
     falhas na transmissao de notas fiscais.
+
+    IMPORTANTE: exige certificado digital A1 configurado no servidor via
+    NFE_CERTIFICADO_PATH / NFE_CERTIFICADO_SENHA. mTLS e exigencia de transporte
+    de todo webservice SEFAZ, inclusive consulta de status - sem certificado,
+    esta tool levanta FiscalConfigurationError.
 
     Args:
         uf: Sigla do estado com 2 letras (ex.: "SP", "MG", "RJ"). Validada contra as UFs do Brasil.
 
     Returns:
         dict com o status atual do servico e a descricao correspondente.
+
+    Raises:
+        FiscalConfigurationError: certificado digital A1 nao configurado no servidor.
     """
     resultado = await consultar_status_sefaz(uf)
     return resultado.model_dump(mode="json", exclude_none=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,17 +3,32 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from cachetools import TTLCache
 from fastapi.testclient import TestClient
 
 from mcp_fiscal_brasil import __version__
+from mcp_fiscal_brasil import api as api_module
 from mcp_fiscal_brasil._core.config import settings as api_settings
+from mcp_fiscal_brasil._core.errors import FiscalHTTPError
 from mcp_fiscal_brasil.agentic.schemas import ComplianceReport
 from mcp_fiscal_brasil.api import app
+from mcp_fiscal_brasil.nfe.schemas import StatusSEFAZResponse
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _status_sefaz_cache_isolado(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cada teste começa com um cache de status SEFAZ vazio e isolado dos demais."""
+    monkeypatch.setattr(
+        api_module,
+        "_status_sefaz_cache",
+        TTLCache(maxsize=32, ttl=api_module._STATUS_SEFAZ_CACHE_TTL_SEGUNDOS),
+    )
 
 
 def test_health() -> None:
@@ -188,3 +203,109 @@ def test_sped_summarize_arquivo_inexistente_dentro_do_diretorio_permitido(
         json={"file_path": str(tmp_path / "nao_existe.txt")},
     )
     assert response.status_code == 404
+
+
+def test_fiscal_certificado_status_sem_certificado_configurado(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_settings, "nfe_certificado_path", "")
+    monkeypatch.setattr(api_settings, "nfe_certificado_senha", "")
+
+    response = client.get("/v1/fiscal/certificado/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["configurado"] is False
+    assert data["valido"] is None
+    assert "cnpj" not in data
+    assert "titular" not in data
+
+
+def test_status_sefaz_uf_invalida_retorna_400() -> None:
+    """UF invalida e erro de input do chamador: 400 mesmo sem certificado configurado."""
+    response = client.get("/v1/nfe/status-sefaz", params={"uf": "XX"})
+    assert response.status_code == 400
+
+
+def test_status_sefaz_sem_certificado_retorna_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sem certificado configurado, a rota responde 503 em vez de fingir sucesso vazio."""
+    monkeypatch.setattr(api_settings, "nfe_certificado_path", "")
+    monkeypatch.setattr(api_settings, "nfe_certificado_senha", "")
+
+    response_uf = client.get("/v1/nfe/status-sefaz", params={"uf": "SP"})
+    assert response_uf.status_code == 503
+
+    response_todas = client.get("/v1/nfe/status-sefaz")
+    assert response_todas.status_code == 503
+
+
+def _fake_status(uf: str) -> StatusSEFAZResponse:
+    return StatusSEFAZResponse(uf=uf, status="OPERACIONAL", descrição="Servico em Operacao")
+
+
+def test_status_sefaz_falha_pontual_de_uma_uf_e_omitida(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Falha pontual (FiscalHTTPError) em uma UF nao derruba a chamada inteira com 500."""
+    monkeypatch.setattr(api_settings, "nfe_certificado_path", "/fake/cert.pfx")
+    monkeypatch.setattr(api_settings, "nfe_certificado_senha", "fake-senha")
+
+    async def _consulta(uf: str) -> StatusSEFAZResponse:
+        if uf == "SP":
+            raise FiscalHTTPError(message="falha de rede", status_code=0, url="https://sefaz")
+        return _fake_status(uf)
+
+    with patch("mcp_fiscal_brasil.api.consultar_status_sefaz", AsyncMock(side_effect=_consulta)):
+        response = client.get("/v1/nfe/status-sefaz")
+
+    assert response.status_code == 200
+    ufs = {item["uf"] for item in response.json()["ufs"]}
+    assert "SP" not in ufs
+    assert "MG" in ufs
+
+
+def test_status_sefaz_cache_evita_nova_consulta_dentro_da_janela(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Segunda chamada para a mesma UF dentro de 60s usa o cache, sem nova consulta SOAP."""
+    monkeypatch.setattr(api_settings, "nfe_certificado_path", "/fake/cert.pfx")
+    monkeypatch.setattr(api_settings, "nfe_certificado_senha", "fake-senha")
+
+    mock_consulta = AsyncMock(return_value=_fake_status("SP"))
+    with patch("mcp_fiscal_brasil.api.consultar_status_sefaz", mock_consulta):
+        primeira = client.get("/v1/nfe/status-sefaz", params={"uf": "SP"})
+        segunda = client.get("/v1/nfe/status-sefaz", params={"uf": "SP"})
+
+    assert primeira.status_code == 200
+    assert segunda.status_code == 200
+    assert primeira.json() == segunda.json()
+    mock_consulta.assert_called_once()
+
+
+def test_nfe_validate_aceita_xml_inline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api_settings, "mcp_fiscal_file_base_dir", str(tmp_path))
+    fake_report = SimpleNamespace(model_dump=lambda **_: {"valida_estruturalmente": True})
+
+    with patch(
+        "mcp_fiscal_brasil.api.validate_nfe_full", AsyncMock(return_value=fake_report)
+    ) as validate:
+        response = client.post("/v1/nfe/validate", json={"xml": "<NFe>conteudo</NFe>"})
+
+    assert response.status_code == 200
+    assert response.json() == {"valida_estruturalmente": True}
+    validate.assert_called_once()
+    # O arquivo temporario criado para a validacao inline nao deve sobreviver a chamada
+    assert list(tmp_path.glob("*.xml")) == []
+
+
+def test_nfe_validate_xml_inline_excede_tamanho_maximo() -> None:
+    xml_grande = "<NFe>" + ("a" * (5 * 1024 * 1024 + 1)) + "</NFe>"
+    response = client.post("/v1/nfe/validate", json={"xml": xml_grande})
+    assert response.status_code == 413
+
+
+def test_nfe_validate_sem_xml_e_sem_xml_path_retorna_400() -> None:
+    response = client.post("/v1/nfe/validate", json={})
+    assert response.status_code == 400

--- a/tests/test_nfe.py
+++ b/tests/test_nfe.py
@@ -1,12 +1,32 @@
 """Testes para o modulo NFe."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import NameOID
+from lxml import etree
 
+from mcp_fiscal_brasil._core.config import settings as nfe_settings
+from mcp_fiscal_brasil._core.errors import FiscalConfigurationError
 from mcp_fiscal_brasil.nfe.client import NFEClient, _extrair_info_chave
-from mcp_fiscal_brasil.nfe.tools import consultar_nfe, consultar_status_sefaz, validar_chave_nfe
-from mcp_fiscal_brasil.shared.exceptions import APIError, RateLimitError, ValidationError
+from mcp_fiscal_brasil.nfe.status_sefaz import _obter_ssl_context
+from mcp_fiscal_brasil.nfe.tools import (
+    consultar_nfe,
+    consultar_status_sefaz,
+    validar_chave_nfe,
+)
+from mcp_fiscal_brasil.shared.exceptions import (
+    APIError,
+    RateLimitError,
+    ValidationError,
+)
+
+_NS_NFE = "http://www.portalfiscal.inf.br/nfe"
 
 
 class TestValidarChaveNFe:
@@ -39,20 +59,85 @@ class TestValidarChaveNFe:
         assert resultado["cnpj_emitente"] == "12345678901234"
 
 
+def _gerar_pfx_teste(tmp_path_factory: pytest.TempPathFactory) -> str:
+    chave = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "BR"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "EMPRESA TESTE:12345678000195"),
+        ]
+    )
+    certificado = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(chave.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(chave, hashes.SHA256())
+    )
+    pfx_bytes = pkcs12.serialize_key_and_certificates(
+        b"cert_teste_nfe",
+        chave,
+        certificado,
+        None,
+        serialization.BestAvailableEncryption(b"senha_teste"),
+    )
+    tmp_dir = tmp_path_factory.mktemp("certs_nfe_tools")
+    pfx_path = str(tmp_dir / "cert_teste.pfx")
+    with open(pfx_path, "wb") as f:
+        f.write(pfx_bytes)
+    return pfx_path
+
+
+def _montar_ret_stat_serv_operacional() -> etree._Element:
+    body_str = (
+        f'<retConsStatServ versao="4.00" xmlns="{_NS_NFE}">'
+        "<tpAmb>1</tpAmb>"
+        "<cStat>107</cStat>"
+        "<xMotivo>Servico em Operacao</xMotivo>"
+        "<cUF>35</cUF>"
+        "<dhRecbto>2026-07-18T10:00:00-03:00</dhRecbto>"
+        "<tMed>1</tMed>"
+        "</retConsStatServ>"
+    )
+    return etree.fromstring(body_str.encode())
+
+
 class TestConsultarStatusSEFAZ:
     async def test_uf_invalida_levanta_erro(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             await consultar_status_sefaz("XX")
         assert exc_info.value.field == "uf"
 
-    async def test_uf_valida_retorna_status(self) -> None:
-        # Pode falhar se SEFAZ/API estiver indisponivel em CI
-        try:
+    async def test_sem_certificado_levanta_configuration_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(nfe_settings, "nfe_certificado_path", "")
+        monkeypatch.setattr(nfe_settings, "nfe_certificado_senha", "")
+
+        with pytest.raises(FiscalConfigurationError):
+            await consultar_status_sefaz("SP")
+
+    async def test_uf_valida_com_certificado_retorna_status(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        pfx_path = _gerar_pfx_teste(tmp_path_factory)
+        monkeypatch.setattr(nfe_settings, "nfe_certificado_path", pfx_path)
+        monkeypatch.setattr(nfe_settings, "nfe_certificado_senha", "senha_teste")
+
+        body_mock = _montar_ret_stat_serv_operacional()
+        _obter_ssl_context.cache_clear()
+        with patch(
+            "mcp_fiscal_brasil.nfe.status_sefaz._enviar_soap_mtls",
+            new=AsyncMock(return_value=body_mock),
+        ):
             resultado = await consultar_status_sefaz("SP")
-            assert resultado.uf == "SP"
-            assert resultado.status is not None
-        except Exception as e:
-            assert "ValidationError" not in type(e).__name__
+
+        assert resultado.uf == "SP"
+        assert resultado.status == "OPERACIONAL"
+        assert resultado.código == 107
 
 
 def _chave_valida_sp() -> str:

--- a/tests/test_nfe_distribuicao.py
+++ b/tests/test_nfe_distribuicao.py
@@ -194,7 +194,7 @@ class TestBaixarNfeDistribuicao:
         )
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ):
             resultado = await baixar_nfe_distribuicao(
@@ -218,7 +218,7 @@ class TestBaixarNfeDistribuicao:
         )
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ):
             resultado = await baixar_nfe_distribuicao(
@@ -243,7 +243,7 @@ class TestBaixarNfeDistribuicao:
         )
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ) as mock_soap:
             resultado = await baixar_nfe_distribuicao(
@@ -270,7 +270,7 @@ class TestBaixarNfeDistribuicao:
         )
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ) as mock_soap:
             resultado = await baixar_nfe_distribuicao(
@@ -356,7 +356,7 @@ class TestBaixarNfeDistribuicao:
         )
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ):
             resultado = await baixar_nfe_distribuicao(
@@ -425,7 +425,7 @@ class TestManifestarNfe:
         body_mock = _montar_retorno_evento_soap()
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ):
             resultado = await manifestar_nfe(
@@ -446,7 +446,7 @@ class TestManifestarNfe:
         body_mock = _montar_retorno_evento_soap()
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ):
             resultado = await manifestar_nfe(
@@ -489,7 +489,7 @@ class TestManifestarNfe:
         body_mock = _montar_retorno_evento_soap()
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ) as mock_soap:
             resultado = await manifestar_nfe(
@@ -533,7 +533,7 @@ class TestManifestarNfe:
         body_mock = _montar_retorno_evento_soap()
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ) as mock_soap:
             await manifestar_nfe(
@@ -554,7 +554,7 @@ class TestManifestarNfe:
         body_mock = _montar_retorno_evento_soap()
 
         with patch(
-            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap",
+            "mcp_fiscal_brasil.nfe.distribuicao._enviar_soap_mtls",
             new=AsyncMock(return_value=body_mock),
         ) as mock_soap:
             await manifestar_nfe(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,22 @@
+"""Testes do servidor MCP (rotas HTTP customizadas)."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from mcp_fiscal_brasil.server import app
+
+
+def test_health_route_disponivel_no_transporte_http() -> None:
+    """FastMCP so expoe /mcp por padrao nos transportes http/sse.
+
+    /health precisa estar registrada explicitamente para o healthcheck do
+    Docker funcionar (ver scripts/docker_healthcheck.py) quando o container
+    roda com --transport http/sse em vez do stdio padrao.
+    """
+    http_app = app.http_app(transport="http")
+    with TestClient(http_app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_soap_mtls.py
+++ b/tests/test_soap_mtls.py
@@ -1,0 +1,119 @@
+"""Testes para nfe/_soap_mtls.py: carregamento de certificado e validacao de emitente."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import NameOID
+
+from mcp_fiscal_brasil._core.config import settings as mtls_settings
+from mcp_fiscal_brasil._core.errors import (
+    FiscalConfigurationError,
+    FiscalValidationError,
+)
+from mcp_fiscal_brasil.nfe._soap_mtls import (
+    carregar_pkcs12,
+    criar_ssl_context_em_memoria,
+)
+
+
+@pytest.fixture(scope="module")
+def chave_privada() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def certificado(chave_privada: rsa.RSAPrivateKey) -> x509.Certificate:
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "BR"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "EMPRESA TESTE:12345678000195"),
+        ]
+    )
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(chave_privada.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(chave_privada, hashes.SHA256())
+    )
+
+
+@pytest.fixture(scope="module")
+def arquivo_pfx(
+    chave_privada: rsa.RSAPrivateKey,
+    certificado: x509.Certificate,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> str:
+    pfx_bytes = pkcs12.serialize_key_and_certificates(
+        b"cert_teste_mtls",
+        chave_privada,
+        certificado,
+        None,
+        serialization.BestAvailableEncryption(b"senha_teste"),
+    )
+    tmp_dir = tmp_path_factory.mktemp("certs_mtls")
+    pfx_path = str(tmp_dir / "cert_teste.pfx")
+    with open(pfx_path, "wb") as f:
+        f.write(pfx_bytes)
+    return pfx_path
+
+
+class TestCarregarPkcs12:
+    def test_caminho_inexistente_levanta_validation_error(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            carregar_pkcs12("/caminho/que/nao/existe.pfx", "qualquer")
+
+    def test_senha_incorreta_levanta_validation_error(self, arquivo_pfx: str) -> None:
+        with pytest.raises(FiscalValidationError):
+            carregar_pkcs12(arquivo_pfx, "senha_errada")
+
+    def test_carrega_certificado_valido(self, arquivo_pfx: str) -> None:
+        chave_pem, cert_pem, chain_pem = carregar_pkcs12(arquivo_pfx, "senha_teste")
+        assert chave_pem.startswith(b"-----BEGIN")
+        assert cert_pem.startswith(b"-----BEGIN")
+        assert chain_pem == []
+
+    def test_monta_ssl_context_sem_erro(self, arquivo_pfx: str) -> None:
+        chave_pem, cert_pem, chain_pem = carregar_pkcs12(arquivo_pfx, "senha_teste")
+        ctx = criar_ssl_context_em_memoria(chave_pem, cert_pem, chain_pem)
+        assert ctx.verify_mode.name == "CERT_REQUIRED"
+
+
+class TestValidarEmitenteCnpj:
+    def test_sem_nfe_emitente_cnpj_configurado_nao_valida(
+        self, arquivo_pfx: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Comportamento legado: sem NFE_EMITENTE_CNPJ, qualquer certificado carrega."""
+        monkeypatch.setattr(mtls_settings, "nfe_emitente_cnpj", "")
+        chave_pem, cert_pem, _ = carregar_pkcs12(arquivo_pfx, "senha_teste")
+        assert chave_pem and cert_pem
+
+    def test_cnpj_esperado_igual_ao_do_certificado_carrega_normalmente(
+        self, arquivo_pfx: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mtls_settings, "nfe_emitente_cnpj", "12345678000195")
+        chave_pem, cert_pem, _ = carregar_pkcs12(arquivo_pfx, "senha_teste")
+        assert chave_pem and cert_pem
+
+    def test_cnpj_esperado_formatado_com_pontuacao_tambem_funciona(
+        self, arquivo_pfx: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mtls_settings, "nfe_emitente_cnpj", "12.345.678/0001-95")
+        chave_pem, cert_pem, _ = carregar_pkcs12(arquivo_pfx, "senha_teste")
+        assert chave_pem and cert_pem
+
+    def test_cnpj_esperado_divergente_levanta_configuration_error(
+        self, arquivo_pfx: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mtls_settings, "nfe_emitente_cnpj", "99999999000199")
+        with pytest.raises(FiscalConfigurationError):
+            carregar_pkcs12(arquivo_pfx, "senha_teste")

--- a/tests/test_status_sefaz.py
+++ b/tests/test_status_sefaz.py
@@ -1,0 +1,226 @@
+"""Testes para status_sefaz.py (consulta real NfeStatusServico4 - mocks, sem SEFAZ real)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import NameOID
+from lxml import etree
+
+from mcp_fiscal_brasil._core.errors import (
+    FiscalConfigurationError,
+    FiscalHTTPError,
+    FiscalValidationError,
+)
+from mcp_fiscal_brasil.nfe.status_sefaz import (
+    StatusSefazReal,
+    _endpoint_para_uf,
+    _montar_body,
+    _obter_ssl_context,
+    consultar_status_real,
+    obter_status_certificado,
+)
+
+_NS_NFE = "http://www.portalfiscal.inf.br/nfe"
+
+
+@pytest.fixture(scope="module")
+def chave_privada_a1() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def certificado_a1(chave_privada_a1: rsa.RSAPrivateKey) -> x509.Certificate:
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "BR"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "EMPRESA TESTE:12345678000195"),
+        ]
+    )
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(chave_privada_a1.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(chave_privada_a1, hashes.SHA256())
+    )
+
+
+@pytest.fixture(scope="module")
+def arquivo_pfx(
+    chave_privada_a1: rsa.RSAPrivateKey,
+    certificado_a1: x509.Certificate,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> str:
+    pfx_bytes = pkcs12.serialize_key_and_certificates(
+        b"cert_teste",
+        chave_privada_a1,
+        certificado_a1,
+        None,
+        serialization.BestAvailableEncryption(b"senha_teste"),
+    )
+    tmp_dir = tmp_path_factory.mktemp("certs_status")
+    pfx_path = str(tmp_dir / "cert_teste.pfx")
+    with open(pfx_path, "wb") as f:
+        f.write(pfx_bytes)
+    return pfx_path
+
+
+def _montar_ret_stat_serv(c_stat: str, x_motivo: str = "Servico em Operacao") -> etree._Element:
+    body_str = (
+        f'<retConsStatServ versao="4.00" xmlns="{_NS_NFE}">'
+        "<tpAmb>1</tpAmb>"
+        "<verAplic>SP_20200205</verAplic>"
+        f"<cStat>{c_stat}</cStat>"
+        f"<xMotivo>{x_motivo}</xMotivo>"
+        "<cUF>35</cUF>"
+        "<dhRecbto>2026-07-18T10:00:00-03:00</dhRecbto>"
+        "<tMed>1</tMed>"
+        "</retConsStatServ>"
+    )
+    return etree.fromstring(body_str.encode())
+
+
+class TestEndpointParaUf:
+    def test_uf_com_estrutura_propria(self) -> None:
+        assert "sp" in _endpoint_para_uf("SP", "producao").lower()
+
+    def test_uf_svrs(self) -> None:
+        assert "svrs" in _endpoint_para_uf("RJ", "producao").lower()
+
+    def test_uf_svan(self) -> None:
+        assert "sefazvirtual" in _endpoint_para_uf("MA", "producao").lower()
+
+    def test_homologacao_usa_url_diferente(self) -> None:
+        assert _endpoint_para_uf("SP", "producao") != _endpoint_para_uf("SP", "homologacao")
+
+    def test_rs_tem_webservice_proprio_distinto_do_svrs(self) -> None:
+        """RS opera o SVRS para OUTRAS UFs, mas tem webservice proprio para si mesmo.
+
+        Divergencia real encontrada no fork (RS estava mapeado para o grupo
+        SVRS): conferido contra nfephp-org/sped-nfe, RS tem dominio proprio
+        (sefazrs.rs.gov.br), distinto do SVRS (svrs.rs.gov.br).
+        """
+        endpoint_rs = _endpoint_para_uf("RS", "producao").lower()
+        endpoint_svrs = _endpoint_para_uf("RJ", "producao").lower()
+        assert "sefazrs" in endpoint_rs
+        assert endpoint_rs != endpoint_svrs
+
+    def test_uf_sem_endpoint_mapeado_levanta_validation_error(self) -> None:
+        """UF invalida e erro de input do chamador (FiscalValidationError), nao de
+        configuracao do servidor (FiscalConfigurationError e reservada a
+        certificado A1 ausente)."""
+        with pytest.raises(FiscalValidationError):
+            _endpoint_para_uf("XX", "producao")
+
+
+class TestMontarBody:
+    def test_svrs_nao_e_uf_valida_para_montar_body(self) -> None:
+        """SVRS/SVAN sao grupos de webservice (_endpoint_para_uf resolve o
+        endpoint), nao UFs - cUF no XML exige a UF real solicitante, nunca o
+        grupo. UF_CODES nao mapeia esses grupos, entao _montar_body deve
+        falhar com FiscalValidationError em vez de KeyError."""
+        with pytest.raises(FiscalValidationError):
+            _montar_body("SVRS", "producao")
+
+    def test_svan_nao_e_uf_valida_para_montar_body(self) -> None:
+        with pytest.raises(FiscalValidationError):
+            _montar_body("SVAN", "producao")
+
+
+class TestConsultarStatusReal:
+    @pytest.fixture(autouse=True)
+    def _limpar_cache_ssl(self) -> None:
+        """_obter_ssl_context e cacheada com lru_cache; cada teste comeca sem cache."""
+        _obter_ssl_context.cache_clear()
+
+    async def test_sem_certificado_levanta_configuration_error(self) -> None:
+        with pytest.raises(FiscalConfigurationError):
+            await consultar_status_real("SP", caminho_certificado="", senha="")
+
+    async def test_cstat_107_retorna_operacional(self, arquivo_pfx: str) -> None:
+        body_mock = _montar_ret_stat_serv("107")
+        with patch(
+            "mcp_fiscal_brasil.nfe.status_sefaz._enviar_soap_mtls",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await consultar_status_real(
+                "SP", caminho_certificado=arquivo_pfx, senha="senha_teste"
+            )
+
+        assert isinstance(resultado, StatusSefazReal)
+        assert resultado.status == "OPERACIONAL"
+        assert resultado.codigo == 107
+
+    async def test_cstat_108_retorna_instavel(self, arquivo_pfx: str) -> None:
+        body_mock = _montar_ret_stat_serv("108", "Servico Paralisado Momentaneamente")
+        with patch(
+            "mcp_fiscal_brasil.nfe.status_sefaz._enviar_soap_mtls",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await consultar_status_real(
+                "SP", caminho_certificado=arquivo_pfx, senha="senha_teste"
+            )
+
+        assert resultado.status == "INSTAVEL"
+
+    async def test_cstat_109_retorna_indisponivel(self, arquivo_pfx: str) -> None:
+        body_mock = _montar_ret_stat_serv("109", "Servico Paralisado sem Previsao")
+        with patch(
+            "mcp_fiscal_brasil.nfe.status_sefaz._enviar_soap_mtls",
+            new=AsyncMock(return_value=body_mock),
+        ):
+            resultado = await consultar_status_real(
+                "SP", caminho_certificado=arquivo_pfx, senha="senha_teste"
+            )
+
+        assert resultado.status == "INDISPONIVEL"
+
+    async def test_cstat_inesperado_levanta_http_error(self, arquivo_pfx: str) -> None:
+        body_mock = _montar_ret_stat_serv("215", "Rejeicao: Falha no schema XML")
+        with (
+            patch(
+                "mcp_fiscal_brasil.nfe.status_sefaz._enviar_soap_mtls",
+                new=AsyncMock(return_value=body_mock),
+            ),
+            pytest.raises(FiscalHTTPError),
+        ):
+            await consultar_status_real("SP", caminho_certificado=arquivo_pfx, senha="senha_teste")
+
+    async def test_senha_incorreta_propaga_erro(self, arquivo_pfx: str) -> None:
+        with pytest.raises(FiscalValidationError):
+            await consultar_status_real("SP", caminho_certificado=arquivo_pfx, senha="senha_errada")
+
+
+class TestObterStatusCertificado:
+    def test_sem_certificado_configurado(self) -> None:
+        resultado = obter_status_certificado(caminho_certificado="", senha="", ambiente="producao")
+        assert resultado.configurado is False
+        assert resultado.cnpj is None
+
+    def test_certificado_valido(self, arquivo_pfx: str) -> None:
+        resultado = obter_status_certificado(
+            caminho_certificado=arquivo_pfx, senha="senha_teste", ambiente="producao"
+        )
+        assert resultado.configurado is True
+        assert resultado.cnpj == "12345678000195"
+        assert resultado.valido is True
+        assert resultado.validade_fim is not None
+
+    def test_senha_incorreta_retorna_erro_sem_expor_detalhes_sensiveis(
+        self, arquivo_pfx: str
+    ) -> None:
+        resultado = obter_status_certificado(
+            caminho_certificado=arquivo_pfx, senha="senha_errada", ambiente="producao"
+        )
+        assert resultado.configurado is True
+        assert resultado.erro is not None


### PR DESCRIPTION
## Resumo

Porte seletivo de correções do fork [Italo9/mcp-fiscal-brasil](https://github.com/Italo9/mcp-fiscal-brasil), auditado, adaptado e revisado (code review + security review) antes de entrar no repositório canônico. Principal entrega: `consultar_status_sefaz` deixa de depender de um endpoint da BrasilAPI que não existe mais (404 permanente) e passa a consultar o webservice real da SEFAZ (`NfeStatusServico4`) via mTLS com certificado A1.

## O que foi portado

| Item | Tratamento | Observação |
|---|---|---|
| Consulta real de status SEFAZ (`NfeStatusServico4`, mTLS) | Adaptado | Reimplementado com endpoints conferidos um a um contra `nfephp-org/sped-nfe` (`storage/wsnfe_4.00_mod55.xml`), não copiado direto do fork |
| Mapeamento RS como webservice próprio (não SVRS) | Como está (confirmado) | Divergência real do fork validada nessa conferência: RS opera `nfe.sefazrs.rs.gov.br` para si, mas atua como SVRS (`nfe.svrs.rs.gov.br`) para outras UFs sem infraestrutura própria |
| Helpers mTLS compartilhados (`carregar_pkcs12`, `criar_ssl_context_em_memoria`, `enviar_soap`) | Adaptado | Extraídos para `nfe/_soap_mtls.py` e reaproveitados entre distribuição, manifestação e status |
| `FiscalConfigurationError` + config de certificado A1 (`NFE_CERTIFICADO_PATH/SENHA/EMITENTE_CNPJ/AMBIENTE`) | Adaptado | Integrado à hierarquia de exceções e ao `Settings` já existentes no projeto |
| Endpoint `GET /v1/fiscal/certificado/status` | Adaptado (endurecido) | Versão do fork expunha titular/CNPJ; aqui a resposta foi reduzida a `configurado/válido/validade_fim` (security review: recon desnecessário em endpoint sem autenticação) |
| Endpoint `GET /v1/nfe/status-sefaz` | Adaptado (endurecido) | Versão original engolia erro de configuração como 200 vazio; aqui responde 503 quando falta certificado, com cache de 60s por UF para conter o fan-out de chamadas mTLS reais |
| `POST /v1/nfe/validate` com XML inline | Como está | Limite de 5 MB, arquivo temporário no diretório permitido, mesma validação anti-XXE já usada no resto do projeto |
| Healthcheck Docker dual-mode | Adaptado | `scripts/docker_healthcheck.py` cobre stdio/REST API/MCP HTTP; a rota `/health` no transporte MCP HTTP (FastMCP só expõe `/mcp` por padrão) foi um gap encontrado durante a revisão e adicionada nesta entrega |
| `compat.py` ("Lumiere") | **Descartado** | Acoplava o contrato REST público deste projeto a um projeto privado de terceiro; não faz sentido como dependência de um servidor MCP de propósito geral |

## BREAKING CHANGES

- `consultar_status_sefaz` (tool MCP e função interna) agora **exige certificado digital A1** configurado (`NFE_CERTIFICADO_PATH` / `NFE_CERTIFICADO_SENHA`). Sem certificado, levanta `FiscalConfigurationError`. O endpoint REST equivalente (`GET /v1/nfe/status-sefaz`) responde **503** nesse caso, não mais 200 com lista vazia.

## Correções adicionais desta revisão (sobre o porte inicial)

- `GET /v1/nfe/status-sefaz`: engolia `FiscalConfigurationError` e devolvia 200 com lista vazia; agora responde 503 com detail em pt-BR. Degradação silenciosa (log + omissão da UF) fica restrita a falha pontual de rede (`FiscalHTTPError`).
- Mitigação de amplificação: cache in-memory de 60s por UF no mesmo endpoint, para conter o fan-out de ~27 chamadas mTLS reais ao certificado do operador por requisição.
- `GET /v1/fiscal/certificado/status`: removidos `titular` e `cnpj` da resposta (endpoint sem autenticação não deveria permitir reconhecimento de identidade).
- Revertido o fallback de `HOST` em `api.py::run()` para `127.0.0.1` (o Dockerfile já define `ENV HOST=0.0.0.0`; fora de container o default seguro é loopback).
- `_endpoint_para_uf` passa a levantar `FiscalValidationError` (UF inválida é erro de input) em vez de `FiscalConfigurationError` (reservada a certificado ausente).
- Docstring de `criar_ssl_context_em_memoria` corrigida para refletir a implementação real (`tempfile.mkstemp()`, não `os.open` direto).
- Healthcheck do servidor MCP: rota `GET /health` adicionada ao transporte HTTP/SSE do FastMCP (antes só existia `/mcp`, então `scripts/docker_healthcheck.py` sempre falhava nesses modos).

## Validação

- Testes: **622 passando** (baseline da main: 618 + 4 novos desta entrega e do porte)
- `ruff check .`: sem erros
- `ruff format --check .`: 160 arquivos já formatados
- `mypy .`: **265 erros, idênticos byte-a-byte ao baseline da main** (mesma lista de erros pré-existentes, zero erros novos introduzidos - confirmado por diff ordenado entre o mypy da main e o desta branch)
- Endpoints SOAP (`NfeStatusServico4`) conferidos um a um contra `nfephp-org/sped-nfe`, incluindo a correção do mapeamento de RS
- Healthcheck reproduzido manualmente: `--transport http` em porta alta, `GET /health` retornando 200, `scripts/docker_healthcheck.py` saindo com exit 0

## Créditos

Correções originadas do fork de **Italo9** ([github.com/Italo9/mcp-fiscal-brasil](https://github.com/Italo9/mcp-fiscal-brasil)), portadas seletivamente após auditoria, adaptação e revisão de código e segurança.

## Follow-ups conhecidos (fora de escopo desta PR)

- Rotas REST deste serviço não têm autenticação nem rate limit por cliente (pré-existente ao port). Avaliar API key e/ou rate limit por cliente em versão futura.
- Validação em ambiente de homologação real das URLs dos webservices SEFAZ (a conferência feita aqui foi contra a config do `sped-nfe`, não contra chamadas reais às 27 UFs).
- Recomendado rodar um build Docker real antes do próximo release, para validar a imagem multi-stage com as mudanças de healthcheck.

## Test plan

- [x] `pytest` completo (622 passando)
- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy .` sem regressão de erros
- [x] Reprodução manual do healthcheck em modo `--transport http`
- [ ] CI do PR verde (acompanhar após abertura)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas funcionalidades**
  * Consulta do status real da SEFAZ por UF, com certificado digital A1 e mTLS.
  * Novo endpoint para verificar o status/configuração do certificado A1.
  * Validação de NFe aceita XML inline e por caminho de arquivo.
  * Healthcheck HTTP `/health` para monitoramento.
* **Correções**
  * Quando o certificado A1 não estiver configurado, o status da SEFAZ retorna 503 e a ferramenta passa a falhar com erro apropriado.
  * Melhor tratamento de falhas pontuais por UF (falhas parciais não derrubam a resposta agregada).
* **Documentação**
  * Atualizadas instruções de configuração e uso do certificado A1, variáveis de ambiente e mudanças do comportamento das rotas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->