### PR TITLE
docs: acentuar negativas no comparativo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ Reinicie o Claude Desktop. As ferramentas fiscais aparecem automaticamente, sem 
 | Funcionalidade | mcp-fiscal-brasil | mcp-brasil | brasil-data-mcp |
 |---|:---:|:---:|:---:|
 | Foco | Vertical fiscal profunda | Dados públicos gerais | Dados públicos gerais |
-| NF-e: parse, validação, DANFE, assinatura | Sim | Nao | Nao |
-| SPED/eSocial: análise offline | Sim | Nao | Nao |
-| Tabelas offline (NCM, CFOP, CNAE) | Sim | Nao | Nao |
-| Reforma Tributária 2026 (IBS/CBS) | Sim | Nao | Nao |
-| Simples Nacional/MEI | Sim | Nao | Nao |
-| Certidão federal/FGTS | Sim (orientação) | Nao | Nao |
-| Certificado A1 (mTLS SEFAZ) | Sim (opt-in) | Nao | Nao |
+| NF-e: parse, validação, DANFE, assinatura | Sim | Não | Não |
+| SPED/eSocial: análise offline | Sim | Não | Não |
+| Tabelas offline (NCM, CFOP, CNAE) | Sim | Não | Não |
+| Reforma Tributária 2026 (IBS/CBS) | Sim | Não | Não |
+| Simples Nacional/MEI | Sim | Não | Não |
+| Certidão federal/FGTS | Sim (orientação) | Não | Não |
+| Certificado A1 (mTLS SEFAZ) | Sim (opt-in) | Não | Não |
 | Zero-cadastro, zero chave obrigatória | Sim | Parcial (3 APIs exigem chave) | Sim |
-| Tools agênticas de alto nível | Sim (6 tools) | Parcial | Nao |
+| Tools agênticas de alto nível | Sim (6 tools) | Parcial | Não |
 | Linguagem de implementação | Python | Python | Node.js |
 
 **mcp-brasil** (1.6k stars) e **brasil-data-mcp** cobrem dados públicos gerais - CEP, bancos, feriados, economia. Este projeto faz algo diferente: é uma vertical fiscal, com parsing offline de XML, validação XSD, tabelas de referência embutidas e suporte à Reforma 2026. Focos diferentes, públicos distintos.


### PR DESCRIPTION
## Problema\n\nA tabela comparativa do README usava `Nao` em texto visível em PT-BR. Isso destoava do restante do documento e da regra de preservar acentuação em conteúdo para leitura humana.\n\n## Solução\n\nTroquei apenas as ocorrências visíveis de `Nao` por `Não` na tabela "Por que mcp-fiscal-brasil e não outros servidores MCP brasileiros?".\n\n## Validação\n\n- `! rg -n '\bNao\b|\bnao\b' README.md`\n- `git diff --check`\n- Antes do patch, confirmei que `uv run --locked ruff check src tests scripts` e `uv run --locked python scripts/check_release_metadata.py` estavam verdes no worktree isolado.\n\n## Riscos e fora de escopo\n\n- Docs-only; não altera código, dependências, release, publicação, API ou runtime MCP.\n- Mantive URLs, slugs e identificadores técnicos sem acento.\n- Não tratei alertas Dependabot/vulnerabilidades do branch padrão neste ciclo diário.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Corrigidas acentuação e caracteres na tabela comparativa do README, sem alterar os valores ou informações apresentados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->