### PR TITLE
fix: CLI sem traceback e status do Simples sem falso erro para CNPJ não optante

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ portadas seletivamente para o repositório canônico.
   as rotas REST deste serviço não possuem autenticação nem rate limit por
   cliente. Avaliar API key e/ou rate limit por cliente em versão futura.
 
+### Correções (CLI e Simples Nacional, 2026-09-03)
+
+* CLI `simples` não vaza mais traceback: CNPJ válido sem opção pelo Simples/MEI (BrasilAPI responde 404) agora retorna status negativo em vez de erro; CNPJ com dígito verificador inválido de fato continua sendo rejeitado antes de qualquer chamada de rede
+* nenhum subcomando do CLI (`cnpj`, `cpf`, `cep`, `simples`, `municipio`, `compliance`, `supplier`, `regimes`) vaza mais traceback: erro de negócio vira JSON estruturado no stdout com código de saída 1, erro inesperado com código 2
+* corpo de resposta HTTP não-JSON de serviços externos agora vira `FiscalHTTPError` em vez de `json.JSONDecodeError` não tratado
+
 ## [0.5.1](https://github.com/DeHor-Labs/mcp-fiscal-brasil/compare/v0.5.0...v0.5.1) (2026-06-21)
 
 

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -10,7 +10,12 @@ from typing import Any, cast
 import httpx
 from aiolimiter import AsyncLimiter
 from cachetools import TTLCache
-from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 __all__ = ["HTTPClient"]
 
@@ -196,8 +201,18 @@ class HTTPClient:
             return tuple(sorted(self._freeze(item) for item in value))
         return value
 
+    def _parse_json(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise self._http_error(
+                response.request.method,
+                response,
+                "A resposta não é um JSON válido.",
+            ) from exc
+
     def _json_object(self, response: httpx.Response) -> dict[str, Any]:
-        data = response.json()
+        data = self._parse_json(response)
         if isinstance(data, dict):
             return cast(dict[str, Any], data)
         raise self._http_error(
@@ -207,7 +222,7 @@ class HTTPClient:
         )
 
     def _json_list(self, response: httpx.Response) -> list[Any]:
-        data = response.json()
+        data = self._parse_json(response)
         if isinstance(data, list):
             return data
         raise self._http_error(

--- a/src/mcp_fiscal_brasil/agentic/compliance.py
+++ b/src/mcp_fiscal_brasil/agentic/compliance.py
@@ -136,7 +136,7 @@ async def analyze_cnpj_compliance(cnpj: str) -> ComplianceReport:
     # Regime tributário
     if simples_data is not None:
         fontes_ok.append("Simples Nacional")
-        if not simples_data.optante and simples_data.optante is not None:
+        if not simples_data.simples_nacional:
             achados.append(
                 ComplianceFinding(
                     categoria="regime_tributario",

--- a/src/mcp_fiscal_brasil/cli.py
+++ b/src/mcp_fiscal_brasil/cli.py
@@ -10,6 +10,11 @@ Exemplos:
     mcp-fiscal-brasil regimes --faturamento 500000 --setor serviços --folha 180000
     mcp-fiscal-brasil cpf 12345678909
     mcp-fiscal-brasil cep 01001000
+
+Toda saída é JSON estruturado (mesmo em erro): {"ok": true, ...} ou
+{"ok": false, "erro": "...", "tipo": "...", "cnpj": ...}. Nenhum comando
+vaza traceback: erro de negócio (FiscalError) sai com código 1, erro
+inesperado sai com código 2.
 """
 
 from __future__ import annotations
@@ -17,12 +22,14 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from typing import Any
+from collections.abc import Coroutine
+from typing import Any, NoReturn
 
 import typer
 from pydantic import BaseModel
 
 from . import __version__
+from ._core.errors import FiscalError
 from .agentic import (
     analyze_cnpj_compliance,
     compare_tax_regimes,
@@ -39,6 +46,7 @@ app = typer.Typer(
     help="CLI fiscal brasileiro: CNPJ, CPF, Simples, NFe, SPED e mais.",
     no_args_is_help=True,
     add_completion=False,
+    pretty_exceptions_enable=False,
 )
 
 
@@ -74,6 +82,38 @@ def _pretty(value: Any, indent: int) -> None:
         typer.echo(f"{prefix}{value}")
 
 
+def _fail(exc: Exception, cnpj: str | None, code: int) -> NoReturn:
+    """Imprime um erro como JSON estruturado no stdout e sai sem traceback."""
+    payload = {
+        "ok": False,
+        "erro": str(exc),
+        "tipo": type(exc).__name__,
+        "cnpj": cnpj,
+    }
+    typer.echo(json.dumps(payload, ensure_ascii=False))
+    raise typer.Exit(code=code)
+
+
+def _run(coro: Coroutine[Any, Any, Any], *, cnpj: str | None = None) -> Any:
+    """Executa uma coroutine do CLI convertendo erros em JSON (nunca traceback)."""
+    try:
+        return asyncio.run(coro)
+    except FiscalError as exc:
+        _fail(exc, cnpj, code=1)
+    except Exception as exc:  # CLI nunca deve vazar traceback
+        _fail(exc, cnpj, code=2)
+
+
+def _call(func: Any, cnpj: str | None = None) -> Any:
+    """Executa uma função síncrona do CLI convertendo erros em JSON (nunca traceback)."""
+    try:
+        return func()
+    except FiscalError as exc:
+        _fail(exc, cnpj, code=1)
+    except Exception as exc:  # CLI nunca deve vazar traceback
+        _fail(exc, cnpj, code=2)
+
+
 @app.command()
 def version() -> None:
     """Exibe versão do pacote."""
@@ -86,7 +126,7 @@ def cnpj(
     as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
 ) -> None:
     """Consulta dados cadastrais de um CNPJ."""
-    resultado = asyncio.run(consultar_cnpj(número))
+    resultado = _run(consultar_cnpj(número), cnpj=número)
     _print(resultado, as_json)
 
 
@@ -96,7 +136,7 @@ def cpf(
     as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
 ) -> None:
     """Valida CPF brasileiro (digito verificador, offline)."""
-    resultado = asyncio.run(validar_cpf_tool(número))
+    resultado = _run(validar_cpf_tool(número))
     _print(resultado, as_json)
 
 
@@ -111,7 +151,7 @@ def cep(
         client = CEPClient()
         return await client.get_address(número)
 
-    resultado = asyncio.run(run())
+    resultado = _run(run())
     _print(resultado, as_json)
 
 
@@ -126,7 +166,7 @@ def simples(
         client = SimplesClient()
         return await client.get_simples_status(cnpj)
 
-    resultado = asyncio.run(run())
+    resultado = _run(run(), cnpj=cnpj)
     _print(resultado, as_json)
 
 
@@ -141,7 +181,7 @@ def municipio(
         client = IBGEClient()
         return await client.get_municipality(int(codigo_ibge))
 
-    resultado = asyncio.run(run())
+    resultado = _run(run())
     _print(resultado, as_json)
 
 
@@ -151,7 +191,7 @@ def compliance(
     as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
 ) -> None:
     """Analise consolidada de compliance fiscal (multiplas fontes)."""
-    resultado = asyncio.run(analyze_cnpj_compliance(cnpj))
+    resultado = _run(analyze_cnpj_compliance(cnpj), cnpj=cnpj)
     _print(resultado, as_json)
 
 
@@ -162,7 +202,10 @@ def supplier(
     as_json: bool = typer.Option(False, "--json", help="Saida em JSON puro"),
 ) -> None:
     """Score de risco para due diligence de fornecedor."""
-    resultado = asyncio.run(risk_score_supplier(cnpj, criterios_estritos=estrito))
+    resultado = _run(
+        risk_score_supplier(cnpj, criterios_estritos=estrito),
+        cnpj=cnpj,
+    )
     _print(resultado, as_json)
 
 
@@ -175,12 +218,17 @@ def regimes(
 ) -> None:
     """Compara regimes tributarios (MEI/Simples/Lucro Presumido/Lucro Real)."""
     if setor not in ("comércio", "serviços", "indústria"):
-        typer.echo("Erro: setor deve ser comércio, serviços ou indústria", err=True)
-        raise typer.Exit(code=1)
-    resultado = compare_tax_regimes(
-        faturamento_anual=faturamento,
-        setor=setor,  # type: ignore[arg-type]
-        folha_pagamento_anual=folha,
+        _fail(
+            ValueError("setor deve ser comércio, serviços ou indústria"),
+            cnpj=None,
+            code=1,
+        )
+    resultado = _call(
+        lambda: compare_tax_regimes(
+            faturamento_anual=faturamento,
+            setor=setor,  # type: ignore[arg-type]
+            folha_pagamento_anual=folha,
+        )
     )
     _print(resultado, as_json)
 

--- a/src/mcp_fiscal_brasil/simples/client.py
+++ b/src/mcp_fiscal_brasil/simples/client.py
@@ -1,8 +1,14 @@
 from datetime import date
 
-from mcp_fiscal_brasil._core import FiscalNotFoundError, HTTPClient, get_logger, settings
+from mcp_fiscal_brasil._core import (
+    FiscalNotFoundError,
+    HTTPClient,
+    get_logger,
+    settings,
+)
 from mcp_fiscal_brasil._core.errors import FiscalHTTPError
 
+from ..shared.validators import normalizar_cnpj, validate_cnpj_qualquer
 from .schemas import SimplesStatus
 
 logger = get_logger(__name__)
@@ -30,40 +36,51 @@ class SimplesClient:
 
     async def get_simples_status(self, cnpj: str) -> SimplesStatus:
         """Consulta o status do Simples Nacional e MEI para um CNPJ."""
-        logger.info("simples_status_started", cnpj=cnpj)
-        cnpj_clean = "".join(c for c in cnpj if c.isdigit())
+        cnpj_clean = normalizar_cnpj(cnpj)
+        if not validate_cnpj_qualquer(cnpj_clean):
+            # A BrasilAPI responde 404 tanto pra CNPJ inexistente quanto pra CNPJ
+            # valido sem opcao pelo Simples/MEI, entao so da pra distinguir
+            # "invalido de fato" validando o digito verificador localmente,
+            # antes de bater na API.
+            raise FiscalNotFoundError("CNPJ inválido", "CNPJ", cnpj_clean)
+
+        logger.info("simples_status_started", cnpj=cnpj_clean)
         async with self._http_client() as client:
             try:
                 data = await client.get(f"/simples/v1/{cnpj_clean}")
-
-                # A BrasilAPI retorna {"simples": {...}, "simei": {...}}
-                # ou dados na raiz dependendo da versão, tratamos ambas.
-                simples = data.get("simples") if isinstance(data.get("simples"), dict) else data
-                simei = data.get("simei") if isinstance(data.get("simei"), dict) else data
-
-                if not isinstance(simples, dict):
-                    simples = {}
-                if not isinstance(simei, dict):
-                    simei = {}
-
-                return SimplesStatus(
-                    cnpj=cnpj_clean,
-                    simples_nacional=simples.get("optante", data.get("simples_nacional", False)),
-                    data_opcao=self._parse_date(
-                        simples.get("data_opcao", data.get("data_opcao_simples"))
-                    ),
-                    data_exclusao=self._parse_date(
-                        simples.get("data_exclusao", data.get("data_exclusao_simples"))
-                    ),
-                    mei=simei.get("optante", data.get("mei", False)),
-                    data_opcao_mei=self._parse_date(
-                        simei.get("data_opcao", data.get("data_opcao_simei"))
-                    ),
-                    data_exclusao_mei=self._parse_date(
-                        simei.get("data_exclusao", data.get("data_exclusao_simei"))
-                    ),
-                )
             except FiscalHTTPError as exc:
                 if exc.status_code == 404:
-                    raise FiscalNotFoundError("CNPJ não encontrado", "CNPJ", cnpj_clean) from exc
+                    # Nao optante pelo Simples/MEI (ou sem dados pro CNPJ):
+                    # nao e erro, e um resultado negativo legitimo.
+                    logger.warning("simples_status_nao_confirmado", cnpj=cnpj_clean)
+                    return SimplesStatus(
+                        cnpj=cnpj_clean,
+                        simples_nacional=False,
+                        mei=False,
+                        fonte_confirmada=False,
+                    )
                 raise
+
+        # A BrasilAPI retorna {"simples": {...}, "simei": {...}}
+        # ou dados na raiz dependendo da versão, tratamos ambas.
+        simples = data.get("simples") if isinstance(data.get("simples"), dict) else data
+        simei = data.get("simei") if isinstance(data.get("simei"), dict) else data
+
+        if not isinstance(simples, dict):
+            simples = {}
+        if not isinstance(simei, dict):
+            simei = {}
+
+        return SimplesStatus(
+            cnpj=cnpj_clean,
+            simples_nacional=simples.get("optante", data.get("simples_nacional", False)),
+            data_opcao=self._parse_date(simples.get("data_opcao", data.get("data_opcao_simples"))),
+            data_exclusao=self._parse_date(
+                simples.get("data_exclusao", data.get("data_exclusao_simples"))
+            ),
+            mei=simei.get("optante", data.get("mei", False)),
+            data_opcao_mei=self._parse_date(simei.get("data_opcao", data.get("data_opcao_simei"))),
+            data_exclusao_mei=self._parse_date(
+                simei.get("data_exclusao", data.get("data_exclusao_simei"))
+            ),
+        )

--- a/src/mcp_fiscal_brasil/simples/schemas.py
+++ b/src/mcp_fiscal_brasil/simples/schemas.py
@@ -11,3 +11,7 @@ class SimplesStatus(BaseModel):
     mei: bool
     data_opcao_mei: date | None = None
     data_exclusao_mei: date | None = None
+    fonte_confirmada: bool = True
+    """False quando o resultado veio de um 404 da BrasilAPI: pode significar
+    'não optante' de fato ou apenas que a fonte não confirmou o dado (endpoint
+    fora do ar, CNPJ inexistente etc). True = dado retornado pela API normalmente."""

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -29,6 +29,7 @@ from mcp_fiscal_brasil.agentic.schemas import (
 )
 from mcp_fiscal_brasil.cnpj.schemas import AtividadeCNAE, CNPJResponse
 from mcp_fiscal_brasil.shared.schemas import Endereco
+from mcp_fiscal_brasil.simples.schemas import SimplesStatus
 
 
 def _cnpj_ativo() -> CNPJResponse:
@@ -286,6 +287,35 @@ async def test_compliance_empresa_baixada_eleva_risco() -> None:
     assert report.risco_geral == "critico"
     assert report.score < 30
     assert any(a.categoria == "situacao_cadastral" for a in report.achados)
+
+
+@pytest.mark.asyncio
+async def test_compliance_simples_data_real_nao_optante_gera_achado() -> None:
+    """Regressao: SimplesStatus real (não mockado como excecao) nao pode
+    disparar AttributeError ao acessar o campo de opcao pelo regime."""
+    with (
+        patch("mcp_fiscal_brasil.agentic.compliance.CNPJClient") as mock_cnpj_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.SimplesClient") as mock_simples_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.MEIClient") as mock_mei_class,
+    ):
+        cnpj_inst = MagicMock()
+        cnpj_inst.consultar = AsyncMock(return_value=_cnpj_ativo())
+        mock_cnpj_class.return_value = cnpj_inst
+
+        simples_inst = MagicMock()
+        simples_inst.get_simples_status = AsyncMock(
+            return_value=SimplesStatus(cnpj="12345678000190", simples_nacional=False, mei=False)
+        )
+        mock_simples_class.return_value = simples_inst
+
+        mei_inst = MagicMock()
+        mei_inst.get_mei_status = AsyncMock(side_effect=Exception("offline"))
+        mock_mei_class.return_value = mei_inst
+
+        report = await analyze_cnpj_compliance("12.345.678/0001-90")
+
+    assert "Simples Nacional" in report.fontes_consultadas
+    assert any(a.categoria == "regime_tributario" for a in report.achados)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
@@ -12,6 +13,7 @@ from mcp_fiscal_brasil.agentic.schemas import (
     TaxRegimeOption,
 )
 from mcp_fiscal_brasil.cli import app
+from mcp_fiscal_brasil.simples.schemas import SimplesStatus
 
 runner = CliRunner()
 
@@ -30,7 +32,15 @@ def test_cli_regimes_setor_invalido() -> None:
 def test_cli_regimes_calculo_valido() -> None:
     result = runner.invoke(
         app,
-        ["regimes", "--faturamento", "500000", "--setor", "serviços", "--folha", "180000"],
+        [
+            "regimes",
+            "--faturamento",
+            "500000",
+            "--setor",
+            "serviços",
+            "--folha",
+            "180000",
+        ],
     )
     assert result.exit_code == 0
     assert (
@@ -120,3 +130,68 @@ def test_cli_regimes_pretty_output() -> None:
     assert result.exit_code == 0
     # pretty output uses key: value
     assert ":" in result.stdout
+
+
+def test_cli_simples_cnpj_invalido_vira_json_sem_traceback() -> None:
+    """CNPJ com digito verificador invalido: erro de negocio, JSON, codigo 1."""
+    result = runner.invoke(app, ["simples", "00000000000000", "--json"])
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+    data = json.loads(result.stdout)
+    assert data == {
+        "ok": False,
+        "erro": "CNPJ inválido",
+        "tipo": "FiscalNotFoundError",
+        "cnpj": "00000000000000",
+    }
+
+
+def test_cli_simples_sucesso_json() -> None:
+    mock_client = AsyncMock()
+    mock_client.get_simples_status.return_value = SimplesStatus(
+        cnpj="33000167000101", simples_nacional=False, mei=False
+    )
+    with patch("mcp_fiscal_brasil.cli.SimplesClient", return_value=mock_client):
+        result = runner.invoke(app, ["simples", "33000167000101", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["simples_nacional"] is False
+    assert data["mei"] is False
+
+
+def test_cli_simples_erro_inesperado_vira_json_codigo_2() -> None:
+    """Erro que nao e FiscalError: JSON estruturado, sem traceback, codigo 2."""
+    mock_client = AsyncMock()
+    mock_client.get_simples_status.side_effect = RuntimeError("boom")
+    with patch("mcp_fiscal_brasil.cli.SimplesClient", return_value=mock_client):
+        result = runner.invoke(app, ["simples", "33000167000101", "--json"])
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    data = json.loads(result.stdout)
+    assert data == {
+        "ok": False,
+        "erro": "boom",
+        "tipo": "RuntimeError",
+        "cnpj": "33000167000101",
+    }
+
+
+def test_cli_compliance_erro_inesperado_vira_json_codigo_2() -> None:
+    mock_async = AsyncMock(side_effect=RuntimeError("todas as fontes falharam"))
+    with patch("mcp_fiscal_brasil.cli.analyze_cnpj_compliance", mock_async):
+        result = runner.invoke(app, ["compliance", "12345678000190", "--json"])
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert data["tipo"] == "RuntimeError"
+    assert data["cnpj"] == "12345678000190"
+
+
+def test_cli_regimes_setor_invalido_json_estruturado() -> None:
+    result = runner.invoke(app, ["regimes", "--faturamento", "100000", "--setor", "invalido"])
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert data["tipo"] == "ValueError"

--- a/tests/test_core_http.py
+++ b/tests/test_core_http.py
@@ -51,7 +51,9 @@ async def test_get_retries_500_and_fails_before_fourth_attempt(
 
 
 @pytest.mark.asyncio
-async def test_get_retries_429_then_returns_success(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_retries_429_then_returns_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls = 0
 
     def handler(_: httpx.Request) -> httpx.Response:
@@ -132,3 +134,52 @@ async def test_rate_limit_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
     assert second == {"call": 2}
     assert elapsed >= 0.9
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_get_raises_fiscal_error_on_non_json_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Um 200 com corpo que nao e JSON valido (HTML, texto truncado etc.) deve
+    virar FiscalHTTPError, nunca um json.JSONDecodeError cru."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/html"}, text="<html/>")
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", max_retries=1, cache_ttl=0)
+
+    with pytest.raises(FiscalHTTPError) as exc_info:
+        await client.get("/broken")
+
+    assert exc_info.value.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_list_raises_fiscal_error_on_non_json_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not json at all")
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", max_retries=1, cache_ttl=0)
+
+    with pytest.raises(FiscalHTTPError):
+        await client.get_list("/broken-list")
+
+
+@pytest.mark.asyncio
+async def test_get_raises_fiscal_error_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out")
+
+    patch_async_client(monkeypatch, handler)
+    client = HTTPClient("https://example.test", max_retries=1, cache_ttl=0)
+
+    with pytest.raises(FiscalHTTPError) as exc_info:
+        await client.get("/slow")
+
+    assert exc_info.value.status_code is None

--- a/tests/test_simples.py
+++ b/tests/test_simples.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,35 +11,100 @@ def client():
     return SimplesClient()
 
 
+@pytest.fixture
+def cnpj_digits(cnpj_valido: str) -> str:
+    return "".join(c for c in cnpj_valido if c.isdigit())
+
+
 @pytest.mark.asyncio
-async def test_get_simples_status_success_simples_format(client):
+async def test_get_simples_status_success_simples_format(client, cnpj_digits):
     with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
         mock_get.return_value = {
             "simples_nacional": True,
             "mei": False,
             "data_opcao_simples": "2020-01-01",
         }
-        result = await client.get_simples_status("123")
+        result = await client.get_simples_status(cnpj_digits)
         assert result.simples_nacional is True
         assert result.mei is False
         assert result.data_opcao is not None
 
 
 @pytest.mark.asyncio
-async def test_get_simples_status_success_brasilapi_format(client):
+async def test_get_simples_status_success_brasilapi_format(client, cnpj_digits):
     with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
         mock_get.return_value = {
             "simples": {"optante": True, "data_opcao": "2020-01-01"},
             "simei": {"optante": True, "data_opcao": "2020-01-01"},
         }
-        result = await client.get_simples_status("123")
+        result = await client.get_simples_status(cnpj_digits)
         assert result.simples_nacional is True
         assert result.mei is True
 
 
 @pytest.mark.asyncio
-async def test_get_simples_status_not_found(client):
+async def test_get_simples_status_404_nao_optante_nao_e_erro(client, cnpj_digits):
+    """BrasilAPI responde 404 (HTML, sem JSON) pra CNPJ valido sem opcao pelo
+    Simples/MEI. Isso e um resultado negativo legitimo, nao uma falha, mas
+    fonte_confirmada fica False porque o 404 nao distingue esse caso de uma
+    fonte indisponivel."""
     with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
-        mock_get.side_effect = FiscalHTTPError("Not found", 404, "http://test")
+        mock_get.side_effect = FiscalHTTPError("Recurso não encontrado", 404, "http://test")
+        result = await client.get_simples_status(cnpj_digits)
+        assert result.simples_nacional is False
+        assert result.mei is False
+        assert result.cnpj == cnpj_digits
+        assert result.fonte_confirmada is False
+
+
+@pytest.mark.asyncio
+async def test_get_simples_status_aceita_cnpj_alfanumerico(client):
+    """CNPJ alfanumerico (IN RFB 2.229/2024) com DVs validos deve bater na API
+    em vez de ser rejeitado localmente como 'invalido'."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.return_value = {"simples_nacional": True, "mei": False}
+        result = await client.get_simples_status("AB123CD0000108")
+        assert result.simples_nacional is True
+        assert result.cnpj == "AB123CD0000108"
+        mock_get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_simples_status_cnpj_invalido_nao_bate_na_api(client, cnpj_invalido):
+    """CNPJ com digito verificador invalido de fato: FiscalNotFoundError sem
+    nenhuma chamada de rede (short-circuit local)."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
         with pytest.raises(FiscalNotFoundError):
-            await client.get_simples_status("123")
+            await client.get_simples_status(cnpj_invalido)
+        mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_simples_status_erro_500_propaga(client, cnpj_digits):
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.side_effect = FiscalHTTPError("Erro interno do servidor", 500, "http://test")
+        with pytest.raises(FiscalHTTPError) as exc_info:
+            await client.get_simples_status(cnpj_digits)
+        assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_get_simples_status_timeout_propaga_como_fiscal_error(client, cnpj_digits):
+    """Timeout ja chega como FiscalHTTPError (status_code=None) via HTTPClient;
+    o client de Simples nao deve engolir isso como 'nao encontrado'."""
+    with patch("mcp_fiscal_brasil._core.http.HTTPClient.get") as mock_get:
+        mock_get.side_effect = FiscalHTTPError(
+            "Falha de comunicação com serviço externo", None, "http://test"
+        )
+        with pytest.raises(FiscalHTTPError) as exc_info:
+            await client.get_simples_status(cnpj_digits)
+        assert exc_info.value.status_code is None
+
+
+@pytest.mark.asyncio
+async def test_get_simples_status_valida_offline_sem_chamar_api(client, cnpj_invalido):
+    """Garante que a validacao roda antes de instanciar/abrir o HTTPClient."""
+    with patch.object(SimplesClient, "_http_client", new=MagicMock()) as mock_http_client:
+        with pytest.raises(FiscalNotFoundError):
+            await client.get_simples_status(cnpj_invalido)
+        mock_http_client.assert_not_called()


### PR DESCRIPTION
## Resumo

O worker do Atlas em produção chama o CLI mcp-fiscal e faz JSON.parse da saída. Para o CNPJ da Petrobras (não optante), o subcomando simples estourava um traceback rich. Reproduzido: a BrasilAPI responde 404 (HTML) em /simples/v1 tanto para CNPJ válido não optante quanto para CNPJ inexistente, e o endpoint não aparece mais no código-fonte atual do BrasilAPI.

## Mudanças

- simples/client.py: valida o dígito verificador localmente antes de chamar a API; 404 vira SimplesStatus negativo com fonte_confirmada=false (não é erro); FiscalNotFoundError só para CNPJ inválido de fato.
- simples/schemas.py: campo fonte_confirmada para o consumidor saber que o negativo não foi confirmado pela fonte.
- _core/http.py: corpo não-JSON vira FiscalHTTPError em vez de JSONDecodeError solto.
- cli.py: nenhum subcomando vaza traceback; erro de negócio vira JSON (ok=false, erro, tipo, cnpj) com exit 1; erro inesperado vira JSON com exit 2.
- agentic/compliance.py ajustado; testes novos para client, http e CLI; entradas no CHANGELOG sob Unreleased (sem bump de versão, porque a main já tem mudanças breaking não lançadas).

## Validação

- Rebase sobre a main atual. pytest: 638 passed. ruff check e ruff format --check limpos.
- CLI real: simples 33000167000101 devolve JSON negativo com fonte_confirmada=false; CNPJ 00000000000000 devolve JSON de erro com exit 1; compliance continua JSON puro no stdout (logs vão para stderr).

## Atenção

Como a BrasilAPI aparentemente descontinuou /simples/v1, o status do Simples fica não confirmado até trocarmos a fonte (Receita/SERPRO). Está sinalizado no resultado, não mascarado.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - O status do Simples Nacional agora indica quando a fonte não confirmou o resultado.
  - CNPJs inválidos são identificados antes da consulta, e respostas 404 indicam resultado negativo sem interromper o comando.

- **Correções**
  - O CLI agora retorna erros em JSON estruturado, sem traceback, com códigos de saída diferenciados.
  - Respostas HTTP que não contêm JSON são tratadas como erros fiscais estruturados.
  - Corrigido o processamento de empresas não optantes pelo Simples Nacional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->