### PR TITLE
feat(cnpj,nfe): provedor premium opcional cpfcnpj.com.br (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,29 @@
 
 # Ambiente SEFAZ: producao ou homologacao. Padrao: producao.
 # NFE_AMBIENTE=producao
+
+# ---------------------------------------------------------------------------
+# Provedor premium OPCIONAL: cpfcnpj.com.br
+# ---------------------------------------------------------------------------
+# O servico continua 100% gratuito e sem cadastro por padrao. Estas variaveis
+# sao totalmente opcionais e ligam uma fonte premium opt-in de dados oficiais em
+# tempo real (D+0). Sem CPFCNPJ_TOKEN definido, NADA muda: as consultas usam
+# apenas as fontes gratuitas atuais (BrasilAPI, ReceitaWS, Portal NFe).
+#
+# Ao definir CPFCNPJ_TOKEN, o provedor passa a ser tentado PRIMEIRO nas consultas,
+# com as fontes gratuitas mantidas como fallback automatico:
+#   - CNPJ (consultar_cnpj): pacote 5 ou 6 (razao/fantasia/endereco/IBGE,
+#     situacao, porte, Simples Nacional, QSA)
+#   - NF-e por chave (consultar_nfe): pacote 100 (modelo 55)
+#   - NFC-e por chave (consultar_nfce): pacote 102 (modelo 65)
+#
+# Documentacao oficial da API: https://www.cpfcnpj.com.br/dev/
+# Token de conta ativa em https://www.cpfcnpj.com.br/. Trate como segredo:
+# nunca versione o token real num .env em disco em producao.
+# CPFCNPJ_TOKEN=
+
+# URL base da API (padrao ja aponta para producao; raramente precisa mudar).
+# CPFCNPJ_BASE_URL=https://api.cpfcnpj.com.br
+
+# Pacote usado nas consultas de CNPJ: 5 (enxuto) ou 6 (completo). Padrao: 6.
+# CPFCNPJ_CNPJ_PACKET=6

--- a/README.md
+++ b/README.md
@@ -210,10 +210,11 @@ Funcionam 100% sem chaves de API. Instale e use imediatamente.
 
 | Módulo | Ferramenta | Descrição | API |
 |--------|-----------|-----------|-----|
-| CNPJ | `consultar_cnpj` | Dados completos: razão social, sócios, CNAE, endereço | BrasilAPI (grátis) |
+| CNPJ | `consultar_cnpj` | Dados completos: razão social, sócios, CNAE, endereço | BrasilAPI (grátis) + cpfcnpj.com.br (premium, opt-in) |
 | CNPJ | `consultar_simples_nacional` | Optante Simples/MEI com datas de entrada e exclusão | BrasilAPI (grátis) |
 | NFe | `validar_chave_nfe` | Valida dígito + extrai UF, CNPJ, data, número | Offline |
-| NFe | `consultar_nfe` | Consulta NFe completa pela chave de 44 dígitos | BrasilAPI (grátis) |
+| NFe | `consultar_nfe` | Consulta NFe completa pela chave de 44 dígitos | BrasilAPI (grátis) + cpfcnpj.com.br (premium, opt-in) |
+| NFe | `consultar_nfce` | Consulta NFC-e (modelo 65) pela chave de 44 dígitos | cpfcnpj.com.br (premium, opt-in) |
 | NFe | `parse_nfe_xml` | Parseia XML bruto de NF-e/NFC-e e retorna dados estruturados | Offline |
 | NFe | `gerar_danfe` | Gera DANFE PDF (A4) a partir do XML de NF-e (mod 55) | Offline |
 | NFe | `validar_assinatura_nfe` | Valida assinatura XMLDSig e extrai dados do certificado | Offline |
@@ -276,6 +277,51 @@ sim, degrada omitindo a UF em vez de derrubar a chamada). `GET
 /v1/fiscal/certificado/status` informa apenas se há certificado configurado e
 válido (sem titular nem CNPJ - endpoint sem autenticação, não deve permitir
 reconhecimento de identidade), sem nunca expor o arquivo ou a senha.
+
+---
+
+### ☁️ Provedor premium opcional: cpfcnpj.com.br (opt-in)
+
+O projeto continua **gratuito, sem cadastro e sem chave de API por padrão**. Para
+quem precisa de cobertura e atualidade de nível empresarial, a
+[cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/) pode ser habilitada como uma
+fonte premium **opt-in**, sem alterar em nada o comportamento gratuito padrão.
+
+Enquanto o token não é configurado, tudo funciona como antes, usando apenas as
+fontes gratuitas (BrasilAPI, ReceitaWS e Portal NFe). Ao definir `CPFCNPJ_TOKEN`,
+o provedor passa a ser consultado **primeiro**, e as fontes gratuitas seguem como
+fallback automático, de forma transparente.
+
+**O que a fonte premium acrescenta a este projeto fiscal:**
+
+- **Dados oficiais em tempo real (D+0):** cadastro atualizado direto na origem,
+  sem depender de janelas de sincronização de bases intermediárias.
+- **Sem bases vazadas ou raspadas:** os dados vêm de fontes oficiais, com
+  procedência conhecida, e não de dumps de terceiros.
+- **Conformidade com certificações ISO/IEC de segurança da informação**
+  (norma <ISO_CERT>), reforçando privacidade e tratamento adequado dos dados.
+- **Cobre a consulta de NF-e por chave**, que hoje depende de fontes públicas
+  instáveis, e adiciona **NFC-e (modelo 65)**, ainda não coberta pelas APIs
+  gratuitas.
+
+**Ferramentas cobertas quando o token está ativo:**
+
+| Ferramenta | Fonte premium | Pacote | Documentação |
+|-----------|---------------|--------|--------------|
+| `consultar_cnpj` | cpfcnpj.com.br | 5 ou 6 | [dev/](https://www.cpfcnpj.com.br/dev/) |
+| `consultar_nfe` | cpfcnpj.com.br | 100 (modelo 55) | [#op-get-token-100-chave](https://www.cpfcnpj.com.br/dev/#op-get-token-100-chave) |
+| `consultar_nfce` | cpfcnpj.com.br | 102 (modelo 65) | [#op-get-token-102-chave](https://www.cpfcnpj.com.br/dev/#op-get-token-102-chave) |
+
+**Configuração** (todas opcionais, ver `.env.example`):
+
+| Variável | Descrição | Padrão |
+|----------|-----------|--------|
+| `CPFCNPJ_TOKEN` | Token da conta em cpfcnpj.com.br. **Vazio = fonte premium desligada.** | (vazio) |
+| `CPFCNPJ_BASE_URL` | URL base da API premium | `https://api.cpfcnpj.com.br` |
+| `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ: `5` (enxuto) ou `6` (completo) | `6` |
+
+Trate o token como segredo: use o gestor de segredos do seu provedor de deploy,
+nunca um `.env` versionado em produção.
 
 ---
 
@@ -403,6 +449,9 @@ Todas as variáveis são opcionais. O servidor funciona sem nenhuma configuraç�
 | `MCP_FISCAL_LOG_LEVEL` | Nível de log: `DEBUG`, `INFO`, `WARNING` | `INFO` |
 | `BRASILAPI_BASE_URL` | URL base da BrasilAPI (para ambientes customizados) | `https://brasilapi.com.br/api` |
 | `HTTP_TIMEOUT` | Timeout em segundos para chamadas HTTP | `30` |
+| `CPFCNPJ_TOKEN` | Token do provedor premium opt-in [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/). Vazio = desligado (padrão gratuito intacto) | (vazio) |
+| `CPFCNPJ_BASE_URL` | URL base da API premium cpfcnpj.com.br | `https://api.cpfcnpj.com.br` |
+| `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ na cpfcnpj.com.br: `5` ou `6` | `6` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Gerais (MG); as demais UFs exigem habilitação sob demanda e podem retornar o e
 | Variável | Descrição | Padrão |
 |----------|-----------|--------|
 | `CPFCNPJ_TOKEN` | Token da conta em cpfcnpj.com.br. **Vazio = fonte premium desligada.** | (vazio) |
-| `CPFCNPJ_BASE_URL` | URL base da API premium | `https://api.cpfcnpj.com.br` |
+| `CPFCNPJ_BASE_URL` | URL base da API premium. Aceita somente `https://` (o token trafega no caminho da URL) | `https://api.cpfcnpj.com.br` |
 | `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ: `5` (enxuto) ou `6` (completo) | `6` |
 
 Trate o token como segredo: use o gestor de segredos do seu provedor de deploy,
@@ -458,7 +458,7 @@ Todas as variáveis são opcionais. O servidor funciona sem nenhuma configuraç�
 | `BRASILAPI_BASE_URL` | URL base da BrasilAPI (para ambientes customizados) | `https://brasilapi.com.br/api` |
 | `HTTP_TIMEOUT` | Timeout em segundos para chamadas HTTP | `30` |
 | `CPFCNPJ_TOKEN` | Token do provedor premium opt-in [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/). Vazio = desligado (padrão gratuito intacto) | (vazio) |
-| `CPFCNPJ_BASE_URL` | URL base da API premium cpfcnpj.com.br | `https://api.cpfcnpj.com.br` |
+| `CPFCNPJ_BASE_URL` | URL base da API premium cpfcnpj.com.br. Aceita somente `https://` | `https://api.cpfcnpj.com.br` |
 | `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ na cpfcnpj.com.br: `5` ou `6` | `6` |
 
 ---

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ fallback automático, de forma transparente.
   sem depender de janelas de sincronização de bases intermediárias.
 - **Sem bases vazadas ou raspadas:** os dados vêm de fontes oficiais, com
   procedência conhecida, e não de dumps de terceiros.
-- **Conformidade com certificações ISO/IEC de segurança da informação**
-  (norma <ISO_CERT>), reforçando privacidade e tratamento adequado dos dados.
+- **Conformidade com certificações internacionais** (ISO/IEC 27001 de segurança
+  da informação, ISO/IEC 27701 de privacidade e ISO 37301 de gestão de
+  conformidade), reforçando privacidade e tratamento adequado dos dados.
 - **Cobre a consulta de NF-e por chave**, que hoje depende de fontes públicas
   instáveis, e adiciona **NFC-e (modelo 65)**, ainda não coberta pelas APIs
   gratuitas.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Funcionam 100% sem chaves de API. Instale e use imediatamente.
 | CNPJ | `consultar_simples_nacional` | Optante Simples/MEI com datas de entrada e exclusão | BrasilAPI (grátis) |
 | NFe | `validar_chave_nfe` | Valida dígito + extrai UF, CNPJ, data, número | Offline |
 | NFe | `consultar_nfe` | Consulta NFe completa pela chave de 44 dígitos | BrasilAPI (grátis) + cpfcnpj.com.br (premium, opt-in) |
-| NFe | `consultar_nfce` | Consulta NFC-e (modelo 65) pela chave de 44 dígitos | cpfcnpj.com.br (premium, opt-in) |
+| NFe | `consultar_nfce` | NFC-e (modelo 65) pela chave de 44 dígitos; consulta completa exige token (pacote 102), senão tenta fontes públicas com dados parciais | cpfcnpj.com.br (pacote 102) + fontes públicas (parcial) |
 | NFe | `parse_nfe_xml` | Parseia XML bruto de NF-e/NFC-e e retorna dados estruturados | Offline |
 | NFe | `gerar_danfe` | Gera DANFE PDF (A4) a partir do XML de NF-e (mod 55) | Offline |
 | NFe | `validar_assinatura_nfe` | Valida assinatura XMLDSig e extrai dados do certificado | Offline |
@@ -312,6 +312,13 @@ fallback automático, de forma transparente.
 | `consultar_cnpj` | cpfcnpj.com.br | 5 ou 6 | [dev/](https://www.cpfcnpj.com.br/dev/) |
 | `consultar_nfe` | cpfcnpj.com.br | 100 (modelo 55) | [#op-get-token-100-chave](https://www.cpfcnpj.com.br/dev/#op-get-token-100-chave) |
 | `consultar_nfce` | cpfcnpj.com.br | 102 (modelo 65) | [#op-get-token-102-chave](https://www.cpfcnpj.com.br/dev/#op-get-token-102-chave) |
+
+O `consultar_nfce` retorna a NFC-e completa apenas com o token configurado (pacote
+102). Sem token, ele recorre às fontes públicas e pode devolver dados parciais da
+chave. A cobertura on-line do pacote 102 está disponível em São Paulo (SP) e Minas
+Gerais (MG); as demais UFs exigem habilitação sob demanda e podem retornar o erro
+204 (sem consumo de crédito). Detalhes de cobertura em
+[cpfcnpj.com.br/dev/](https://www.cpfcnpj.com.br/dev/).
 
 **Configuração** (todas opcionais, ver `.env.example`):
 

--- a/src/mcp_fiscal_brasil/_core/config.py
+++ b/src/mcp_fiscal_brasil/_core/config.py
@@ -1,5 +1,6 @@
 """Application configuration for mcp-fiscal-brasil."""
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -38,6 +39,23 @@ class Settings(BaseSettings):
     nfe_ambiente: str = "producao"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    @field_validator("cpfcnpj_base_url")
+    @classmethod
+    def _exigir_https_cpfcnpj(cls, valor: str) -> str:
+        """Exige HTTPS na base da cpfcnpj.com.br.
+
+        O token da conta viaja no caminho da URL (``/{token}/{pacote}/{documento}``),
+        portanto a base nao pode usar ``http://``, mesmo quando sobrescrita por
+        variavel de ambiente, sob pena de expor o token sem criptografia.
+        """
+        normalizado = valor.strip()
+        if not normalizado.lower().startswith("https://"):
+            raise ValueError(
+                "CPFCNPJ_BASE_URL deve usar https:// (o token da conta viaja no "
+                "caminho da URL e nao pode trafegar sem criptografia)."
+            )
+        return normalizado
 
 
 settings = Settings()

--- a/src/mcp_fiscal_brasil/_core/config.py
+++ b/src/mcp_fiscal_brasil/_core/config.py
@@ -15,6 +15,15 @@ class Settings(BaseSettings):
     mcp_fiscal_file_base_dir: str = "~/.local/share/mcp-fiscal-brasil/files"
     brasilapi_base_url: str = "https://brasilapi.com.br/api"
     receita_base_url: str = "https://receitaws.com.br/v1"
+
+    # Provedor premium opcional cpfcnpj.com.br (opt-in). Sem token configurado, o
+    # servico opera exatamente como antes, usando apenas as fontes gratuitas. Ao
+    # definir CPFCNPJ_TOKEN, as consultas de CNPJ (pacotes 5/6) e de NF-e/NFC-e por
+    # chave (pacotes 100/102) passam a tentar primeiro a cpfcnpj.com.br, com dados
+    # oficiais em tempo real, e mantem as fontes gratuitas como fallback.
+    cpfcnpj_token: str = ""
+    cpfcnpj_base_url: str = "https://api.cpfcnpj.com.br"
+    cpfcnpj_cnpj_packet: int = 6
     ibge_cnae_base_url: str = "https://servicodados.ibge.gov.br/api/v2/cnae"
     ibge_localidades_base_url: str = "https://servicodados.ibge.gov.br/api/v1/localidades"
     bcb_sgs_base_url: str = "https://api.bcb.gov.br/dados/serie"

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -43,6 +43,7 @@ class HTTPClient:
         max_retries: int = 3,
         cache_ttl: int = 300,
         rate_limit_per_second: int = 10,
+        limiter: AsyncLimiter | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/") + "/"
         self.timeout = timeout
@@ -58,9 +59,13 @@ class HTTPClient:
             maxsize=1024,
             ttl=self.cache_ttl,
         )
-        self._limiter = AsyncLimiter(
-            self.rate_limit_per_second,
-            self.rate_limit_per_second,
+        # Um limitador pode ser injetado para ser compartilhado entre varias
+        # instancias (ex.: o teto global da cpfcnpj.com.br). Quando ausente, cada
+        # instancia usa o proprio, derivado de rate_limit_per_second.
+        self._limiter = (
+            limiter
+            if limiter is not None
+            else AsyncLimiter(self.rate_limit_per_second, self.rate_limit_per_second)
         )
 
     async def __aenter__(self) -> HTTPClient:

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -144,14 +144,6 @@ class HTTPClient:
         headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         try:
-            await self._limiter.acquire()
-        except ValueError as exc:
-            raise self._rate_limit_error(
-                "Limite de requisições excedido",
-                retry_after=float(self.rate_limit_per_second),
-            ) from exc
-
-        try:
             async for attempt in AsyncRetrying(
                 retry=retry_if_exception(self._is_retryable_error),
                 wait=wait_exponential(min=1, max=60),
@@ -159,6 +151,9 @@ class HTTPClient:
                 reraise=True,
             ):
                 with attempt:
+                    # Cada tentativa consome uma vaga do limitador: um retry
+                    # tambem conta para o teto de requisicoes por segundo.
+                    await self._acquire_rate_limit()
                     response = await self._client.request(
                         method,
                         path.lstrip("/"),
@@ -177,6 +172,15 @@ class HTTPClient:
             raise self._request_error(method, exc) from exc
 
         raise self._http_error(method, None)
+
+    async def _acquire_rate_limit(self) -> None:
+        try:
+            await self._limiter.acquire()
+        except ValueError as exc:
+            raise self._rate_limit_error(
+                "Limite de requisições excedido",
+                retry_after=float(self.rate_limit_per_second),
+            ) from exc
 
     def _absolute_url(self, path: str) -> str:
         return str(httpx.URL(self.base_url).join(path.lstrip("/")))

--- a/src/mcp_fiscal_brasil/agentic/compliance.py
+++ b/src/mcp_fiscal_brasil/agentic/compliance.py
@@ -9,6 +9,7 @@ from mcp_fiscal_brasil._core import get_logger
 
 from ..cnpj.client import CNPJClient
 from ..mei.client import MEIClient
+from ..shared.validators import normalizar_cnpj
 from ..simples.client import SimplesClient
 from .schemas import ComplianceFinding, ComplianceReport, RiskLevel
 
@@ -71,7 +72,7 @@ async def analyze_cnpj_compliance(cnpj: str) -> ComplianceReport:
     score 0-100, risco classificado e achados acionaveis.
 
     Args:
-        cnpj: CNPJ com ou sem formatacao (so digitos são usados).
+        cnpj: CNPJ numerico ou alfanumerico (IN RFB 2.229/2024), com ou sem formatacao.
 
     Returns:
         ComplianceReport com risco_geral, score, achados e resumo executivo.
@@ -86,7 +87,10 @@ async def analyze_cnpj_compliance(cnpj: str) -> ComplianceReport:
         Esta tool NAO consulta certidoes negativas reais (somente gera URLs).
         Para validação de certidoes use as ferramentas especificas do modulo certidoes.
     """
-    cnpj_limpo = "".join(c for c in cnpj if c.isdigit())
+    # normalizar_cnpj preserva letras (CNPJ alfanumérico, IN RFB 2.229/2024) em vez
+    # de descartá-las como o antigo strip por isdigit(). A validação aqui é só de
+    # comprimento (o dígito verificador é validado nas entradas consultar_cnpj/API/SDK).
+    cnpj_limpo = normalizar_cnpj(cnpj)
     if len(cnpj_limpo) != 14:
         raise ValueError(f"CNPJ deve ter 14 digitos, recebido {len(cnpj_limpo)}: {cnpj}")
 

--- a/src/mcp_fiscal_brasil/agentic/supplier.py
+++ b/src/mcp_fiscal_brasil/agentic/supplier.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from mcp_fiscal_brasil._core import get_logger
 
+from ..shared.validators import normalizar_cnpj
 from .compliance import analyze_cnpj_compliance
 from .schemas import (
     ComplianceReport,
@@ -17,8 +18,8 @@ from .schemas import (
 
 
 def _normaliza_cnpj(cnpj: str) -> str:
-    """Normaliza CNPJ para apenas dígitos."""
-    return "".join(d for d in cnpj if d.isdigit())
+    """Normaliza o CNPJ removendo a máscara e preservando letras (alfanumérico)."""
+    return normalizar_cnpj(cnpj)
 
 
 def _erro_consulta(cnpj: str, erro: Exception | str) -> str:

--- a/src/mcp_fiscal_brasil/api.py
+++ b/src/mcp_fiscal_brasil/api.py
@@ -57,13 +57,13 @@ app = FastAPI(
 
 
 def _validated_cnpj(cnpj: str) -> str:
-    # Aceita CNPJ numérico ou alfanumérico (IN RFB 2.229/2024). normalizar_cnpj
-    # remove a máscara e mantém as letras (A-Z em maiúsculas); validate_cnpj_qualquer
-    # valida o dígito verificador em ambos os formatos.
-    normalizado = normalizar_cnpj(cnpj)
-    if len(normalizado) != 14 or not validate_cnpj_qualquer(normalizado):
+    # Aceita CNPJ numérico ou alfanumérico (IN RFB 2.229/2024). A validação roda
+    # sobre o valor original: validate_cnpj_qualquer tolera apenas a máscara padrão
+    # (ponto, barra e traço) e rejeita espaços ou outros caracteres. Só depois de
+    # aceito o valor é normalizado (máscara removida, letras em maiúsculas).
+    if not validate_cnpj_qualquer(cnpj):
         raise HTTPException(status_code=400, detail="CNPJ inválido")
-    return normalizado
+    return normalizar_cnpj(cnpj)
 
 
 def _allowed_file_base_dir() -> Path:

--- a/src/mcp_fiscal_brasil/api.py
+++ b/src/mcp_fiscal_brasil/api.py
@@ -41,7 +41,7 @@ from .cpf.tools import validar_cpf_tool
 from .ibge.client import IBGEClient
 from .nfe.status_sefaz import obter_status_certificado
 from .nfe.tools import UFS_VALIDAS, consultar_status_sefaz, validar_chave_nfe
-from .shared.validators import validate_cnpj
+from .shared.validators import normalizar_cnpj, validate_cnpj_qualquer
 from .simples.client import SimplesClient
 
 logger = get_logger(__name__)
@@ -56,15 +56,14 @@ app = FastAPI(
 )
 
 
-def _only_digits(value: str) -> str:
-    return "".join(char for char in value if char.isdigit())
-
-
 def _validated_cnpj(cnpj: str) -> str:
-    digits = _only_digits(cnpj)
-    if len(digits) != 14 or not validate_cnpj(digits):
+    # Aceita CNPJ numérico ou alfanumérico (IN RFB 2.229/2024). normalizar_cnpj
+    # remove a máscara e mantém as letras (A-Z em maiúsculas); validate_cnpj_qualquer
+    # valida o dígito verificador em ambos os formatos.
+    normalizado = normalizar_cnpj(cnpj)
+    if len(normalizado) != 14 or not validate_cnpj_qualquer(normalizado):
         raise HTTPException(status_code=400, detail="CNPJ inválido")
-    return digits
+    return normalizado
 
 
 def _allowed_file_base_dir() -> Path:

--- a/src/mcp_fiscal_brasil/cnpj/client.py
+++ b/src/mcp_fiscal_brasil/cnpj/client.py
@@ -13,6 +13,7 @@ from mcp_fiscal_brasil._core import HTTPClient, Settings, get_logger
 
 from ..shared import cpfcnpj as cpfcnpj_provider
 from ..shared.schemas import Endereco
+from ..shared.validators import normalizar_cnpj
 from .schemas import AtividadeCNAE, CNPJResponse, QSASocio
 
 logger = get_logger(__name__)
@@ -55,7 +56,12 @@ class CNPJClient:
         Quando o provedor premium cpfcnpj.com.br esta configurado, ele e tentado
         primeiro. Em seguida, tenta BrasilAPI e, por fim, ReceitaWS.
         """
-        cnpj_limpo = "".join(c for c in cnpj if c.isdigit())
+        # Normaliza removendo mascara e preservando letras: o CNPJ alfanumerico
+        # (IN RFB 2.229/2024, vigencia jul/2026) tem 12 posicoes alfanumericas
+        # seguidas de 2 digitos verificadores. Usar isdigit() aqui descartaria as
+        # letras e quebraria a consulta. normalizar_cnpj remove separadores e
+        # mantem A-Z (em maiusculas), aceito pela cpfcnpj.com.br no caminho da URL.
+        cnpj_limpo = normalizar_cnpj(cnpj)
         logger.info("cnpj_lookup_started", cnpj=cnpj_limpo)
 
         if cpfcnpj_provider.provedor_configurado():

--- a/src/mcp_fiscal_brasil/cnpj/client.py
+++ b/src/mcp_fiscal_brasil/cnpj/client.py
@@ -1,15 +1,39 @@
-"""Cliente para consulta de CNPJ via BrasilAPI e ReceitaWS."""
+"""Cliente para consulta de CNPJ via BrasilAPI e ReceitaWS.
+
+Quando o provedor premium opcional cpfcnpj.com.br esta configurado (token via
+``CPFCNPJ_TOKEN``), ele e tentado primeiro, com dados oficiais em tempo real, e
+as fontes gratuitas (BrasilAPI e ReceitaWS) seguem como fallback. Sem token, o
+comportamento e identico ao anterior: apenas as fontes gratuitas sao usadas.
+"""
 
 from datetime import date
 from typing import Any
 
 from mcp_fiscal_brasil._core import HTTPClient, Settings, get_logger
 
+from ..shared import cpfcnpj as cpfcnpj_provider
 from ..shared.schemas import Endereco
 from .schemas import AtividadeCNAE, CNPJResponse, QSASocio
 
 logger = get_logger(__name__)
 _settings = Settings()
+
+
+def _parse_data(valor: str | None) -> date | None:
+    """Converte datas em ISO (AAAA-MM-DD) ou no formato brasileiro (DD/MM/AAAA)."""
+    if not valor:
+        return None
+    texto = valor.strip()
+    for formato in ("iso", "%d/%m/%Y"):
+        try:
+            if formato == "iso":
+                return date.fromisoformat(texto[:10])
+            from datetime import datetime
+
+            return datetime.strptime(texto, formato).date()
+        except ValueError:
+            continue
+    return None
 
 
 class CNPJClient:
@@ -28,10 +52,22 @@ class CNPJClient:
         """
         Consulta os dados de um CNPJ.
 
-        Tenta BrasilAPI primeiro; em caso de falha, tenta ReceitaWS.
+        Quando o provedor premium cpfcnpj.com.br esta configurado, ele e tentado
+        primeiro. Em seguida, tenta BrasilAPI e, por fim, ReceitaWS.
         """
         cnpj_limpo = "".join(c for c in cnpj if c.isdigit())
         logger.info("cnpj_lookup_started", cnpj=cnpj_limpo)
+
+        if cpfcnpj_provider.provedor_configurado():
+            try:
+                return await self._consultar_cpfcnpj(cnpj_limpo)
+            except Exception as exc:
+                logger.warning(
+                    "cpfcnpj_cnpj_lookup_failed",
+                    cnpj=cnpj_limpo,
+                    error=str(exc),
+                    fallback="brasilapi",
+                )
 
         try:
             return await self._consultar_brasil_api(cnpj_limpo)
@@ -43,6 +79,10 @@ class CNPJClient:
                 fallback="receitaws",
             )
             return await self._consultar_receita_ws(cnpj_limpo)
+
+    async def _consultar_cpfcnpj(self, cnpj: str) -> CNPJResponse:
+        data = await cpfcnpj_provider.consultar(_settings.cpfcnpj_cnpj_packet, cnpj)
+        return self._parse_cpfcnpj(data, cnpj)
 
     async def _consultar_brasil_api(self, cnpj: str) -> CNPJResponse:
         async with self._http_client(_settings.brasilapi_base_url) as client:
@@ -165,3 +205,105 @@ class CNPJClient:
             qsa=qsa,
             origem="ReceitaWS",
         )
+
+    def _parse_cpfcnpj(self, data: dict[str, Any], cnpj: str) -> CNPJResponse:
+        """Transforma a resposta do pacote CNPJ da cpfcnpj.com.br em CNPJResponse."""
+        cnae = data.get("cnae") or {}
+        atividade_principal = None
+        if cnae.get("fiscal") and cnae.get("descricao"):
+            atividade_principal = AtividadeCNAE(
+                código=str(cnae["fiscal"]),
+                descrição=cnae["descricao"],
+            )
+
+        atividades_secundarias = []
+        for sec in cnae.get("secundarias") or []:
+            codigo = sec.get("subclasse") or sec.get("id")
+            if codigo and sec.get("descricao"):
+                atividades_secundarias.append(
+                    AtividadeCNAE(código=str(codigo), descrição=sec["descricao"])
+                )
+
+        endereco_raw = data.get("matrizEndereco") or {}
+        endereco = Endereco(
+            logradouro=endereco_raw.get("logradouro"),
+            número=endereco_raw.get("numero"),
+            complemento=endereco_raw.get("complemento"),
+            bairro=endereco_raw.get("bairro"),
+            municipio=endereco_raw.get("cidade"),
+            uf=endereco_raw.get("uf"),
+            cep=endereco_raw.get("cep"),
+        )
+
+        qsa = []
+        for sócio in data.get("socios") or []:
+            qsa.append(
+                QSASocio(
+                    nome=sócio.get("nome", ""),
+                    qualificacao=self._qualificacao_texto(sócio.get("qualificacao_socio")),
+                    cpf_cnpj_socio=sócio.get("cpf_cnpj_socio"),
+                    faixa_etaria=sócio.get("faixa_etaria"),
+                    nome_representante_legal=sócio.get("nome_representante"),
+                    qualificacao_representante_legal=self._qualificacao_texto(
+                        sócio.get("qualificacao_representante")
+                    ),
+                )
+            )
+
+        natureza = data.get("naturezaJuridica") or {}
+        natureza_texto = " - ".join(
+            parte for parte in (natureza.get("codigo"), natureza.get("descricao")) if parte
+        )
+
+        telefone = None
+        for tel in data.get("telefones") or []:
+            ddd = tel.get("ddd")
+            numero = tel.get("numero")
+            if ddd and numero:
+                telefone = f"({ddd}) {numero}"
+                break
+            if numero:
+                telefone = numero
+                break
+
+        situacao = data.get("situacao") or {}
+        simples = data.get("simplesNacional") or {}
+        porte = data.get("porte") or {}
+
+        return CNPJResponse(
+            cnpj=cnpj,
+            razao_social=data.get("razao", ""),
+            nome_fantasia=data.get("fantasia") or None,
+            situacao_cadastral=situacao.get("nome", ""),
+            data_situacao_cadastral=_parse_data(situacao.get("data")),
+            natureza_juridica=natureza_texto,
+            porte=porte.get("descricao"),
+            capital_social=data.get("capitalSocial"),
+            data_abertura=_parse_data(data.get("inicioAtividade")),
+            atividade_principal=atividade_principal,
+            atividades_secundarias=atividades_secundarias,
+            endereco=endereco,
+            telefone=telefone,
+            email=data.get("email"),
+            qsa=qsa,
+            simples_nacional=self._sim_nao(simples.get("optante")),
+            mei=self._sim_nao(simples.get("mei")),
+            opcao_simples=simples or None,
+            origem="cpfcnpj.com.br",
+        )
+
+    @staticmethod
+    def _sim_nao(valor: Any) -> bool | None:
+        """Converte um campo textual 'Sim'/'Nao' em booleano; None se ausente."""
+        if not isinstance(valor, str) or not valor.strip():
+            return None
+        return valor.strip().lower().startswith("s")
+
+    @staticmethod
+    def _qualificacao_texto(valor: Any) -> str:
+        """Extrai a descricao de uma qualificacao que pode vir como texto ou objeto."""
+        if isinstance(valor, dict):
+            return str(valor.get("descricao") or valor.get("nome") or "")
+        if isinstance(valor, str):
+            return valor
+        return ""

--- a/src/mcp_fiscal_brasil/cnpj/client.py
+++ b/src/mcp_fiscal_brasil/cnpj/client.py
@@ -9,7 +9,7 @@ comportamento e identico ao anterior: apenas as fontes gratuitas sao usadas.
 from datetime import date
 from typing import Any
 
-from mcp_fiscal_brasil._core import HTTPClient, Settings, get_logger
+from mcp_fiscal_brasil._core import FiscalError, HTTPClient, Settings, get_logger
 
 from ..shared import cpfcnpj as cpfcnpj_provider
 from ..shared.schemas import Endereco
@@ -55,6 +55,18 @@ class CNPJClient:
 
         Quando o provedor premium cpfcnpj.com.br esta configurado, ele e tentado
         primeiro. Em seguida, tenta BrasilAPI e, por fim, ReceitaWS.
+
+        Suporte a CNPJ alfanumerico (IN RFB 2.229/2024, vigencia jul/2026) por
+        provedor:
+        - cpfcnpj.com.br: aceita o formato alfanumerico no caminho da URL
+          (confirmado pelo provedor).
+        - BrasilAPI: aceita, pois apenas faz proxy para o projeto minha-receita,
+          que valida o CNPJ com a lib go-cnpj (com tratamento alfanumerico).
+          Ref.: BrasilAPI issues #789 e #827 (fechadas) e services/cnpj.js
+          (repassa o parametro sem remover letras).
+        - ReceitaWS: a documentacao publica nao confirma suporte ao formato
+          alfanumerico; por isso NAO usamos essa fonte como fallback quando o
+          CNPJ contem letras, evitando respostas incorretas.
         """
         # Normaliza removendo mascara e preservando letras: o CNPJ alfanumerico
         # (IN RFB 2.229/2024, vigencia jul/2026) tem 12 posicoes alfanumericas
@@ -62,7 +74,8 @@ class CNPJClient:
         # letras e quebraria a consulta. normalizar_cnpj remove separadores e
         # mantem A-Z (em maiusculas), aceito pela cpfcnpj.com.br no caminho da URL.
         cnpj_limpo = normalizar_cnpj(cnpj)
-        logger.info("cnpj_lookup_started", cnpj=cnpj_limpo)
+        alfanumerico = bool(cnpj_limpo) and not cnpj_limpo.isdigit()
+        logger.info("cnpj_lookup_started", cnpj=cnpj_limpo, alfanumerico=alfanumerico)
 
         if cpfcnpj_provider.provedor_configurado():
             try:
@@ -78,6 +91,19 @@ class CNPJClient:
         try:
             return await self._consultar_brasil_api(cnpj_limpo)
         except Exception as exc:
+            if alfanumerico:
+                # ReceitaWS nao tem suporte documentado a CNPJ alfanumerico:
+                # nao fazemos fallback para nao devolver dados incorretos.
+                logger.warning(
+                    "receitaws_skip_alfanumerico",
+                    cnpj=cnpj_limpo,
+                    error=str(exc),
+                )
+                raise FiscalError(
+                    "CNPJ alfanumérico não obtido na BrasilAPI e a ReceitaWS não "
+                    "atende o formato alfanumérico (IN RFB 2.229/2024). Configure o "
+                    "provedor cpfcnpj.com.br (CPFCNPJ_TOKEN) para consultas alfanuméricas."
+                ) from exc
             logger.warning(
                 "brasilapi_cnpj_lookup_failed",
                 cnpj=cnpj_limpo,

--- a/src/mcp_fiscal_brasil/cnpj/tools.py
+++ b/src/mcp_fiscal_brasil/cnpj/tools.py
@@ -3,12 +3,14 @@
 from mcp_fiscal_brasil._core import FiscalValidationError, get_logger
 
 from ..shared.exceptions import ValidationError as SharedValidationError
-from ..shared.validators import format_cnpj, validate_cnpj
+from ..shared.validators import format_cnpj, normalizar_cnpj, validate_cnpj_qualquer
 from .client import CNPJClient
 from .schemas import CNPJResponse
 
 logger = get_logger(__name__)
-_INVALID_CNPJ_REASON = "CNPJ inválido. Verifique os 14 dígitos e o dígito verificador."
+_INVALID_CNPJ_REASON = (
+    "CNPJ inválido. Verifique os 14 caracteres (numérico ou alfanumérico) e o dígito verificador."
+)
 
 
 class _CNPJValidationError(FiscalValidationError, SharedValidationError):
@@ -34,11 +36,13 @@ async def consultar_cnpj(cnpj: str) -> CNPJResponse:
     """
     Consulta os dados cadastrais de uma empresa pelo CNPJ.
 
-    Aceita o CNPJ com ou sem formatação (pontos, barra, traço).
+    Aceita o CNPJ numérico ou alfanumérico (IN RFB 2.229/2024), com ou sem
+    formatação (pontos, barra, traço).
     Retorna razão social, endereço, atividades econômicas, sócios e situação cadastral.
 
     Args:
-        cnpj: Número do CNPJ (ex: '11.222.333/0001-81' ou '11222333000181')
+        cnpj: Número do CNPJ (ex: '11.222.333/0001-81', '11222333000181'
+            ou '12ABC34501DE35')
 
     Returns:
         CNPJResponse com os dados completos da empresa.
@@ -48,12 +52,13 @@ async def consultar_cnpj(cnpj: str) -> CNPJResponse:
         NotFoundError: Se o CNPJ não for encontrado na Receita Federal.
         APIError: Em caso de falha nas APIs consultadas.
     """
-    if not validate_cnpj(cnpj):
+    cnpj_normalizado = normalizar_cnpj(cnpj)
+    if not validate_cnpj_qualquer(cnpj_normalizado):
         raise _CNPJValidationError(field="cnpj", value=cnpj, reason=_INVALID_CNPJ_REASON)
 
-    cnpj_formatado = format_cnpj(cnpj)
+    cnpj_formatado = format_cnpj(cnpj_normalizado)
     logger.info("cnpj_lookup_requested", cnpj=cnpj_formatado)
-    return await _client.consultar(cnpj)
+    return await _client.consultar(cnpj_normalizado)
 
 
 async def listar_cnpjs_por_nome(nome: str, uf: str | None = None) -> list[dict[str, str]]:

--- a/src/mcp_fiscal_brasil/cnpj/tools.py
+++ b/src/mcp_fiscal_brasil/cnpj/tools.py
@@ -52,9 +52,11 @@ async def consultar_cnpj(cnpj: str) -> CNPJResponse:
         NotFoundError: Se o CNPJ não for encontrado na Receita Federal.
         APIError: Em caso de falha nas APIs consultadas.
     """
-    cnpj_normalizado = normalizar_cnpj(cnpj)
-    if not validate_cnpj_qualquer(cnpj_normalizado):
+    # Valida o valor bruto (aceita só a máscara padrão; espaços e outros
+    # caracteres são rejeitados) e normaliza somente depois de aceito.
+    if not validate_cnpj_qualquer(cnpj):
         raise _CNPJValidationError(field="cnpj", value=cnpj, reason=_INVALID_CNPJ_REASON)
+    cnpj_normalizado = normalizar_cnpj(cnpj)
 
     cnpj_formatado = format_cnpj(cnpj_normalizado)
     logger.info("cnpj_lookup_requested", cnpj=cnpj_formatado)

--- a/src/mcp_fiscal_brasil/empresa/_tools.py
+++ b/src/mcp_fiscal_brasil/empresa/_tools.py
@@ -31,7 +31,8 @@ def register(app: Any) -> None:
         cadastro de fornecedores e analise de regime tributario.
 
         Args:
-            cnpj: Numero do CNPJ com 14 digitos, com ou sem formatacao
+            cnpj: Numero do CNPJ com 14 caracteres (numerico ou alfanumerico,
+                IN RFB 2.229/2024), com ou sem formatacao
                 (ex: '11.222.333/0001-81' ou '11222333000181').
 
         Returns:

--- a/src/mcp_fiscal_brasil/mei/_tools.py
+++ b/src/mcp_fiscal_brasil/mei/_tools.py
@@ -30,17 +30,13 @@ def register(app: Any) -> None:
         datas de opcao e exclusao quando disponiveis.
 
         Args:
-            cnpj: Numero do CNPJ com 14 digitos, com ou sem formatacao
-                (ex: '11.222.333/0001-81' ou '11222333000181').
+            cnpj: Numero do CNPJ com 14 caracteres (numerico ou alfanumerico,
+                IN RFB 2.229/2024), com ou sem formatacao
+                (ex: '11.222.333/0001-81', '11222333000181' ou '12ABC34501DE35').
 
         Returns:
             dict com 'cnpj', 'mei' (bool), 'simples_nacional' (bool),
             'data_opcao_mei' e 'data_exclusao_mei' (quando disponiveis).
         """
-        cnpj_digits = "".join(c for c in cnpj if c.isdigit())
-        if len(cnpj_digits) != 14:
-            raise ValueError(
-                f"CNPJ inválido: '{cnpj}'. Informe 14 dígitos numéricos (ex: '11.222.333/0001-81' ou '11222333000181')."
-            )
-        result = await consultar_status_mei(cnpj_digits)
+        result = await consultar_status_mei(cnpj)
         return result.model_dump(mode="json", exclude_none=True)

--- a/src/mcp_fiscal_brasil/mei/client.py
+++ b/src/mcp_fiscal_brasil/mei/client.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from mcp_fiscal_brasil._core import FiscalNotFoundError, HTTPClient, get_logger, settings
 from mcp_fiscal_brasil._core.errors import FiscalHTTPError
+from mcp_fiscal_brasil.shared.validators import normalizar_cnpj
 
 from .schemas import MEIStatus
 
@@ -31,7 +32,7 @@ class MEIClient:
     async def get_mei_status(self, cnpj: str) -> MEIStatus:
         """Consulta o status MEI de um CNPJ."""
         logger.info("mei_status_started", cnpj=cnpj)
-        cnpj_clean = "".join(c for c in cnpj if c.isdigit())
+        cnpj_clean = normalizar_cnpj(cnpj)
         async with self._http_client() as client:
             try:
                 data = await client.get(f"/simples/v1/{cnpj_clean}")

--- a/src/mcp_fiscal_brasil/nfe/__init__.py
+++ b/src/mcp_fiscal_brasil/nfe/__init__.py
@@ -1,11 +1,12 @@
 """Modulo NFe: consulta, validação de chave e status SEFAZ."""
 
 from .schemas import NFeResponse, StatusSEFAZResponse
-from .tools import consultar_nfe, consultar_status_sefaz, validar_chave_nfe
+from .tools import consultar_nfce, consultar_nfe, consultar_status_sefaz, validar_chave_nfe
 
 __all__ = [
     "NFeResponse",
     "StatusSEFAZResponse",
+    "consultar_nfce",
     "consultar_nfe",
     "consultar_status_sefaz",
     "validar_chave_nfe",

--- a/src/mcp_fiscal_brasil/nfe/client.py
+++ b/src/mcp_fiscal_brasil/nfe/client.py
@@ -21,6 +21,7 @@ from mcp_fiscal_brasil._core import (
 
 from ..shared import cpfcnpj as cpfcnpj_provider
 from ..shared.constants import CODIGO_UF
+from ..shared.validators import normalizar_cnpj
 from .schemas import EnderecoNFe, NFeResponse, StatusSEFAZResponse, TotaisNFe
 from .status_sefaz import consultar_status_real
 from .xml_parser import parse_nfe_xml
@@ -288,13 +289,20 @@ class NFEClient:
             somente = "".join(c for c in str(valor) if c.isdigit())
             return somente or None
 
+        def _cnpj(valor: Any) -> str | None:
+            # CNPJ pode ser alfanumerico (IN RFB 2.229/2024): remove so a mascara
+            # e preserva as letras. CPF segue numerico.
+            if not valor:
+                return None
+            return normalizar_cnpj(str(valor)) or None
+
         return EnderecoNFe(
             logradouro=raw.get("endereco"),
             bairro=raw.get("bairroDistrito"),
             municipio=raw.get("municipio"),
             uf=raw.get("uf"),
             cep=raw.get("cep"),
-            cnpj=_digitos(raw.get("cnpj")),
+            cnpj=_cnpj(raw.get("cnpj")),
             cpf=_digitos(raw.get("cpf")),
             ie=raw.get("inscricaoEstadual"),
             nome=raw.get("nomeRazaoSocial"),

--- a/src/mcp_fiscal_brasil/nfe/client.py
+++ b/src/mcp_fiscal_brasil/nfe/client.py
@@ -1,5 +1,13 @@
-"""NFe lookup client backed by BrasilAPI and the National NFe Portal."""
+"""NFe lookup client backed by BrasilAPI and the National NFe Portal.
 
+Quando o provedor premium opcional cpfcnpj.com.br esta configurado (token via
+``CPFCNPJ_TOKEN``), ele e tentado primeiro na consulta por chave, cobrindo NF-e
+(modelo 55, pacote 100) e NFC-e (modelo 65, pacote 102) com dados oficiais em
+tempo real. As fontes gratuitas seguem como fallback. Sem token, o comportamento
+e identico ao anterior.
+"""
+
+from datetime import datetime
 from typing import Any, cast
 
 from mcp_fiscal_brasil._core import (
@@ -10,12 +18,43 @@ from mcp_fiscal_brasil._core import (
     settings,
 )
 
+from ..shared import cpfcnpj as cpfcnpj_provider
 from ..shared.constants import CODIGO_UF
-from .schemas import NFeResponse, StatusSEFAZResponse
+from .schemas import EnderecoNFe, NFeResponse, StatusSEFAZResponse, TotaisNFe
 from .status_sefaz import consultar_status_real
 from .xml_parser import parse_nfe_xml
 
 logger = get_logger(__name__)
+
+
+def _parse_datetime_br(valor: str | None) -> datetime | None:
+    """Converte data/hora em formato brasileiro ou ISO em datetime; None se invalido."""
+    if not valor:
+        return None
+    texto = valor.strip()
+    for formato in ("%d/%m/%Y %H:%M:%S", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(texto, formato)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(texto)
+    except ValueError:
+        return None
+
+
+def _parse_valor_br(valor: str | None) -> float | None:
+    """Converte um valor monetario no formato brasileiro (1.234,56) em float."""
+    if valor is None:
+        return None
+    texto = str(valor).strip()
+    if not texto:
+        return None
+    try:
+        return float(texto.replace(".", "").replace(",", "."))
+    except ValueError:
+        return None
+
 
 # National NFe Portal public lookup endpoint, no certificate required.
 PORTAL_NFE_BASE = "https://www.nfe.fazenda.gov.br/portal"
@@ -74,11 +113,25 @@ class NFEClient:
         Look up NFe data by its 44 digit access key.
 
         Fallback chain:
+          0. cpfcnpj.com.br premium provider, only when a token is configured
           1. BrasilAPI, with partial state coverage
           2. National NFe Portal, public lookup without authentication
           3. Partial fields extracted from the access key itself
         """
         logger.info("nfe_lookup_started", chave_prefix=chave[:10])
+
+        if cpfcnpj_provider.provedor_configurado():
+            try:
+                resultado = await self._consultar_cpfcnpj(chave)
+                logger.info("nfe_lookup_cpfcnpj_success", chave_prefix=chave[:10])
+                return resultado
+            except Exception as exc:
+                logger.warning(
+                    "nfe_lookup_cpfcnpj_failed",
+                    chave_prefix=chave[:10],
+                    error=str(exc),
+                    fallback="brasilapi",
+                )
 
         try:
             resultado = await self._consultar_brasil_api(chave)
@@ -140,6 +193,105 @@ class NFEClient:
             serie=str(data.get("serie", "")),
             situacao=data.get("situacao"),
         )
+
+    def _pacote_cpfcnpj(self, chave: str) -> int | None:
+        """Escolhe o pacote da cpfcnpj.com.br pelo modelo embutido na chave.
+
+        Modelo 55 (NF-e) usa o pacote 100; modelo 65 (NFC-e) usa o pacote 102.
+        Outros modelos nao sao cobertos e retornam None, pulando o provedor premium.
+        """
+        modelo = chave[20:22] if len(chave) >= 22 else ""
+        if modelo == "55":
+            return cpfcnpj_provider.PACOTE_NFE
+        if modelo == "65":
+            return cpfcnpj_provider.PACOTE_NFCE
+        return None
+
+    async def _consultar_cpfcnpj(self, chave: str) -> NFeResponse:
+        """Consulta NF-e (pacote 100) ou NFC-e (pacote 102) na cpfcnpj.com.br."""
+        pacote = self._pacote_cpfcnpj(chave)
+        if pacote is None:
+            raise FiscalHTTPError(
+                "Modelo de documento nao suportado pelo provedor cpfcnpj.com.br.",
+                status_code=0,
+                url=settings.cpfcnpj_base_url,
+            )
+        data = await cpfcnpj_provider.consultar(pacote, chave)
+        return self._parse_cpfcnpj(data, chave)
+
+    def _parse_cpfcnpj(self, data: dict[str, Any], chave: str) -> NFeResponse:
+        """Transforma a resposta de NF-e/NFC-e da cpfcnpj.com.br em NFeResponse."""
+        dados_nfe = ((data.get("nfe") or {}).get("dadosDaNfe")) or {}
+        emissao = ((data.get("nfe") or {}).get("emissao")) or {}
+        situacao_atual = data.get("situacaoAtual") or {}
+        dados_gerais = data.get("dadosGerais") or {}
+
+        emitente = self._endereco_nfe(data.get("emitente"))
+        destinatario = self._endereco_nfe(data.get("destinatario"))
+
+        protocolo = None
+        data_autorizacao = None
+        for evento in data.get("eventosNfe") or []:
+            if "autoriza" in str(evento.get("evento", "")).lower():
+                protocolo = evento.get("protocolo")
+                data_autorizacao = _parse_datetime_br(evento.get("dataAutorizacao"))
+                break
+
+        valor_nota = _parse_valor_br(dados_nfe.get("valorTotalDaNotaFiscal"))
+        totais = TotaisNFe(valor_nota=valor_nota) if valor_nota is not None else None
+
+        numero = dados_nfe.get("numero") or dados_gerais.get("numero")
+
+        return NFeResponse(
+            chave_acesso=chave,
+            número=str(numero) if numero else None,
+            serie=str(dados_nfe["serie"]) if dados_nfe.get("serie") else None,
+            modelo=str(dados_nfe.get("modelo") or chave[20:22] or "55"),
+            emitente=emitente,
+            destinatario=destinatario,
+            data_emissao=_parse_datetime_br(dados_nfe.get("dataDeEmissao")),
+            data_saida_entrada=_parse_datetime_br(dados_nfe.get("dataHoraDeSaidaOuDaEntrada")),
+            natureza_operacao=emissao.get("naturezaDaOperacao"),
+            tipo_operacao=emissao.get("tipoDaOperacao"),
+            finalidade=emissao.get("finalidade"),
+            totais=totais,
+            protocolo_autorizacao=protocolo,
+            data_autorizacao=data_autorizacao,
+            situacao=situacao_atual.get("situacao"),
+            informacoes_adicionais=self._info_ambiente(situacao_atual),
+        )
+
+    @staticmethod
+    def _endereco_nfe(raw: dict[str, Any] | None) -> EnderecoNFe | None:
+        """Monta um EnderecoNFe a partir do bloco emitente/destinatario da cpfcnpj.com.br."""
+        if not raw:
+            return None
+
+        def _digitos(valor: Any) -> str | None:
+            if not valor:
+                return None
+            somente = "".join(c for c in str(valor) if c.isdigit())
+            return somente or None
+
+        return EnderecoNFe(
+            logradouro=raw.get("endereco"),
+            bairro=raw.get("bairroDistrito"),
+            municipio=raw.get("municipio"),
+            uf=raw.get("uf"),
+            cep=raw.get("cep"),
+            cnpj=_digitos(raw.get("cnpj")),
+            cpf=_digitos(raw.get("cpf")),
+            ie=raw.get("inscricaoEstadual"),
+            nome=raw.get("nomeRazaoSocial"),
+        )
+
+    @staticmethod
+    def _info_ambiente(situacao_atual: dict[str, Any]) -> str | None:
+        """Descreve o ambiente de autorizacao quando informado."""
+        ambiente = situacao_atual.get("ambienteAutorizacao")
+        if ambiente:
+            return f"Ambiente de autorização: {ambiente}."
+        return None
 
     async def _consultar_portal_nfe(self, chave: str) -> NFeResponse:
         """

--- a/src/mcp_fiscal_brasil/nfe/client.py
+++ b/src/mcp_fiscal_brasil/nfe/client.py
@@ -7,6 +7,7 @@ tempo real. As fontes gratuitas seguem como fallback. Sem token, o comportamento
 e identico ao anterior.
 """
 
+import re
 from datetime import datetime
 from typing import Any, cast
 
@@ -44,14 +45,28 @@ def _parse_datetime_br(valor: str | None) -> datetime | None:
 
 
 def _parse_valor_br(valor: str | None) -> float | None:
-    """Converte um valor monetario no formato brasileiro (1.234,56) em float."""
+    """Converte um valor monetario em float.
+
+    Aceita o formato brasileiro (``1.234,56``) e o formato decimal com ponto
+    (``1234.56``), este ultimo comum no ``valorTotalDaNotaFiscal`` dos pacotes
+    100/102 da cpfcnpj.com.br. Regra: havendo virgula, ela e o separador decimal
+    e o ponto e separador de milhar; sem virgula, um unico ponto seguido de 1 ou
+    2 digitos e tratado como decimal, e qualquer outra ocorrencia de ponto e
+    tratada como separador de milhar.
+    """
     if valor is None:
         return None
     texto = str(valor).strip()
     if not texto:
         return None
+    if "," in texto:
+        normalizado = texto.replace(".", "").replace(",", ".")
+    elif re.fullmatch(r"-?\d+\.\d{1,2}", texto):
+        normalizado = texto
+    else:
+        normalizado = texto.replace(".", "")
     try:
-        return float(texto.replace(".", "").replace(",", "."))
+        return float(normalizado)
     except ValueError:
         return None
 

--- a/src/mcp_fiscal_brasil/nfe/tools.py
+++ b/src/mcp_fiscal_brasil/nfe/tools.py
@@ -112,6 +112,21 @@ async def consultar_nfce(chave_acesso: str) -> NFeResponse:
             ),
         )
 
+    # As posicoes 21-22 da chave (indice 20:22) carregam o modelo do documento.
+    # A NFC-e e o modelo 65; uma chave de modelo 55 (NF-e) passa na validacao de
+    # digito verificador, mas nao deve ser consultada aqui, senao o provedor
+    # escolheria o pacote 100 e devolveria uma NF-e onde se prometeu NFC-e.
+    modelo = chave_limpa[20:22]
+    if modelo != "65":
+        raise NFeValidationError(
+            field="chave_acesso",
+            value=chave_acesso,
+            reason=(
+                f"Chave de modelo {modelo}, esperado modelo 65 (NFC-e). "
+                "Para NF-e (modelo 55) use consultar_nfe."
+            ),
+        )
+
     return await _client.consultar_por_chave(chave_limpa)
 
 

--- a/src/mcp_fiscal_brasil/nfe/tools.py
+++ b/src/mcp_fiscal_brasil/nfe/tools.py
@@ -83,6 +83,38 @@ async def consultar_nfe(chave_acesso: str) -> NFeResponse:
     return await _client.consultar_por_chave(chave_limpa)
 
 
+async def consultar_nfce(chave_acesso: str) -> NFeResponse:
+    """
+    Look up NFC-e (Nota Fiscal de Consumidor Eletronica, modelo 65) data by access key.
+
+    A NFC-e e a nota do varejo ao consumidor final. A cobertura completa depende do
+    provedor premium opcional cpfcnpj.com.br (pacote 102), habilitado por token.
+
+    Args:
+        chave_acesso: 44 digit NFC-e access key, accepted with or without spaces.
+
+    Returns:
+        NFeResponse with issuer, recipient and totals (layout compartilhado com a NF-e).
+
+    Raises:
+        FiscalValidationError: If the access key is invalid.
+        FiscalHTTPError: If the upstream provider fails.
+    """
+    chave_limpa = "".join(c for c in chave_acesso if c.isdigit())
+
+    if not validate_chave_nfe(chave_limpa):
+        raise NFeValidationError(
+            field="chave_acesso",
+            value=chave_acesso,
+            reason=(
+                "Chave de acesso NFC-e inválida. "
+                "Deve ter 44 dígitos com dígito verificador correto."
+            ),
+        )
+
+    return await _client.consultar_por_chave(chave_limpa)
+
+
 async def validar_chave_nfe(chave_acesso: str) -> dict[str, object]:
     """
     Validate the format and check digit of an NFe access key.

--- a/src/mcp_fiscal_brasil/sdk.py
+++ b/src/mcp_fiscal_brasil/sdk.py
@@ -96,8 +96,11 @@ class FiscalBrasil:
         """
         Consulta os dados de um CNPJ na Receita Federal.
 
-        Tenta BrasilAPI primeiro; em caso de falha, usa ReceitaWS como
-        fallback automático.
+        Ordem das fontes: com ``CPFCNPJ_TOKEN`` configurado, tenta primeiro o
+        provedor premium cpfcnpj.com.br; depois a BrasilAPI e, por fim, a
+        ReceitaWS. Sem token, começa direto na BrasilAPI. A ReceitaWS só entra
+        como fallback para CNPJ numérico: para CNPJ alfanumérico a cadeia termina
+        na BrasilAPI.
 
         Args:
             cnpj: CNPJ numérico ou alfanumérico (IN RFB 2.229/2024), com ou sem

--- a/src/mcp_fiscal_brasil/sdk.py
+++ b/src/mcp_fiscal_brasil/sdk.py
@@ -37,7 +37,7 @@ from .cnpj.client import CNPJClient
 from .cnpj.schemas import CNPJResponse
 from .nfe.client import NFEClient
 from .nfe.schemas import NFeResponse, StatusSEFAZResponse
-from .shared.validators import validate_chave_nfe, validate_cnpj, validate_cpf
+from .shared.validators import validate_chave_nfe, validate_cnpj_qualquer, validate_cpf
 from .simples.client import SimplesClient
 from .simples.schemas import SimplesStatus
 
@@ -100,7 +100,8 @@ class FiscalBrasil:
         fallback automático.
 
         Args:
-            cnpj: CNPJ com ou sem máscara (ex: "33.000.167/0001-01" ou "33000167000101").
+            cnpj: CNPJ numérico ou alfanumérico (IN RFB 2.229/2024), com ou sem
+                máscara (ex: "33.000.167/0001-01", "33000167000101" ou "12ABC34501DE35").
 
         Returns:
             CNPJResponse com razão social, endereço, CNAE, QSA e mais.
@@ -113,7 +114,7 @@ class FiscalBrasil:
             empresa = await fiscal.consultar_cnpj("33.000.167/0001-01")
             print(empresa.razao_social)  # "PETROLEO BRASILEIRO S A PETROBRAS"
         """
-        if not validate_cnpj(cnpj):
+        if not validate_cnpj_qualquer(cnpj):
             raise ValueError(f"CNPJ inválido: {cnpj}")
         return await self._cnpj_client.consultar(cnpj)
 
@@ -131,7 +132,7 @@ class FiscalBrasil:
             fiscal.validar_cnpj("33.000.167/0001-01")  # True
             fiscal.validar_cnpj("11.111.111/1111-11")  # False
         """
-        return validate_cnpj(cnpj)
+        return validate_cnpj_qualquer(cnpj)
 
     # ------------------------------------------------------------------
     # CPF
@@ -275,7 +276,7 @@ class FiscalBrasil:
             print(simples.simples_nacional)  # False (Petrobras não é optante)
             print(simples.mei)      # False
         """
-        if not validate_cnpj(cnpj):
+        if not validate_cnpj_qualquer(cnpj):
             raise ValueError(f"CNPJ inválido: {cnpj}")
         return await self._simples_client.get_simples_status(cnpj)
 

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -44,7 +44,12 @@ from .nfe.distribuicao import (
     manifestar_nfe,
 )
 from .nfe.documento import parse_nfe_documento
-from .nfe.tools import consultar_nfe, consultar_status_sefaz, validar_chave_nfe
+from .nfe.tools import (
+    consultar_nfce,
+    consultar_nfe,
+    consultar_status_sefaz,
+    validar_chave_nfe,
+)
 from .nfse.tools import consultar_nfse
 from .shared.validators import normalizar_cnpj, validate_cnpj_qualquer
 from .simples.tools import consultar_simples_nacional
@@ -220,6 +225,31 @@ async def tool_consultar_nfe(chave_acesso: str) -> dict[str, Any]:
         dict com emitente, destinatario, itens, totais e protocolo da nota.
     """
     resultado = await consultar_nfe(chave_acesso)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="consultar_nfce",
+    description=(
+        "Consulta os dados de uma Nota Fiscal de Consumidor Eletrônica (NFC-e, modelo 65) "
+        "pela chave de acesso de 44 dígitos. A NFC-e é a nota do varejo ao consumidor final. "
+        "A cobertura completa depende do provedor premium opcional cpfcnpj.com.br (pacote 102), "
+        "habilitado por token; sem token, use a NF-e (modelo 55) em consultar_nfe."
+    ),
+)
+async def tool_consultar_nfce(chave_acesso: str) -> dict[str, Any]:
+    """Consulta uma NFC-e (Nota Fiscal de Consumidor Eletronica, modelo 65) pela chave de acesso.
+
+    Recupera emitente, destinatario e totais no mesmo layout da NF-e. A cobertura depende do
+    provedor premium opcional cpfcnpj.com.br (pacote 102), habilitado por token.
+
+    Args:
+        chave_acesso: Chave de acesso da NFC-e com 44 digitos (aceita com ou sem espacos).
+
+    Returns:
+        dict com emitente, destinatario, totais e protocolo da nota.
+    """
+    resultado = await consultar_nfce(chave_acesso)
     return resultado.model_dump(mode="json", exclude_none=True)
 
 

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -120,7 +120,8 @@ async def health(_request: Request) -> JSONResponse:
         "Consulta os dados cadastrais completos de uma empresa pelo CNPJ. "
         "Retorna razão social, endereço, atividades econômicas (CNAE), "
         "sócios (QSA), situação cadastral e porte da empresa. "
-        "Aceita CNPJ com ou sem formatação (pontos, barra, traço)."
+        "Aceita CNPJ numérico ou alfanumérico (IN RFB 2.229/2024), "
+        "com ou sem formatação (pontos, barra, traço)."
     ),
 )
 async def tool_consultar_cnpj(cnpj: str) -> dict[str, Any]:
@@ -132,7 +133,8 @@ async def tool_consultar_cnpj(cnpj: str) -> dict[str, Any]:
     Util para identificar empresas, validar fornecedores/clientes e preencher dados fiscais.
 
     Args:
-        cnpj: Numero do CNPJ com 14 digitos, com ou sem formatacao
+        cnpj: Numero do CNPJ com 14 caracteres (numerico ou alfanumerico, IN RFB 2.229/2024),
+            com ou sem formatacao
             (ex.: "11.222.333/0001-81" ou "11222333000181").
 
     Returns:
@@ -644,7 +646,7 @@ async def tool_consultar_simples_nacional(cnpj: str) -> dict[str, Any]:
     Util para definir o regime tributario antes de calcular impostos ou tributar notas fiscais.
 
     Args:
-        cnpj: Numero do CNPJ com 14 digitos, com ou sem formatacao.
+        cnpj: Numero do CNPJ com 14 caracteres (numerico ou alfanumerico, IN RFB 2.229/2024), com ou sem formatacao.
 
     Returns:
         dict com a situacao no Simples Nacional e no MEI e respectivas datas.
@@ -832,7 +834,7 @@ async def tool_analyze_cnpj_compliance(cnpj: str) -> dict[str, Any]:
     um relatorio com score 0-100, classificacao de risco e achados acionaveis.
 
     Args:
-        cnpj: Numero do CNPJ com 14 digitos, com ou sem formatacao.
+        cnpj: Numero do CNPJ com 14 caracteres (numerico ou alfanumerico, IN RFB 2.229/2024), com ou sem formatacao.
 
     Returns:
         dict com score, risco, situacao, regime, cnae e lista de achados.
@@ -999,7 +1001,7 @@ async def tool_risk_score_supplier(cnpj: str, criterios_estritos: bool = False) 
     politicas anti-corrupcao (ex: Lei 12.846/2013).
 
     Args:
-        cnpj: Numero do CNPJ com 14 digitos, com ou sem formatacao.
+        cnpj: Numero do CNPJ com 14 caracteres (numerico ou alfanumerico, IN RFB 2.229/2024), com ou sem formatacao.
         criterios_estritos: Se True, aplica pesos mais rigorosos. Padrao: False.
 
     Returns:

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -62,6 +62,19 @@ logger = logging.getLogger(__name__)
 MAX_CNPJS_POR_LOTE = 50
 
 
+def _validar_cnpj_ou_erro(cnpj: str) -> None:
+    """Rejeita CNPJ com dígito verificador inválido antes de qualquer consulta externa.
+
+    Evita que as tools agenticas disparem consultas (Receita, Simples, MEI) para
+    um valor que nunca poderia existir.
+    """
+    if not validate_cnpj_qualquer(cnpj):
+        raise ValueError(
+            f"CNPJ inválido: {cnpj}. Verifique o formato e o dígito verificador "
+            "(numérico ou alfanumérico, com ou sem máscara)."
+        )
+
+
 def _normalizar_e_validar_cnpjs(cnpjs: list[str]) -> list[str]:
     if len(cnpjs) > MAX_CNPJS_POR_LOTE:
         raise ValueError(
@@ -839,6 +852,7 @@ async def tool_analyze_cnpj_compliance(cnpj: str) -> dict[str, Any]:
     Returns:
         dict com score, risco, situacao, regime, cnae e lista de achados.
     """
+    _validar_cnpj_ou_erro(cnpj)
     resultado = await analyze_cnpj_compliance(cnpj)
     return resultado.model_dump(mode="json", exclude_none=True)
 
@@ -1007,6 +1021,7 @@ async def tool_risk_score_supplier(cnpj: str, criterios_estritos: bool = False) 
     Returns:
         dict com score, recomendacao e justificativa da classificacao.
     """
+    _validar_cnpj_ou_erro(cnpj)
     resultado = await risk_score_supplier(cnpj, criterios_estritos)
     return resultado.model_dump(mode="json", exclude_none=True)
 

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -1,0 +1,90 @@
+"""Transporte do provedor premium opcional cpfcnpj.com.br.
+
+Este modulo concentra a comunicacao HTTP com a API da cpfcnpj.com.br, usada de
+forma opcional pelos clientes de CNPJ e de NF-e/NFC-e. O provedor so entra em
+acao quando um token e configurado via ``CPFCNPJ_TOKEN``; sem token, os clientes
+seguem usando exclusivamente as fontes gratuitas padrao.
+
+Formato da chamada: ``GET {base}/{token}/{pacote}/{documento}``. A resposta traz
+``status`` igual a 1 em caso de sucesso e igual a 0 em caso de erro, acompanhada
+dos campos ``erro`` e ``erroCodigo``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_fiscal_brasil._core import (
+    FiscalHTTPError,
+    HTTPClient,
+    get_logger,
+    settings,
+)
+
+logger = get_logger(__name__)
+
+# Pacotes de consulta na cpfcnpj.com.br.
+PACOTE_NFE = 100
+PACOTE_NFCE = 102
+
+
+def provedor_configurado() -> bool:
+    """Indica se o provedor premium cpfcnpj.com.br esta habilitado (token definido)."""
+    return bool(settings.cpfcnpj_token.strip())
+
+
+def _http_client() -> HTTPClient:
+    return HTTPClient(
+        settings.cpfcnpj_base_url,
+        timeout=settings.mcp_fiscal_http_timeout,
+        max_retries=settings.mcp_fiscal_max_retries,
+        cache_ttl=settings.mcp_fiscal_cache_ttl,
+        rate_limit_per_second=settings.mcp_fiscal_rate_limit,
+    )
+
+
+async def consultar(pacote: int, documento: str) -> dict[str, Any]:
+    """Consulta um documento na cpfcnpj.com.br e retorna o corpo JSON de sucesso.
+
+    Args:
+        pacote: Identificador do pacote de consulta (ex.: 6 para CNPJ, 100 para NF-e).
+        documento: Documento consultado (CNPJ ou chave de acesso, apenas digitos).
+
+    Returns:
+        dict com o corpo da resposta quando ``status`` e igual a 1.
+
+    Raises:
+        FiscalHTTPError: Quando o provedor nao esta configurado ou retorna erro
+            (``status`` diferente de 1).
+    """
+    token = settings.cpfcnpj_token.strip()
+    if not token:
+        raise FiscalHTTPError(
+            "Provedor cpfcnpj.com.br nao configurado (CPFCNPJ_TOKEN ausente).",
+            status_code=0,
+            url=settings.cpfcnpj_base_url,
+        )
+
+    path = f"/{token}/{pacote}/{documento}"
+    async with _http_client() as client:
+        data = await client.get(path)
+
+    if data.get("status") != 1:
+        codigo = data.get("erroCodigo")
+        mensagem = data.get("erro") or "Consulta cpfcnpj.com.br sem sucesso."
+        raise FiscalHTTPError(
+            f"cpfcnpj.com.br retornou erro: {mensagem}",
+            status_code=int(codigo) if isinstance(codigo, int) else 0,
+            url=f"{settings.cpfcnpj_base_url}/***/{pacote}/{documento}",
+            detail={"erro": mensagem, "erroCodigo": codigo},
+        )
+
+    return data
+
+
+__all__ = [
+    "PACOTE_NFCE",
+    "PACOTE_NFE",
+    "consultar",
+    "provedor_configurado",
+]

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from aiolimiter import AsyncLimiter
+
 from mcp_fiscal_brasil._core import (
     FiscalHTTPError,
     HTTPClient,
@@ -27,6 +29,26 @@ logger = get_logger(__name__)
 PACOTE_NFE = 100
 PACOTE_NFCE = 102
 
+# Teto de requisicoes por segundo da cpfcnpj.com.br. Cada consulta abre um
+# HTTPClient novo, entao o limitador precisa ser compartilhado por todas as
+# instancias/chamadas: sem isso, consultas concorrentes (CNPJ pacotes 5/6 e
+# NF-e/NFC-e pacotes 100/102) somariam limitadores independentes e poderiam
+# ultrapassar o teto, recebendo o erro 1007 (HTTP 429).
+CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO = 20
+
+_limiter: AsyncLimiter | None = None
+
+
+def _get_limiter() -> AsyncLimiter:
+    """Retorna o limitador unico (singleton de modulo) compartilhado pela API."""
+    global _limiter
+    if _limiter is None:
+        _limiter = AsyncLimiter(
+            CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
+            CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
+        )
+    return _limiter
+
 
 def provedor_configurado() -> bool:
     """Indica se o provedor premium cpfcnpj.com.br esta habilitado (token definido)."""
@@ -39,7 +61,8 @@ def _http_client() -> HTTPClient:
         timeout=settings.mcp_fiscal_http_timeout,
         max_retries=settings.mcp_fiscal_max_retries,
         cache_ttl=settings.mcp_fiscal_cache_ttl,
-        rate_limit_per_second=settings.mcp_fiscal_rate_limit,
+        rate_limit_per_second=CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
+        limiter=_get_limiter(),
     )
 
 

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -71,7 +71,8 @@ async def consultar(pacote: int, documento: str) -> dict[str, Any]:
 
     Args:
         pacote: Identificador do pacote de consulta (ex.: 6 para CNPJ, 100 para NF-e).
-        documento: Documento consultado (CNPJ ou chave de acesso, apenas digitos).
+        documento: Documento consultado sem máscara (CNPJ numérico ou alfanumérico,
+            CPF ou chave de acesso). O provedor aceita CNPJ alfanumérico no caminho da URL.
 
     Returns:
         dict com o corpo da resposta quando ``status`` e igual a 1.

--- a/src/mcp_fiscal_brasil/shared/validators.py
+++ b/src/mcp_fiscal_brasil/shared/validators.py
@@ -286,18 +286,26 @@ def format_cpf(cpf: str, remover_mascara: bool = False) -> str:
 
 def format_cnpj(cnpj: str, remover_mascara: bool = False) -> str:
     """
-    Formata um CNPJ com ou sem mascara.
+    Formata um CNPJ (numérico ou alfanumérico) com ou sem máscara.
 
-    Se remover_mascara=True, retorna apenas os 14 digitos numericos.
-    Caso contrario, retorna no formato XX.XXX.XXX/XXXX-XX.
+    Aceita o CNPJ alfanumérico da IN RFB 2.229/2024 (vigência jul/2026): as 12
+    primeiras posições podem conter letras maiúsculas (A-Z) ou dígitos e as 2
+    últimas são dígitos verificadores. A entrada é normalizada (máscara removida,
+    letras em maiúsculas) antes de formatar.
+
+    Se remover_mascara=True, retorna apenas os 14 caracteres sem máscara.
+    Caso contrário, retorna no formato XX.XXX.XXX/XXXX-XX
+    (ex.: '11.222.333/0001-81' ou '12.ABC.345/01DE-35').
     """
-    números = _somente_digitos(cnpj)
-    if len(números) != 14:
-        raise ValueError(f"CNPJ deve ter 14 digitos, recebeu {len(números)}")
+    caracteres = normalizar_cnpj(cnpj)
+    if len(caracteres) != 14:
+        raise ValueError(f"CNPJ deve ter 14 caracteres, recebeu {len(caracteres)}")
 
     if remover_mascara:
-        return números
-    return f"{números[:2]}.{números[2:5]}.{números[5:8]}/{números[8:12]}-{números[12:]}"
+        return caracteres
+    return (
+        f"{caracteres[:2]}.{caracteres[2:5]}.{caracteres[5:8]}/{caracteres[8:12]}-{caracteres[12:]}"
+    )
 
 
 def format_chave_nfe(chave: str) -> str:

--- a/src/mcp_fiscal_brasil/simples/tools.py
+++ b/src/mcp_fiscal_brasil/simples/tools.py
@@ -1,7 +1,7 @@
 """Ferramentas MCP para Simples Nacional."""
 
 from ..shared.exceptions import ValidationError
-from ..shared.validators import validate_cnpj
+from ..shared.validators import validate_cnpj_qualquer
 from .client import SimplesClient
 from .schemas import SimplesStatus
 
@@ -23,10 +23,13 @@ async def consultar_simples_nacional(cnpj: str) -> SimplesStatus:
         NotFoundError: Se o CNPJ não for encontrado.
         APIError: Em caso de falha na API.
     """
-    if not validate_cnpj(cnpj):
+    if not validate_cnpj_qualquer(cnpj):
         raise ValidationError(
             field="cnpj",
             value=cnpj,
-            reason="CNPJ inválido. Verifique os 14 dígitos e o dígito verificador.",
+            reason=(
+                "CNPJ inválido. Verifique os 14 caracteres (numérico ou alfanumérico) "
+                "e o dígito verificador."
+            ),
         )
     return await _client.get_simples_status(cnpj)

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -454,3 +454,68 @@ async def test_risk_score_supplier_empresa_baixada_recusa() -> None:
         resultado = await risk_score_supplier("98765432000100")
     assert resultado.recomendacao == "recusar"
     assert resultado.risco == "critico"
+
+
+# ---------------------------------------------------------------------------
+# Tools MCP: CNPJ invalido e barrado antes de qualquer consulta externa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cnpj_invalido", ["123", "12345678000190", "33 000 167 0001 01"])
+async def test_tool_analyze_cnpj_compliance_rejeita_sem_consultar_clientes(
+    cnpj_invalido: str,
+) -> None:
+    with (
+        patch("mcp_fiscal_brasil.agentic.compliance.CNPJClient") as mock_cnpj_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.SimplesClient") as mock_simples_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.MEIClient") as mock_mei_class,
+    ):
+        with pytest.raises(ValueError, match="CNPJ inválido"):
+            await mcp_server.tool_analyze_cnpj_compliance(cnpj_invalido)
+
+    mock_cnpj_class.assert_not_called()
+    mock_simples_class.assert_not_called()
+    mock_mei_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cnpj_invalido", ["123", "12345678000190", "33 000 167 0001 01"])
+async def test_tool_risk_score_supplier_rejeita_sem_consultar_clientes(
+    cnpj_invalido: str,
+) -> None:
+    with (
+        patch("mcp_fiscal_brasil.agentic.compliance.CNPJClient") as mock_cnpj_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.SimplesClient") as mock_simples_class,
+        patch("mcp_fiscal_brasil.agentic.compliance.MEIClient") as mock_mei_class,
+        patch("mcp_fiscal_brasil.agentic.supplier.analyze_cnpj_compliance") as mock_compliance,
+    ):
+        with pytest.raises(ValueError, match="CNPJ inválido"):
+            await mcp_server.tool_risk_score_supplier(cnpj_invalido, criterios_estritos=True)
+
+    mock_compliance.assert_not_called()
+    mock_cnpj_class.assert_not_called()
+    mock_simples_class.assert_not_called()
+    mock_mei_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_analyze_cnpj_compliance_aceita_mascara_padrao() -> None:
+    relatorio = ComplianceReport(
+        cnpj="33000167000101",
+        razao_social="PETROLEO BRASILEIRO S A PETROBRAS",
+        situacao_cadastral="ATIVA",
+        risco_geral="baixo",
+        score=95,
+        achados=[],
+        resumo_executivo="Ok.",
+        fontes_consultadas=["BrasilAPI"],
+    )
+    with patch(
+        "mcp_fiscal_brasil.server.analyze_cnpj_compliance",
+        AsyncMock(return_value=relatorio),
+    ) as mock_tool:
+        resposta = await mcp_server.tool_analyze_cnpj_compliance("33.000.167/0001-01")
+
+    assert resposta["cnpj"] == "33000167000101"
+    mock_tool.assert_awaited_once_with("33.000.167/0001-01")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -309,3 +309,11 @@ def test_nfe_validate_xml_inline_excede_tamanho_maximo() -> None:
 def test_nfe_validate_sem_xml_e_sem_xml_path_retorna_400() -> None:
     response = client.post("/v1/nfe/validate", json={})
     assert response.status_code == 400
+
+
+def test_cnpj_lookup_rejeita_espacos_mesmo_com_digito_valido() -> None:
+    """O valor original e validado antes da normalizacao: espacos nao sao mascara."""
+    with patch("mcp_fiscal_brasil.api.consultar_cnpj", AsyncMock()) as consultar:
+        response = client.get("/v1/cnpj/33 000 167 0001 01")
+    assert response.status_code == 400
+    consultar.assert_not_called()

--- a/tests/test_cnpj_alfanumerico.py
+++ b/tests/test_cnpj_alfanumerico.py
@@ -212,3 +212,10 @@ async def test_receitaws_fallback_preservado_para_numerico(
 
     resposta = await CNPJClient().consultar(CNPJ_NUM)
     assert resposta.origem == "ReceitaWS"
+
+
+async def test_tool_rejeita_espacos_mesmo_com_digito_valido() -> None:
+    """validate_cnpj_qualquer roda sobre o valor bruto: espacos nao sao mascara aceita."""
+    with pytest.raises(ValidationError) as exc_info:
+        await consultar_cnpj("33 000 167 0001 01")
+    assert exc_info.value.field == "cnpj"

--- a/tests/test_cnpj_alfanumerico.py
+++ b/tests/test_cnpj_alfanumerico.py
@@ -1,0 +1,214 @@
+"""Suporte a CNPJ alfanumérico (IN RFB 2.229/2024) em toda a cadeia de consulta.
+
+Cobre as três entradas (ferramenta MCP, API HTTP e SDK async/sync), a rejeição
+de CNPJ alfanumérico com dígito verificador errado e o comportamento dos
+provedores públicos: a BrasilAPI atende o formato alfanumérico (proxy para o
+minha-receita, que valida com a lib go-cnpj) e a ReceitaWS, sem suporte
+documentado, é pulada quando o CNPJ contém letras.
+"""
+
+from typing import Any, ClassVar
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_fiscal_brasil._core import FiscalError, settings
+from mcp_fiscal_brasil.api import app
+from mcp_fiscal_brasil.cnpj.client import CNPJClient
+from mcp_fiscal_brasil.cnpj.schemas import CNPJResponse
+from mcp_fiscal_brasil.cnpj.tools import consultar_cnpj
+from mcp_fiscal_brasil.sdk import FiscalBrasil
+from mcp_fiscal_brasil.shared import cpfcnpj as cpfcnpj_provider
+from mcp_fiscal_brasil.shared.exceptions import ValidationError
+
+# CNPJ alfanumérico válido (exemplo oficial da IN RFB 2.229/2024) e sua máscara.
+CNPJ_ALFA = "12ABC34501DE35"
+CNPJ_ALFA_MASCARA = "12.ABC.345/01DE-35"
+CNPJ_ALFA_DV_ERRADO = "12ABC34501DE00"
+CNPJ_NUM = "00000000000191"
+CNPJ_NUM_MASCARA = "00.000.000/0001-91"
+
+CNPJ_PAYLOAD_ALFA: dict[str, Any] = {"status": 1, "cnpj": CNPJ_ALFA, "razao": "EMPRESA ALFA LTDA"}
+
+
+class _FakeHTTPClient:
+    """HTTPClient falso: registra o path chamado e devolve um corpo fixo, sem rede."""
+
+    payload: ClassVar[dict[str, Any]] = {}
+    ultimo_path: ClassVar[str | None] = None
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeHTTPClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> bool:
+        return False
+
+    async def get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        _FakeHTTPClient.ultimo_path = path
+        return _FakeHTTPClient.payload
+
+
+@pytest.fixture
+def provedor_habilitado(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Habilita o provedor premium cpfcnpj.com.br com token de teste e HTTP mockado."""
+    monkeypatch.setattr(settings, "cpfcnpj_token", "token_de_teste", raising=False)
+    monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
+    _FakeHTTPClient.payload = CNPJ_PAYLOAD_ALFA
+    _FakeHTTPClient.ultimo_path = None
+
+
+@pytest.fixture
+def provedor_desligado(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Desliga o provedor premium para exercitar somente as fontes públicas."""
+    monkeypatch.setattr(settings, "cpfcnpj_token", "", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Entrada 1: ferramenta MCP (cnpj/tools.py::consultar_cnpj)
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_alfanumerico_chega_no_provedor(provedor_habilitado: None) -> None:
+    resposta = await consultar_cnpj(CNPJ_ALFA_MASCARA)
+    assert resposta.origem == "cpfcnpj.com.br"
+    # A máscara é removida e as letras preservadas em maiúsculas no caminho da URL.
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/6/{CNPJ_ALFA}"
+
+
+async def test_tool_alfanumerico_dv_errado_rejeitado() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        await consultar_cnpj(CNPJ_ALFA_DV_ERRADO)
+    assert exc_info.value.field == "cnpj"
+
+
+async def test_tool_numerico_formatado_continua_ok(provedor_habilitado: None) -> None:
+    await consultar_cnpj(CNPJ_NUM_MASCARA)
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/6/{CNPJ_NUM}"
+
+
+# ---------------------------------------------------------------------------
+# Entrada 2: API HTTP (api.py::_validated_cnpj + /v1/cnpj/{cnpj})
+# ---------------------------------------------------------------------------
+
+
+def test_api_alfanumerico_chega_no_provedor(provedor_habilitado: None) -> None:
+    client = TestClient(app)
+    response = client.get(f"/v1/cnpj/{CNPJ_ALFA}")
+    assert response.status_code == 200
+    assert response.json()["origem"] == "cpfcnpj.com.br"
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/6/{CNPJ_ALFA}"
+
+
+def test_api_alfanumerico_dv_errado_400() -> None:
+    from unittest.mock import AsyncMock, patch
+
+    client = TestClient(app)
+    with patch("mcp_fiscal_brasil.api.consultar_cnpj", AsyncMock()) as consultar:
+        response = client.get(f"/v1/cnpj/{CNPJ_ALFA_DV_ERRADO}")
+    assert response.status_code == 400
+    consultar.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Entrada 3: SDK (sdk.py::consultar_cnpj async/sync + validar_cnpj)
+# ---------------------------------------------------------------------------
+
+
+async def test_sdk_async_alfanumerico_chega_no_provedor(provedor_habilitado: None) -> None:
+    resposta = await FiscalBrasil().consultar_cnpj(CNPJ_ALFA_MASCARA)
+    assert resposta.origem == "cpfcnpj.com.br"
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/6/{CNPJ_ALFA}"
+
+
+async def test_sdk_async_alfanumerico_dv_errado_rejeitado() -> None:
+    with pytest.raises(ValueError):
+        await FiscalBrasil().consultar_cnpj(CNPJ_ALFA_DV_ERRADO)
+
+
+def test_sdk_sync_alfanumerico_chega_no_provedor(provedor_habilitado: None) -> None:
+    resposta = FiscalBrasil().consultar_cnpj_sync(CNPJ_ALFA_MASCARA)
+    assert resposta.origem == "cpfcnpj.com.br"
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/6/{CNPJ_ALFA}"
+
+
+def test_sdk_validar_cnpj_alfanumerico() -> None:
+    fiscal = FiscalBrasil()
+    assert fiscal.validar_cnpj(CNPJ_ALFA) is True
+    assert fiscal.validar_cnpj(CNPJ_ALFA_MASCARA) is True
+    assert fiscal.validar_cnpj(CNPJ_ALFA_DV_ERRADO) is False
+    # CNPJ numérico continua válido.
+    assert fiscal.validar_cnpj(CNPJ_NUM_MASCARA) is True
+
+
+# ---------------------------------------------------------------------------
+# Comportamento dos provedores públicos (BrasilAPI vs ReceitaWS)
+# ---------------------------------------------------------------------------
+
+
+async def test_brasilapi_atende_alfanumerico(
+    provedor_desligado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recebidos: list[str] = []
+
+    async def _fake_brasil_api(self: CNPJClient, cnpj: str) -> CNPJResponse:
+        recebidos.append(cnpj)
+        return CNPJResponse(
+            cnpj=cnpj,
+            razao_social="EMPRESA BRASILAPI",
+            situacao_cadastral="ATIVA",
+            natureza_juridica="LTDA",
+            origem="BrasilAPI",
+        )
+
+    monkeypatch.setattr(CNPJClient, "_consultar_brasil_api", _fake_brasil_api)
+    resposta = await CNPJClient().consultar(CNPJ_ALFA_MASCARA)
+    assert resposta.origem == "BrasilAPI"
+    # A BrasilAPI recebe o CNPJ alfanumérico normalizado (com letras).
+    assert recebidos == [CNPJ_ALFA]
+
+
+async def test_receitaws_pulada_para_alfanumerico(
+    provedor_desligado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _brasil_api_falha(self: CNPJClient, cnpj: str) -> CNPJResponse:
+        raise FiscalError("BrasilAPI indisponível")
+
+    async def _receitaws_nao_deve_ser_chamada(self: CNPJClient, cnpj: str) -> CNPJResponse:
+        raise AssertionError("ReceitaWS não deve ser consultada para CNPJ alfanumérico")
+
+    monkeypatch.setattr(CNPJClient, "_consultar_brasil_api", _brasil_api_falha)
+    monkeypatch.setattr(CNPJClient, "_consultar_receita_ws", _receitaws_nao_deve_ser_chamada)
+
+    with pytest.raises(FiscalError) as exc_info:
+        await CNPJClient().consultar(CNPJ_ALFA)
+    assert "alfanumérico" in str(exc_info.value)
+
+
+async def test_receitaws_fallback_preservado_para_numerico(
+    provedor_desligado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _brasil_api_falha(self: CNPJClient, cnpj: str) -> CNPJResponse:
+        raise FiscalError("BrasilAPI indisponível")
+
+    async def _fake_receitaws(self: CNPJClient, cnpj: str) -> CNPJResponse:
+        return CNPJResponse(
+            cnpj=cnpj,
+            razao_social="EMPRESA RECEITAWS",
+            situacao_cadastral="ATIVA",
+            natureza_juridica="LTDA",
+            origem="ReceitaWS",
+        )
+
+    monkeypatch.setattr(CNPJClient, "_consultar_brasil_api", _brasil_api_falha)
+    monkeypatch.setattr(CNPJClient, "_consultar_receita_ws", _fake_receitaws)
+
+    resposta = await CNPJClient().consultar(CNPJ_NUM)
+    assert resposta.origem == "ReceitaWS"

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from mcp_fiscal_brasil._core.config import Settings
 
 
@@ -73,3 +75,21 @@ def test_settings_env_file_is_respected(tmp_path: Path) -> None:
     assert settings.mcp_fiscal_file_base_dir == "/tmp/fiscal-env-inputs"
     assert settings.brasilapi_base_url == "https://brasilapi.env.test"
     assert settings.receita_base_url == "https://receita.env.test"
+
+
+def test_cpfcnpj_base_url_padrao_e_https() -> None:
+    settings = Settings(_env_file=None)
+    assert settings.cpfcnpj_base_url == "https://api.cpfcnpj.com.br"
+
+
+def test_cpfcnpj_base_url_http_e_rejeitada(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # O token viaja no caminho da URL: http:// deve ser rejeitado mesmo via env.
+    monkeypatch.setenv("CPFCNPJ_BASE_URL", "http://api.cpfcnpj.com.br")
+    with pytest.raises(ValueError):
+        Settings(_env_file=None)
+
+
+def test_cpfcnpj_base_url_https_customizada_e_aceita(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("CPFCNPJ_BASE_URL", "https://proxy.interno.example/cpfcnpj")
+    settings = Settings(_env_file=None)
+    assert settings.cpfcnpj_base_url == "https://proxy.interno.example/cpfcnpj"

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -82,14 +82,14 @@ def test_cpfcnpj_base_url_padrao_e_https() -> None:
     assert settings.cpfcnpj_base_url == "https://api.cpfcnpj.com.br"
 
 
-def test_cpfcnpj_base_url_http_e_rejeitada(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_cpfcnpj_base_url_http_e_rejeitada(monkeypatch: pytest.MonkeyPatch) -> None:
     # O token viaja no caminho da URL: http:// deve ser rejeitado mesmo via env.
     monkeypatch.setenv("CPFCNPJ_BASE_URL", "http://api.cpfcnpj.com.br")
     with pytest.raises(ValueError):
         Settings(_env_file=None)
 
 
-def test_cpfcnpj_base_url_https_customizada_e_aceita(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_cpfcnpj_base_url_https_customizada_e_aceita(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CPFCNPJ_BASE_URL", "https://proxy.interno.example/cpfcnpj")
     settings = Settings(_env_file=None)
     assert settings.cpfcnpj_base_url == "https://proxy.interno.example/cpfcnpj"

--- a/tests/test_core_http.py
+++ b/tests/test_core_http.py
@@ -183,3 +183,40 @@ async def test_get_raises_fiscal_error_on_timeout(
         await client.get("/slow")
 
     assert exc_info.value.status_code is None
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_acquired_on_every_retry_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cada tentativa (inclusive retries) passa pelo limitador compartilhado."""
+    calls = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(503, json={"erro": "instável"})
+        return httpx.Response(200, json={"ok": True})
+
+    class _CountingLimiter:
+        def __init__(self) -> None:
+            self.acquired = 0
+
+        async def acquire(self, amount: float = 1) -> None:
+            self.acquired += 1
+
+    patch_async_client(monkeypatch, handler)
+    limiter = _CountingLimiter()
+    client = HTTPClient(
+        "https://example.test",
+        max_retries=2,
+        cache_ttl=0,
+        limiter=limiter,  # type: ignore[arg-type]
+    )
+
+    payload = await client.get("/flaky")
+
+    assert payload == {"ok": True}
+    assert calls == 2
+    assert limiter.acquired == 2

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -1,0 +1,256 @@
+"""Testes do provedor premium opcional cpfcnpj.com.br.
+
+Cobrem o transporte (status de sucesso/erro e ausencia de token), o mapeamento
+das respostas de CNPJ (pacote 6) e de NF-e/NFC-e por chave (pacotes 100/102) e a
+garantia de que, sem token configurado, o comportamento gratuito padrao nao muda.
+"""
+
+from typing import Any, ClassVar
+
+import pytest
+
+from mcp_fiscal_brasil._core import FiscalHTTPError, settings
+from mcp_fiscal_brasil.cnpj.client import CNPJClient
+from mcp_fiscal_brasil.nfe.client import NFEClient
+from mcp_fiscal_brasil.shared import cpfcnpj as cpfcnpj_provider
+
+# Amostras fieis ao contrato publicado em https://www.cpfcnpj.com.br/dev/openapi.json
+
+CNPJ_6_SAMPLE: dict[str, Any] = {
+    "status": 1,
+    "cnpj": "00000000000191",
+    "razao": "BANCO EXEMPLO SA",
+    "fantasia": "BANCO EXEMPLO",
+    "capitalSocial": 120000000000.0,
+    "inicioAtividade": "1966-08-01",
+    "email": "contato@exemplo.com.br",
+    "naturezaJuridica": {"codigo": "2038", "descricao": "Sociedade de Economia Mista"},
+    "simplesNacional": {"optante": "Não", "mei": "Não"},
+    "matrizEndereco": {
+        "cep": "70073901",
+        "logradouro": "Setor Bancario Sul",
+        "numero": "S/N",
+        "complemento": "Edificio Sede",
+        "bairro": "Asa Sul",
+        "cidade": "Brasilia",
+        "uf": "DF",
+    },
+    "telefones": [{"ddd": "61", "numero": "31070001"}],
+    "situacao": {"id": 2, "nome": "Ativa", "data": "2005-11-03", "motivo": None},
+    "cnae": {
+        "fiscal": "6422100",
+        "descricao": "Bancos multiplos com carteira comercial",
+        "secundarias": [
+            {"id": "6491300", "subclasse": "6491300", "descricao": "Sociedades de fomento"}
+        ],
+    },
+    "porte": {"id": "05", "descricao": "Demais"},
+    "socios": [
+        {
+            "cpf_cnpj_socio": "***000000**",
+            "nome": "FULANO DE TAL",
+            "qualificacao_socio": {"id": 10, "descricao": "Diretor"},
+            "faixa_etaria": "51 a 60",
+            "nome_representante": None,
+            "qualificacao_representante": None,
+        }
+    ],
+    "pacoteUsado": 6,
+    "saldo": 999,
+}
+
+NFE_100_SAMPLE: dict[str, Any] = {
+    "status": 1,
+    "chave": "35170608530528000184550000000154301000771561",
+    "dadosGerais": {"numero": "000.000.071", "versaoXml": "4.00"},
+    "nfe": {
+        "dadosDaNfe": {
+            "modelo": "55",
+            "serie": "1",
+            "numero": "71",
+            "dataDeEmissao": "01/01/2025 10:00:00",
+            "dataHoraDeSaidaOuDaEntrada": "01/01/2025 12:00:00",
+            "valorTotalDaNotaFiscal": "1.234,56",
+        },
+        "emissao": {
+            "naturezaDaOperacao": "Venda de mercadoria",
+            "finalidade": "NF-e normal",
+            "tipoDaOperacao": "Saída",
+        },
+    },
+    "situacaoAtual": {"situacao": "Autorizada", "ambienteAutorizacao": "Produção"},
+    "eventosNfe": [
+        {
+            "evento": "Autorização de Uso",
+            "protocolo": "135250000000071",
+            "dataAutorizacao": "2025-01-01T10:00:05-03:00",
+        }
+    ],
+    "emitente": {
+        "nomeRazaoSocial": "Empresa Emitente Ltda",
+        "cnpj": "00.000.000/0001-91",
+        "endereco": "Rua A, 100",
+        "bairroDistrito": "Centro",
+        "cep": "00000-111",
+        "municipio": "Sao Paulo",
+        "uf": "SP",
+        "inscricaoEstadual": "000000000000",
+    },
+    "destinatario": {
+        "nomeRazaoSocial": "Cliente Final",
+        "cpf": "000.000.000-00",
+        "endereco": "Rua B, 200",
+        "municipio": "Sao Paulo",
+        "uf": "SP",
+    },
+    "pacoteUsado": 100,
+    "saldo": 998,
+}
+
+NFCE_102_CHAVE = "35200114200166000187650010000000091000000097"
+
+
+class _FakeHTTPClient:
+    """HTTPClient falso para testes: devolve um corpo pre-definido, sem rede."""
+
+    payload: ClassVar[dict[str, Any]] = {}
+    ultimo_path: ClassVar[str | None] = None
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeHTTPClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> bool:
+        return False
+
+    async def get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        _FakeHTTPClient.ultimo_path = path
+        return _FakeHTTPClient.payload
+
+
+@pytest.fixture
+def provedor_habilitado(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Habilita o provedor premium com token de teste e HTTP mockado."""
+    monkeypatch.setattr(settings, "cpfcnpj_token", "token_de_teste", raising=False)
+    monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
+
+
+def test_provedor_desligado_por_padrao() -> None:
+    assert cpfcnpj_provider.provedor_configurado() is False
+
+
+async def test_consultar_sem_token_levanta_erro(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_token", "", raising=False)
+    with pytest.raises(FiscalHTTPError):
+        await cpfcnpj_provider.consultar(6, "00000000000191")
+
+
+async def test_transporte_sucesso_status_1(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = {"status": 1, "cnpj": "00000000000191"}
+    data = await cpfcnpj_provider.consultar(6, "00000000000191")
+    assert data["cnpj"] == "00000000000191"
+    assert _FakeHTTPClient.ultimo_path == "/token_de_teste/6/00000000000191"
+
+
+async def test_transporte_erro_status_0(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = {"status": 0, "erro": "CNPJ inválido!", "erroCodigo": 200}
+    with pytest.raises(FiscalHTTPError) as exc_info:
+        await cpfcnpj_provider.consultar(6, "00000000000000")
+    assert exc_info.value.status_code == 200
+    assert "CNPJ inválido" in str(exc_info.value)
+
+
+def test_parse_cnpj_pacote_6_mapeia_campos() -> None:
+    resposta = CNPJClient()._parse_cpfcnpj(CNPJ_6_SAMPLE, "00000000000191")
+
+    assert resposta.origem == "cpfcnpj.com.br"
+    assert resposta.razao_social == "BANCO EXEMPLO SA"
+    assert resposta.nome_fantasia == "BANCO EXEMPLO"
+    assert resposta.situacao_cadastral == "Ativa"
+    assert resposta.natureza_juridica == "2038 - Sociedade de Economia Mista"
+    assert resposta.porte == "Demais"
+    assert resposta.capital_social == 120000000000.0
+    assert resposta.data_abertura is not None and resposta.data_abertura.year == 1966
+    assert resposta.atividade_principal is not None
+    assert resposta.atividade_principal.código == "6422100"
+    assert len(resposta.atividades_secundarias) == 1
+    assert resposta.endereco is not None and resposta.endereco.municipio == "Brasilia"
+    assert resposta.telefone == "(61) 31070001"
+    assert resposta.simples_nacional is False
+    assert resposta.mei is False
+    assert len(resposta.qsa) == 1
+    assert resposta.qsa[0].qualificacao == "Diretor"
+    assert resposta.qsa[0].faixa_etaria == "51 a 60"
+
+
+async def test_cnpj_usa_provedor_quando_configurado(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = CNPJ_6_SAMPLE
+    resposta = await CNPJClient().consultar("00.000.000/0001-91")
+    assert resposta.origem == "cpfcnpj.com.br"
+    assert _FakeHTTPClient.ultimo_path == "/token_de_teste/6/00000000000191"
+
+
+async def test_cnpj_faz_fallback_quando_provedor_falha(
+    provedor_habilitado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _FakeHTTPClient.payload = {"status": 0, "erro": "Créditos insuficientes!", "erroCodigo": 1001}
+
+    async def _fake_brasil_api(self: CNPJClient, cnpj: str) -> Any:
+        from mcp_fiscal_brasil.cnpj.schemas import CNPJResponse
+
+        return CNPJResponse(
+            cnpj=cnpj,
+            razao_social="EMPRESA FALLBACK",
+            situacao_cadastral="ATIVA",
+            natureza_juridica="LTDA",
+            origem="BrasilAPI",
+        )
+
+    monkeypatch.setattr(CNPJClient, "_consultar_brasil_api", _fake_brasil_api)
+    resposta = await CNPJClient().consultar("00000000000191")
+    assert resposta.origem == "BrasilAPI"
+
+
+def test_parse_nfe_pacote_100_mapeia_campos() -> None:
+    chave = "35170608530528000184550000000154301000771561"
+    resposta = NFEClient()._parse_cpfcnpj(NFE_100_SAMPLE, chave)
+
+    assert resposta.chave_acesso == chave
+    assert resposta.modelo == "55"
+    assert resposta.serie == "1"
+    assert resposta.número == "71"
+    assert resposta.situacao == "Autorizada"
+    assert resposta.natureza_operacao == "Venda de mercadoria"
+    assert resposta.protocolo_autorizacao == "135250000000071"
+    assert resposta.data_emissao is not None and resposta.data_emissao.year == 2025
+    assert resposta.totais is not None and resposta.totais.valor_nota == 1234.56
+    assert resposta.emitente is not None
+    assert resposta.emitente.cnpj == "00000000000191"
+    assert resposta.emitente.nome == "Empresa Emitente Ltda"
+    assert resposta.destinatario is not None and resposta.destinatario.cpf == "00000000000"
+
+
+def test_pacote_cpfcnpj_roteia_por_modelo() -> None:
+    client = NFEClient()
+    assert client._pacote_cpfcnpj("35170608530528000184550000000154301000771561") == 100
+    assert client._pacote_cpfcnpj(NFCE_102_CHAVE) == 102
+    assert client._pacote_cpfcnpj("3517060853052800018499") is None
+
+
+async def test_nfce_modelo_65_usa_pacote_102(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = {
+        "status": 1,
+        "chave": NFCE_102_CHAVE,
+        "nfe": {"dadosDaNfe": {"modelo": "65", "serie": "1", "numero": "9"}},
+        "situacaoAtual": {"situacao": "Autorizada"},
+    }
+    resposta = await NFEClient().consultar_por_chave(NFCE_102_CHAVE)
+    assert resposta.modelo == "65"
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/102/{NFCE_102_CHAVE}"

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -305,3 +305,32 @@ def test_limitador_cpfcnpj_compartilhado() -> None:
     cliente_b = cpfcnpj_provider._http_client()
     assert cliente_a._limiter is cliente_b._limiter
     assert cliente_a._limiter is limitador
+
+
+def test_parse_nfe_preserva_cnpj_alfanumerico_de_emitente_e_destinatario() -> None:
+    """CNPJ alfanumerico (IN RFB 2.229/2024) nao pode perder as letras no parse da NF-e."""
+    chave = "35170608530528000184550000000154301000771561"
+    cnpj_alfa = _gerar_cnpj_alfanumerico("12ABC34501DE")
+    amostra = {
+        **NFE_100_SAMPLE,
+        "emitente": {**NFE_100_SAMPLE["emitente"], "cnpj": _mascara_cnpj(cnpj_alfa)},
+        "destinatario": {
+            "nomeRazaoSocial": "Cliente PJ",
+            "cnpj": cnpj_alfa.lower(),
+            "endereco": "Rua C, 300",
+            "municipio": "Sao Paulo",
+            "uf": "SP",
+        },
+    }
+
+    resposta = NFEClient()._parse_cpfcnpj(amostra, chave)
+
+    assert resposta.emitente is not None
+    assert resposta.emitente.cnpj == cnpj_alfa
+    assert resposta.destinatario is not None
+    assert resposta.destinatario.cnpj == cnpj_alfa
+    assert resposta.destinatario.cpf is None
+
+
+def _mascara_cnpj(cnpj: str) -> str:
+    return f"{cnpj[:2]}.{cnpj[2:5]}.{cnpj[5:8]}/{cnpj[8:12]}-{cnpj[12:]}"

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -142,7 +142,10 @@ def provedor_habilitado(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
 
 
-def test_provedor_desligado_por_padrao() -> None:
+def test_provedor_desligado_por_padrao(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isola o token do ambiente/.env: sem forcar o valor vazio, uma execucao com
+    # CPFCNPJ_TOKEN definido faria provedor_configurado() retornar True.
+    monkeypatch.setattr(settings, "cpfcnpj_token", "", raising=False)
     assert cpfcnpj_provider.provedor_configurado() is False
 
 
@@ -254,3 +257,51 @@ async def test_nfce_modelo_65_usa_pacote_102(provedor_habilitado: None) -> None:
     resposta = await NFEClient().consultar_por_chave(NFCE_102_CHAVE)
     assert resposta.modelo == "65"
     assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/102/{NFCE_102_CHAVE}"
+
+
+def _gerar_cnpj_alfanumerico(base12: str) -> str:
+    """Gera um CNPJ alfanumerico com os 2 DVs corretos (IN RFB 2.229/2024)."""
+    valores = [ord(c) - 48 for c in base12]
+    pesos1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    pesos2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    soma = sum(valores[i] * pesos1[i] for i in range(12))
+    resto = soma % 11
+    dv1 = 0 if resto < 2 else 11 - resto
+    valores2 = [*valores, dv1]
+    soma = sum(valores2[i] * pesos2[i] for i in range(13))
+    resto = soma % 11
+    dv2 = 0 if resto < 2 else 11 - resto
+    return f"{base12}{dv1}{dv2}"
+
+
+def test_cnpj_alfanumerico_gerado_tem_dv_valido() -> None:
+    from mcp_fiscal_brasil.shared.validators import (
+        validate_cnpj_alfanumerico,
+        validate_cnpj_qualquer,
+    )
+
+    cnpj = _gerar_cnpj_alfanumerico("12ABC34501DE")
+    assert validate_cnpj_alfanumerico(cnpj) is True
+    # DV alterado deve invalidar
+    dv_errado = cnpj[:13] + str((int(cnpj[13]) + 1) % 10)
+    assert validate_cnpj_alfanumerico(dv_errado) is False
+    # CNPJ numerico valido continua aceito
+    assert validate_cnpj_qualquer("33.000.167/0001-01") is True
+
+
+async def test_cnpj_alfanumerico_usa_provedor(provedor_habilitado: None) -> None:
+    # CNPJ alfanumerico com mascara deve ser normalizado (letras preservadas em
+    # maiusculas) e enviado inteiro no caminho da consulta.
+    _FakeHTTPClient.payload = {"status": 1, "cnpj": "12ABC34501DE35"}
+    await CNPJClient().consultar("12.ABC.345/01DE-35")
+    assert _FakeHTTPClient.ultimo_path == "/token_de_teste/6/12ABC34501DE35"
+
+
+def test_limitador_cpfcnpj_compartilhado() -> None:
+    # Duas instancias/chamadas devem compartilhar o mesmo AsyncLimiter (singleton).
+    limitador = cpfcnpj_provider._get_limiter()
+    assert limitador is cpfcnpj_provider._get_limiter()
+    cliente_a = cpfcnpj_provider._http_client()
+    cliente_b = cpfcnpj_provider._http_client()
+    assert cliente_a._limiter is cliente_b._limiter
+    assert cliente_a._limiter is limitador

--- a/tests/test_nfe.py
+++ b/tests/test_nfe.py
@@ -13,9 +13,10 @@ from lxml import etree
 
 from mcp_fiscal_brasil._core.config import settings as nfe_settings
 from mcp_fiscal_brasil._core.errors import FiscalConfigurationError
-from mcp_fiscal_brasil.nfe.client import NFEClient, _extrair_info_chave
+from mcp_fiscal_brasil.nfe.client import NFEClient, _extrair_info_chave, _parse_valor_br
 from mcp_fiscal_brasil.nfe.status_sefaz import _obter_ssl_context
 from mcp_fiscal_brasil.nfe.tools import (
+    consultar_nfce,
     consultar_nfe,
     consultar_status_sefaz,
     validar_chave_nfe,
@@ -248,3 +249,50 @@ class TestNFEClientFallback:
         with pytest.raises(ValidationError) as exc_info:
             await consultar_nfe("1234567890")
         assert exc_info.value.field == "chave_acesso"
+
+
+# Chaves de acesso com digito verificador valido, geradas para os testes.
+_CHAVE_MODELO_55 = "35240112345678000195550010000000121123456782"
+_CHAVE_MODELO_65 = "35240112345678000195650010000000121123456785"
+
+
+class TestConsultarNFCeModelo:
+    async def test_chave_modelo_55_e_rejeitada(self) -> None:
+        # Chave valida de NF-e (modelo 55) nao deve ser aceita como NFC-e.
+        with pytest.raises(ValidationError) as exc_info:
+            await consultar_nfce(_CHAVE_MODELO_55)
+        assert exc_info.value.field == "chave_acesso"
+        assert "modelo 65" in exc_info.value.reason
+
+    async def test_chave_modelo_65_passa_na_validacao(self) -> None:
+        from mcp_fiscal_brasil.nfe.schemas import NFeResponse
+
+        esperado = NFeResponse(chave_acesso=_CHAVE_MODELO_65, modelo="65")
+        with patch(
+            "mcp_fiscal_brasil.nfe.tools._client.consultar_por_chave",
+            new=AsyncMock(return_value=esperado),
+        ) as mock_consulta:
+            resultado = await consultar_nfce(_CHAVE_MODELO_65)
+        assert resultado.modelo == "65"
+        mock_consulta.assert_awaited_once_with(_CHAVE_MODELO_65)
+
+
+class TestParseValorBr:
+    def test_formato_brasileiro_com_milhar_e_decimal(self) -> None:
+        assert _parse_valor_br("1.234,56") == 1234.56
+
+    def test_decimal_com_ponto(self) -> None:
+        assert _parse_valor_br("1234.56") == 1234.56
+
+    def test_decimal_com_ponto_uma_casa(self) -> None:
+        assert _parse_valor_br("1234.5") == 1234.5
+
+    def test_ponto_como_milhar_sem_virgula(self) -> None:
+        assert _parse_valor_br("1.234") == 1234.0
+
+    def test_apenas_inteiro(self) -> None:
+        assert _parse_valor_br("1234") == 1234.0
+
+    def test_vazio_retorna_none(self) -> None:
+        assert _parse_valor_br("") is None
+        assert _parse_valor_br(None) is None

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -92,6 +92,15 @@ class TestFormatCNPJ:
         with pytest.raises(ValueError):
             format_cnpj("123")
 
+    def test_formata_alfanumerico_sem_mascara(self) -> None:
+        assert format_cnpj("12ABC34501DE35") == "12.ABC.345/01DE-35"
+
+    def test_formata_alfanumerico_com_mascara_e_minusculas(self) -> None:
+        assert format_cnpj("12.abc.345/01de-35") == "12.ABC.345/01DE-35"
+
+    def test_remove_mascara_alfanumerico(self) -> None:
+        assert format_cnpj("12.ABC.345/01DE-35", remover_mascara=True) == "12ABC34501DE35"
+
 
 class TestValidateCNPJAlfanumerico:
     """Testes para validação de CNPJ alfanumérico (IN RFB 2.229/2024, vigência jul/2026).


### PR DESCRIPTION
Relacionado: #141

## Resumo

Adiciona a [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/) como fonte de dados premium opcional para consultas de CNPJ (pacotes 5/6) e de NF-e/NFC-e por chave (pacotes 100/102). O provedor só entra em ação quando `CPFCNPJ_TOKEN` está configurado. Sem token, o comportamento gratuito e sem cadastro permanece intacto e continua sendo o padrão.

Quando habilitado, o provedor é consultado primeiro e as fontes gratuitas (BrasilAPI, ReceitaWS e Portal Nacional da NF-e) seguem como fallback automático, de modo que uma falha do provedor premium nunca quebra o caminho gratuito.

## Motivação

- **NF-e por chave estável**: hoje a consulta por chave depende de fontes públicas instáveis ou indisponíveis. O pacote 100 (modelo 55) traz os dados oficiais de forma confiável.
- **NFC-e coberta**: a NFC-e (modelo 65) não existe nas APIs gratuitas. Este PR adiciona a tool `consultar_nfce` (pacote 102).
- **CNPJ enriquecido**: o pacote 6 preenche situação cadastral, Simples/MEI, sócios e representantes, endereço da matriz, mantendo o mesmo schema.

## Diferenciais da fonte premium

- **Dados oficiais em tempo real (D+0)**, direto na origem.
- **Sem bases vazadas ou raspadas**: procedência conhecida.
- **Conformidade com certificações internacionais**: ISO/IEC 27001 (segurança da informação), ISO/IEC 27701 (privacidade) e ISO 37301 (gestão de conformidade).

## Alterações

- `shared/cpfcnpj.py`: transporte HTTP protegido por token. Mapeia respostas com `status` diferente de 1 para `FiscalHTTPError`, preservando `erro`/`erroCodigo` do provedor. O token é mascarado na URL das mensagens de erro.
- `cnpj/client.py`: mapeamento do pacote 6 para `CNPJResponse`, com o provedor premium tentado antes de BrasilAPI e ReceitaWS.
- `nfe/client.py`: roteamento por modelo embutido na chave (55 para o pacote 100, 65 para o pacote 102) e mapeamento defensivo para `NFeResponse` (campos ausentes ficam vazios sem quebrar o schema).
- `nfe/tools.py`, `server.py`: nova tool `consultar_nfce` para NFC-e (modelo 65).
- `_core/config.py`, `.env.example`, `README.md`: documentam o provedor opt-in, os dados oficiais em tempo real e a documentação da API.

## Desenho e segurança

- Opt-in por token: sem `CPFCNPJ_TOKEN`, nenhuma chamada ao provedor é feita e o caminho gratuito é preservado byte a byte.
- Token nunca hardcoded nem versionado; vem de variável de ambiente ou gestor de segredos. O valor não aparece em logs nem em mensagens de erro.
- Sem regressão nas fontes gratuitas: elas permanecem como fallback e como padrão.

## Testes

- `tests/test_cpfcnpj_provider.py`: cobre transporte (sucesso, erro e ausência de token), parsing de CNPJ (pacote 6) e de NF-e/NFC-e (pacotes 100/102), roteamento por modelo e a garantia de que o padrão gratuito não muda.
- Suíte completa: 648 testes passando. `ruff check .` sem erros.

## Documentação

- API: https://www.cpfcnpj.com.br/dev/
- NF-e por chave (pacote 100): https://www.cpfcnpj.com.br/dev/#op-get-token-100-chave
- NFC-e por chave (pacote 102): https://www.cpfcnpj.com.br/dev/#op-get-token-102-chave


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos recursos**
  * Adicionada integração opcional com o provedor premium cpfcnpj.com.br para consultas de CNPJ, NF-e e NFC-e.
  * Adicionada consulta de NFC-e pela chave de acesso.
  * Consultas premium priorizam essa fonte e usam fallback automático para fontes gratuitas.
  * CNPJs alfanuméricos agora são aceitos em consultas, validações e formatações.

* **Documentação**
  * Atualizadas as instruções de configuração, cobertura, pacotes e variáveis de ambiente do provedor premium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->