### PR TITLE
feat(cpf): consulta de situação cadastral de CPF pelo provedor opcional cpfcnpj.com.br

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@
 #     situacao, porte, Simples Nacional, QSA)
 #   - NF-e por chave (consultar_nfe): pacote 100 (modelo 55)
 #   - NFC-e por chave (consultar_nfce): pacote 102 (modelo 65)
+#   - CPF (consultar_cpf): situacao cadastral do titular (nao ha fonte gratuita;
+#     esta consulta so acontece com o token definido)
 #
 # Documentacao oficial da API: https://www.cpfcnpj.com.br/dev/
 # Token de conta ativa em https://www.cpfcnpj.com.br/. Trate como segredo:
@@ -77,3 +79,10 @@
 
 # Pacote usado nas consultas de CNPJ: 5 (enxuto) ou 6 (completo). Padrao: 6.
 # CPFCNPJ_CNPJ_PACKET=6
+
+# Pacote usado nas consultas de CPF (consultar_cpf). Valores aceitos:
+#   26 (padrao) = nome, nascimento e situacao cadastral (mais barato com situacao)
+#    8          = 26 + motivo, ano de obito, numero e PDF do comprovante da Receita
+#    3          = nome, nascimento, genero e endereco completo
+#    1          = so o nome (conferencia rapida)
+# CPFCNPJ_CPF_PACKET=26

--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@
 # URL base da API (padrao ja aponta para producao; raramente precisa mudar).
 # CPFCNPJ_BASE_URL=https://api.cpfcnpj.com.br
 
+# Timeout (segundos) das consultas ao provedor. A documentacao recomenda 60: com
+# um valor menor a requisicao pode ser cortada depois de o credito ja ter sido
+# consumido. Nao afeta o timeout global das fontes gratuitas. Padrao: 60.
+# CPFCNPJ_TIMEOUT=60
+
 # Pacote usado nas consultas de CNPJ: 5 (enxuto) ou 6 (completo). Padrao: 6.
 # CPFCNPJ_CNPJ_PACKET=6
 

--- a/.env.example
+++ b/.env.example
@@ -3,13 +3,17 @@
 # Copie este arquivo para .env e ajuste conforme necessario:
 #   cp .env.example .env
 #
-# IMPORTANTE: o servidor funciona 100% sem nenhuma variavel definida.
-# Todas as opcoes abaixo sao OPCIONAIS e so importam quando voce roda em
-# modo HTTP/SSE (deploy remoto). No modo padrao (stdio, usado por Claude
-# Desktop e Claude Code) nenhuma delas e necessaria.
+# IMPORTANTE: o servidor funciona 100% sem nenhuma variavel definida. Todas as
+# opcoes abaixo sao OPCIONAIS.
 #
-# As tres variaveis abaixo sao as UNICAS lidas pelo codigo atualmente
-# (src/mcp_fiscal_brasil/server.py, funcao main).
+# Algumas so tem efeito no modo HTTP/SSE (deploy remoto): o transporte
+# (FASTMCP_TRANSPORT) e o bind de rede (PORT, HOST). No modo padrao (stdio, usado
+# por Claude Desktop e Claude Code) essas tres sao ignoradas.
+#
+# As demais valem em QUALQUER transporte, inclusive stdio: o certificado digital A1
+# (status SEFAZ e distribuicao/manifestacao de NF-e) e o provedor premium opcional
+# cpfcnpj.com.br (CPFCNPJ_TOKEN, CPFCNPJ_TIMEOUT, CPFCNPJ_BASE_URL e os pacotes
+# CPFCNPJ_*), lidos pelas tools de CNPJ/CPF/NF-e ao consultar.
 
 # Protocolo de transporte do servidor MCP.
 # Valores aceitos: stdio | sse | http | streamable-http

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 Correções originadas do fork de Italo9 (github.com/Italo9/mcp-fiscal-brasil),
 portadas seletivamente para o repositório canônico.
 
+### Ajustes de conformidade com a documentação do provedor cpfcnpj.com.br
+
+* timeout dedicado `CPFCNPJ_TIMEOUT` (padrão 60s, recomendado pela documentação),
+  usado só nas consultas ao provedor premium, sem alterar o timeout global das
+  fontes gratuitas
+* rate limit por pacote: NF-e/NFC-e por chave (100/102) usam um limitador próprio
+  de 2 req/s por conta (HTTP 429 + erroCodigo 1007), separado do de 20 req/s dos
+  demais pacotes (CPF/CNPJ/IE)
+* token do provedor mascarado na origem: o primeiro segmento do path (onde viaja o
+  token) é substituído por `***` nas URLs carregadas pelos erros de transporte,
+  apenas para o cliente do provedor premium (fontes gratuitas intactas)
+
 ### BREAKING CHANGES
 
 * `consultar_status_sefaz` agora consulta o webservice real da SEFAZ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ portadas seletivamente para o repositório canônico.
 
 ### Novas funcionalidades
 
+* tool `consultar_cpf` (premium, opt-in via `CPFCNPJ_TOKEN`) consulta a situação
+  cadastral do CPF na Receita Federal para conferir destinatário de NF-e/NFC-e ou
+  tomador de NFS-e (pessoa física) antes de emitir; deriva `apto_emissao` (verdadeiro
+  só quando Regular), valida o dígito verificador antes de gastar crédito, mascara o
+  CPF em todo log e não expõe campos operacionais do provedor. Pacote configurável por
+  `CPFCNPJ_CPF_PACKET` (`26` padrão, `8`, `3` ou `1`). Exposta também no endpoint REST
+  `GET /v1/cpf/{cpf}/cadastro` e no SDK (`consultar_cpf` / `consultar_cpf_sync`)
 * consulta real de status da SEFAZ via NfeStatusServico4 (mTLS), substituindo
   o antigo proxy da BrasilAPI que retornava 404 para toda UF
 * endpoint `GET /v1/fiscal/certificado/status` informa apenas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ portadas seletivamente para o repositório canônico.
   só quando Regular), valida o dígito verificador antes de gastar crédito, mascara o
   CPF em todo log e não expõe campos operacionais do provedor. Pacote configurável por
   `CPFCNPJ_CPF_PACKET` (`26` padrão, `8`, `3` ou `1`). Exposta também no endpoint REST
-  `GET /v1/cpf/{cpf}/cadastro` e no SDK (`consultar_cpf` / `consultar_cpf_sync`)
+  `POST /v1/cpf/cadastro` (CPF no corpo JSON, fora do path) e no SDK
+  (`consultar_cpf` / `consultar_cpf_sync`)
 * consulta real de status da SEFAZ via NfeStatusServico4 (mTLS), substituindo
   o antigo proxy da BrasilAPI que retornava 404 para toda UF
 * endpoint `GET /v1/fiscal/certificado/status` informa apenas

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Reinicie o Claude Desktop. As ferramentas fiscais aparecem automaticamente, sem 
 | Tabelas offline (NCM, CFOP, CNAE) | Sim | Não | Não |
 | Reforma Tributária 2026 (IBS/CBS) | Sim | Não | Não |
 | Simples Nacional/MEI | Sim | Não | Não |
+| CPF: validação + situação cadastral (opt-in premium) | Sim | Não | Não |
 | Certidão federal/FGTS | Sim (orientação) | Não | Não |
 | Certificado A1 (mTLS SEFAZ) | Sim (opt-in) | Não | Não |
 | Zero-cadastro, zero chave obrigatória | Sim | Parcial (3 APIs exigem chave) | Sim |
@@ -222,6 +223,7 @@ Funcionam 100% sem chaves de API. Instale e use imediatamente.
 | NFe | `baixar_nfe_distribuicao` | Baixa documentos via NFeDistribuicaoDFe (requer cert A1 local) | SEFAZ (mTLS) |
 | NFe | `manifestar_nfe` | Manifesta destinatario em NF-e via NFeRecepcaoEvento (requer cert A1) | SEFAZ (mTLS) |
 | CPF | `validar_cpf` | Validação de dígito verificador | Offline |
+| CPF | `consultar_cpf` | Situação cadastral do titular (Regular/Suspensa/Cancelada/Titular Falecido) para emissão a pessoa física | cpfcnpj.com.br (premium, opt-in) |
 | SPED | `analisar_sped` | Analisa arquivo EFD/ECD/ECF: período, empresa, erros | Offline |
 | SPED | `listar_registros_sped` | Filtra registros por tipo (C100, E110, etc.) | Offline |
 | eSocial | `listar_eventos_esocial` | Catálogo de eventos filtrável por grupo | Offline |
@@ -310,8 +312,24 @@ fallback automático, de forma transparente.
 | Ferramenta | Fonte premium | Pacote | Documentação |
 |-----------|---------------|--------|--------------|
 | `consultar_cnpj` | cpfcnpj.com.br | 5 ou 6 | [dev/](https://www.cpfcnpj.com.br/dev/) |
+| `consultar_cpf` | cpfcnpj.com.br | 1, 3, 8 ou 26 (padrão 26) | [dev/](https://www.cpfcnpj.com.br/dev/) |
 | `consultar_nfe` | cpfcnpj.com.br | 100 (modelo 55) | [#op-get-token-100-chave](https://www.cpfcnpj.com.br/dev/#op-get-token-100-chave) |
 | `consultar_nfce` | cpfcnpj.com.br | 102 (modelo 65) | [#op-get-token-102-chave](https://www.cpfcnpj.com.br/dev/#op-get-token-102-chave) |
+
+O `consultar_cpf` confere a situação cadastral do titular antes de emitir NF-e, NFC-e
+ou NFS-e a pessoa física (destinatário ou tomador), e deriva `apto_emissao` (verdadeiro
+só quando a situação é Regular). Não há fonte gratuita de dados de CPF, então a consulta
+só ocorre com o token configurado. O pacote define o que volta:
+
+| Pacote | O que devolve |
+|--------|---------------|
+| `26` (padrão) | Nome, nascimento e situação cadastral. Suficiente para o caso fiscal e o mais barato com situação. |
+| `8` | O do pacote 26 mais motivo da situação, ano de óbito, número e PDF do comprovante da Receita (para arquivar junto da nota). |
+| `3` | Nome, nascimento, gênero e endereço completo (preencher o destinatário da NF-e). |
+| `1` | Só o nome (conferir se o nome informado bate com o CPF). |
+
+O CPF é mascarado em todo log (`***.***.***-XX`) e os campos operacionais do provedor
+(saldo, consultaID, pacote usado) não são retornados.
 
 O `consultar_nfce` retorna a NFC-e completa apenas com o token configurado (pacote
 102). Sem token, ele recorre às fontes públicas e pode devolver dados parciais da
@@ -327,6 +345,7 @@ Gerais (MG); as demais UFs exigem habilitação sob demanda e podem retornar o e
 | `CPFCNPJ_TOKEN` | Token da conta em cpfcnpj.com.br. **Vazio = fonte premium desligada.** | (vazio) |
 | `CPFCNPJ_BASE_URL` | URL base da API premium. Aceita somente `https://` (o token trafega no caminho da URL) | `https://api.cpfcnpj.com.br` |
 | `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ: `5` (enxuto) ou `6` (completo) | `6` |
+| `CPFCNPJ_CPF_PACKET` | Pacote de CPF do `consultar_cpf`: `26` (nome, nascimento, situação), `8` (situação + PDF do comprovante e óbito), `3` (nome, nascimento, gênero, endereço) ou `1` (só nome) | `26` |
 
 Trate o token como segredo: use o gestor de segredos do seu provedor de deploy,
 nunca um `.env` versionado em produção.
@@ -460,6 +479,7 @@ Todas as variáveis são opcionais. O servidor funciona sem nenhuma configuraç�
 | `CPFCNPJ_TOKEN` | Token do provedor premium opt-in [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/). Vazio = desligado (padrão gratuito intacto) | (vazio) |
 | `CPFCNPJ_BASE_URL` | URL base da API premium cpfcnpj.com.br. Aceita somente `https://` | `https://api.cpfcnpj.com.br` |
 | `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ na cpfcnpj.com.br: `5` ou `6` | `6` |
+| `CPFCNPJ_CPF_PACKET` | Pacote de CPF na cpfcnpj.com.br: `1`, `3`, `8` ou `26` | `26` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Gerais (MG); as demais UFs exigem habilitação sob demanda e podem retornar o e
 |----------|-----------|--------|
 | `CPFCNPJ_TOKEN` | Token da conta em cpfcnpj.com.br. **Vazio = fonte premium desligada.** | (vazio) |
 | `CPFCNPJ_BASE_URL` | URL base da API premium. Aceita somente `https://` (o token trafega no caminho da URL) | `https://api.cpfcnpj.com.br` |
+| `CPFCNPJ_TIMEOUT` | Timeout (segundos) das consultas ao provedor. A documentação recomenda 60 (valor menor pode cortar a requisição após o crédito já ter sido consumido) | `60` |
 | `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ: `5` (enxuto) ou `6` (completo) | `6` |
 | `CPFCNPJ_CPF_PACKET` | Pacote de CPF do `consultar_cpf`: `26` (nome, nascimento, situação), `8` (situação + PDF do comprovante e óbito), `3` (nome, nascimento, gênero, endereço) ou `1` (só nome) | `26` |
 
@@ -478,6 +479,7 @@ Todas as variáveis são opcionais. O servidor funciona sem nenhuma configuraç�
 | `HTTP_TIMEOUT` | Timeout em segundos para chamadas HTTP | `30` |
 | `CPFCNPJ_TOKEN` | Token do provedor premium opt-in [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/). Vazio = desligado (padrão gratuito intacto) | (vazio) |
 | `CPFCNPJ_BASE_URL` | URL base da API premium cpfcnpj.com.br. Aceita somente `https://` | `https://api.cpfcnpj.com.br` |
+| `CPFCNPJ_TIMEOUT` | Timeout (segundos) das consultas à cpfcnpj.com.br (recomendado 60 pela documentação) | `60` |
 | `CPFCNPJ_CNPJ_PACKET` | Pacote de CNPJ na cpfcnpj.com.br: `5` ou `6` | `6` |
 | `CPFCNPJ_CPF_PACKET` | Pacote de CPF na cpfcnpj.com.br: `1`, `3`, `8` ou `26` | `26` |
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Funcionam 100% sem chaves de API. Instale e use imediatamente.
 | NFe | `baixar_nfe_distribuicao` | Baixa documentos via NFeDistribuicaoDFe (requer cert A1 local) | SEFAZ (mTLS) |
 | NFe | `manifestar_nfe` | Manifesta destinatario em NF-e via NFeRecepcaoEvento (requer cert A1) | SEFAZ (mTLS) |
 | CPF | `validar_cpf` | Validação de dígito verificador | Offline |
-| CPF | `consultar_cpf` | Situação cadastral do titular (Regular/Suspensa/Cancelada/Titular Falecido) para emissão a pessoa física | cpfcnpj.com.br (premium, opt-in) |
+| CPF | `consultar_cpf` | Situação cadastral do titular (Regular, Suspensa, Titular Falecido, Pendente de Regularização, Cancelada por Multiplicidade, Nula, Cancelada de Ofício) para emissão a pessoa física | cpfcnpj.com.br (premium, opt-in) |
 | SPED | `analisar_sped` | Analisa arquivo EFD/ECD/ECF: período, empresa, erros | Offline |
 | SPED | `listar_registros_sped` | Filtra registros por tipo (C100, E110, etc.) | Offline |
 | eSocial | `listar_eventos_esocial` | Catálogo de eventos filtrável por grupo | Offline |

--- a/docs/modules/cpf.md
+++ b/docs/modules/cpf.md
@@ -30,12 +30,13 @@ antes de qualquer chamada, para não gastar crédito com CPF malformado.
 from mcp_fiscal_brasil.cpf.tools import consultar_cpf_tool
 
 cadastro = await consultar_cpf_tool("123.456.789-09")
-print(cadastro.situacao.descricao)  # ex.: "Regular"
+# situacao so vem nos pacotes 26 e 8; nos pacotes 1 e 3 fica None.
+print(cadastro.situacao.descricao if cadastro.situacao else None)  # ex.: "Regular"
 print(cadastro.apto_emissao)        # True apenas quando a situação é Regular
 ```
 
 O pacote é definido por `CPFCNPJ_CPF_PACKET`: `26` (padrão: nome, nascimento e situação),
-`8` (situação com motivo, ano de óbito e PDF do comprovante), `3` (nome, nascimento,
+`8` (situação com motivo, ano de óbito, número e PDF do comprovante), `3` (nome, nascimento,
 gênero e endereço) ou `1` (só o nome). Situações reconhecidas (código oficial da Receita):
 `00` Regular, `02` Suspensa, `03` Titular Falecido, `04` Pendente de Regularização, `05`
 Cancelada por Multiplicidade, `08` Nula, `09` Cancelada de Ofício.

--- a/docs/modules/cpf.md
+++ b/docs/modules/cpf.md
@@ -16,13 +16,40 @@ print(resultado.válido)  # True/False
 ## Tool MCP
 
 - `validar_cpf(cpf: str)` - validação offline do DV
+- `consultar_cpf(cpf: str)` - situação cadastral do titular (premium, opt-in)
+
+## Consulta de situação cadastral (premium, opt-in)
+
+Com o provedor premium opcional cpfcnpj.com.br habilitado (`CPFCNPJ_TOKEN`), a tool
+`consultar_cpf` confere a situação cadastral do titular na Receita Federal antes de
+emitir NF-e, NFC-e ou NFS-e a pessoa física. Não há fonte gratuita de dados de CPF, então
+a consulta só ocorre com o token configurado. O dígito verificador é validado localmente
+antes de qualquer chamada, para não gastar crédito com CPF malformado.
+
+```python
+from mcp_fiscal_brasil.cpf.tools import consultar_cpf_tool
+
+cadastro = await consultar_cpf_tool("123.456.789-09")
+print(cadastro.situacao.descricao)  # ex.: "Regular"
+print(cadastro.apto_emissao)        # True apenas quando a situação é Regular
+```
+
+O pacote é definido por `CPFCNPJ_CPF_PACKET`: `26` (padrão: nome, nascimento e situação),
+`8` (situação com motivo, ano de óbito e PDF do comprovante), `3` (nome, nascimento,
+gênero e endereço) ou `1` (só o nome). Situações reconhecidas (código oficial da Receita):
+`00` Regular, `02` Suspensa, `03` Titular Falecido, `04` Pendente de Regularização, `05`
+Cancelada por Multiplicidade, `08` Nula, `09` Cancelada de Ofício.
+
+Privacidade: o CPF é mascarado em todo log (`***.***.***-XX`); o PDF do comprovante nunca
+passa por log; campos operacionais do provedor (saldo, consultaID, pacote usado) não são
+retornados.
 
 ## Limitacoes
 
-Não consulta:
+A validação offline (`validar_cpf`) não consulta:
 
 - Nome titular
 - Situacao cadastral (regular/pendente/cancelada)
 - Outras informações pessoais
 
-Para esses dados, e necessário contrato com SERPRO Datavalid ou Caixa.
+Esses dados vêm de `consultar_cpf` com o provedor premium opt-in cpfcnpj.com.br.

--- a/src/mcp_fiscal_brasil/_core/config.py
+++ b/src/mcp_fiscal_brasil/_core/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
     cpfcnpj_token: str = ""
     cpfcnpj_base_url: str = "https://api.cpfcnpj.com.br"
     cpfcnpj_cnpj_packet: int = 6
+    # Pacote de CPF usado por consultar_cpf. Padrao 26 (CPF D Simplificado): nome,
+    # nascimento e situacao cadastral, o mais barato que traz situacao. Aceita
+    # 1 (so nome), 3 (nome, nascimento, genero e endereco), 8 (situacao + motivo,
+    # ano de obito, numero e PDF do comprovante) e 26.
+    cpfcnpj_cpf_packet: int = 26
     ibge_cnae_base_url: str = "https://servicodados.ibge.gov.br/api/v2/cnae"
     ibge_localidades_base_url: str = "https://servicodados.ibge.gov.br/api/v1/localidades"
     bcb_sgs_base_url: str = "https://api.bcb.gov.br/dados/serie"
@@ -56,6 +61,21 @@ class Settings(BaseSettings):
                 "caminho da URL e nao pode trafegar sem criptografia)."
             )
         return normalizado
+
+    @field_validator("cpfcnpj_cpf_packet")
+    @classmethod
+    def _validar_pacote_cpf(cls, valor: int) -> int:
+        """Restringe o pacote de CPF aos niveis suportados por consultar_cpf.
+
+        Apenas os pacotes com uso fiscal claro sao aceitos: 1 (so nome), 3 (nome,
+        nascimento, genero e endereco), 8 (situacao completa com PDF do comprovante)
+        e 26 (situacao simplificada). Um valor fora disso e um erro de configuracao.
+        """
+        pacotes_validos = {1, 3, 8, 26}
+        if valor not in pacotes_validos:
+            aceitos = ", ".join(str(p) for p in sorted(pacotes_validos))
+            raise ValueError(f"CPFCNPJ_CPF_PACKET deve ser um de: {aceitos} (recebido: {valor}).")
+        return valor
 
 
 settings = Settings()

--- a/src/mcp_fiscal_brasil/_core/config.py
+++ b/src/mcp_fiscal_brasil/_core/config.py
@@ -24,6 +24,10 @@ class Settings(BaseSettings):
     # oficiais em tempo real, e mantem as fontes gratuitas como fallback.
     cpfcnpj_token: str = ""
     cpfcnpj_base_url: str = "https://api.cpfcnpj.com.br"
+    # Timeout dedicado da cpfcnpj.com.br. A documentacao do provedor recomenda 60s:
+    # com um valor menor a requisicao pode ser cortada depois de o credito ja ter
+    # sido consumido. Nao afeta o timeout global das fontes gratuitas.
+    cpfcnpj_timeout: float = 60.0
     cpfcnpj_cnpj_packet: int = 6
     # Pacote de CPF usado por consultar_cpf. Padrao 26 (CPF D Simplificado): nome,
     # nascimento e situacao cadastral, o mais barato que traz situacao. Aceita
@@ -61,6 +65,14 @@ class Settings(BaseSettings):
                 "caminho da URL e nao pode trafegar sem criptografia)."
             )
         return normalizado
+
+    @field_validator("cpfcnpj_timeout")
+    @classmethod
+    def _validar_timeout_cpfcnpj(cls, valor: float) -> float:
+        """Garante um timeout positivo para o provedor premium."""
+        if valor <= 0:
+            raise ValueError(f"CPFCNPJ_TIMEOUT deve ser maior que zero (recebido: {valor}).")
+        return valor
 
     @field_validator("cpfcnpj_cpf_packet")
     @classmethod

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -44,12 +44,26 @@ class HTTPClient:
         cache_ttl: int = 300,
         rate_limit_per_second: int = 10,
         limiter: AsyncLimiter | None = None,
+        mask_first_path_segment: bool = False,
+        mask_secret: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/") + "/"
         self.timeout = timeout
         self.max_retries = max(1, max_retries)
         self.cache_ttl = max(0, cache_ttl)
         self.rate_limit_per_second = max(1, rate_limit_per_second)
+        # Quando o primeiro segmento do path e um segredo (ex.: o token da
+        # cpfcnpj.com.br em /{token}/{pacote}/{documento}), ele nao pode vazar nas
+        # URLs carregadas pelos erros. As fontes gratuitas nao setam esse flag.
+        self.mask_first_path_segment = mask_first_path_segment
+        # Prefixo de path da base_url (ex.: "/cpfcnpj/" quando a base traz um
+        # prefixo). O segmento a mascarar e o primeiro DEPOIS desse prefixo, senao
+        # uma base com prefixo mascararia o prefixo e deixaria o token exposto.
+        self._base_path = httpx.URL(self.base_url).path
+        # Segredo literal conhecido (ex.: o token). Quando informado, qualquer
+        # ocorrencia dele e trocada por "***" em url/endpoint/mensagem/details,
+        # como defesa em profundidade caso a URL nao siga o formato esperado.
+        self.mask_secret = mask_secret or None
         self._client = httpx.AsyncClient(
             base_url=self.base_url,
             timeout=timeout,
@@ -250,9 +264,50 @@ class HTTPClient:
     def _is_retryable_status(self, status_code: int) -> bool:
         return status_code == 429 or 500 <= status_code <= 599
 
+    def _mask_url(self, url: str) -> str:
+        """Mascara o primeiro segmento do path quando ele carrega um segredo.
+
+        Usado pelo provedor cpfcnpj.com.br, cujo token viaja em ``/{token}/...``.
+        Quando a base_url tem prefixo de path (ex.: ``https://proxy/cpfcnpj``), o
+        segmento mascarado e o primeiro DEPOIS do prefixo, para nao mascarar o
+        prefixo e deixar o token exposto. Sem o flag ligado, o path fica intacto
+        (mas o segredo literal, se conhecido, ainda e removido).
+        """
+        if not self.mask_first_path_segment:
+            return self._scrub_secret(url)
+        try:
+            parsed = httpx.URL(url)
+        except (httpx.InvalidURL, ValueError):
+            return self._scrub_secret(url)
+        caminho = parsed.path
+        prefixo = self._base_path
+        if prefixo not in ("", "/") and caminho.startswith(prefixo):
+            mascarado = prefixo + self._mascarar_primeiro_segmento(caminho[len(prefixo) :])
+        else:
+            mascarado = self._mascarar_primeiro_segmento(caminho)
+        if mascarado == caminho:
+            return self._scrub_secret(url)
+        return self._scrub_secret(str(parsed.copy_with(path=mascarado)))
+
+    def _mascarar_primeiro_segmento(self, caminho: str) -> str:
+        segmentos = caminho.split("/")
+        for indice, segmento in enumerate(segmentos):
+            if segmento:
+                segmentos[indice] = "***"
+                return "/".join(segmentos)
+        return caminho
+
+    def _scrub_secret(self, texto: str) -> str:
+        """Remove qualquer ocorrencia literal do segredo conhecido do texto."""
+        if self.mask_secret and self.mask_secret in texto:
+            return texto.replace(self.mask_secret, "***")
+        return texto
+
     def _request_error(self, method: str, exc: httpx.RequestError) -> Exception:
         request = exc.request
-        url = str(request.url) if request is not None else self.base_url
+        bruta = str(request.url) if request is not None else self.base_url
+        url = self._mask_url(bruta)
+        detalhe = self._scrub_secret(str(exc).replace(bruta, url) if bruta else str(exc))
         return self._make_core_error(
             "FiscalHTTPError",
             "Falha de comunicação com serviço externo",
@@ -260,7 +315,7 @@ class HTTPClient:
             url=url,
             endpoint=url,
             status_code=None,
-            details={"error": str(exc)},
+            details={"error": detalhe},
         )
 
     def _http_error(
@@ -270,11 +325,11 @@ class HTTPClient:
         message: str | None = None,
     ) -> Exception:
         status_code = response.status_code if response is not None else None
-        url = str(response.request.url) if response is not None else self.base_url
-        response_text = response.text if response is not None else None
+        url = self._mask_url(str(response.request.url) if response is not None else self.base_url)
+        response_text = self._scrub_secret(response.text) if response is not None else None
         return self._make_core_error(
             "FiscalHTTPError",
-            message or self._status_message(status_code),
+            self._scrub_secret(message or self._status_message(status_code)),
             method=method.upper(),
             url=url,
             endpoint=url,

--- a/src/mcp_fiscal_brasil/_core/http.py
+++ b/src/mcp_fiscal_brasil/_core/http.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from importlib import import_module
 from inspect import Parameter, signature
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 import httpx
 from aiolimiter import AsyncLimiter
@@ -17,9 +17,21 @@ from tenacity import (
     wait_exponential,
 )
 
-__all__ = ["HTTPClient"]
+__all__ = ["HTTPClient", "RateLimiter"]
 
 _CacheKey = tuple[str, str, tuple[tuple[str, Any], ...]]
+
+
+class RateLimiter(Protocol):
+    """Interface estrutural do limitador aceito pelo :class:`HTTPClient`.
+
+    Cobre o ``AsyncLimiter`` do aiolimiter (padrao interno das fontes gratuitas) e
+    limitadores proprios, como o limitador de processo do provedor cpfcnpj.com.br,
+    sem exigir heranca: basta expor ``acquire``. O ``AsyncLimiter`` satisfaz o
+    protocolo estruturalmente.
+    """
+
+    async def acquire(self, amount: float = 1) -> None: ...
 
 
 class _ReadableQuery(bytes):
@@ -43,7 +55,7 @@ class HTTPClient:
         max_retries: int = 3,
         cache_ttl: int = 300,
         rate_limit_per_second: int = 10,
-        limiter: AsyncLimiter | None = None,
+        limiter: RateLimiter | None = None,
         mask_first_path_segment: bool = False,
         mask_secret: str | None = None,
     ) -> None:
@@ -76,7 +88,7 @@ class HTTPClient:
         # Um limitador pode ser injetado para ser compartilhado entre varias
         # instancias (ex.: o teto global da cpfcnpj.com.br). Quando ausente, cada
         # instancia usa o proprio, derivado de rate_limit_per_second.
-        self._limiter = (
+        self._limiter: RateLimiter = (
             limiter
             if limiter is not None
             else AsyncLimiter(self.rate_limit_per_second, self.rate_limit_per_second)

--- a/src/mcp_fiscal_brasil/api.py
+++ b/src/mcp_fiscal_brasil/api.py
@@ -153,20 +153,25 @@ async def cpf_validate(cpf: str) -> dict[str, Any]:
     return resultado.model_dump(mode="json", exclude_none=True)
 
 
-@app.get(
-    "/v1/cpf/{cpf}/cadastro",
+class CPFCadastroRequest(BaseModel):
+    cpf: str = Field(description="CPF com ou sem máscara (ex.: '123.456.789-09').")
+
+
+@app.post(
+    "/v1/cpf/cadastro",
     tags=["cpf"],
     summary="Situacao cadastral do CPF (premium, opt-in)",
 )
-async def cpf_cadastro(cpf: str) -> dict[str, Any]:
+async def cpf_cadastro(req: CPFCadastroRequest) -> dict[str, Any]:
     """Consulta a situacao cadastral do CPF via provedor premium opcional cpfcnpj.com.br.
 
-    Valida o digito verificador (HTTP 400 se invalido) antes de consultar. Requer
-    CPFCNPJ_TOKEN; sem token ou com CPF inexistente na Receita, responde 502 com a
-    mensagem do provedor.
+    O CPF vai no corpo JSON (``{"cpf": "..."}``), nunca no path: assim o numero
+    completo nao aparece em log de acesso, trace ou proxy. Valida o digito verificador
+    (HTTP 400 se invalido) antes de consultar. Requer CPFCNPJ_TOKEN; sem token ou com
+    CPF inexistente na Receita, responde 502 com a mensagem do provedor.
     """
     try:
-        resultado = await consultar_cpf_tool(_validated_cpf(cpf))
+        resultado = await consultar_cpf_tool(_validated_cpf(req.cpf))
     except FiscalError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     return resultado.model_dump(mode="json", exclude_none=True)

--- a/src/mcp_fiscal_brasil/api.py
+++ b/src/mcp_fiscal_brasil/api.py
@@ -26,7 +26,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 from . import __version__
-from ._core import FiscalHTTPError, get_logger
+from ._core import FiscalError, FiscalHTTPError, get_logger
 from ._core.config import settings
 from .agentic import (
     analyze_cnpj_compliance,
@@ -37,11 +37,11 @@ from .agentic import (
 )
 from .cep.client import CEPClient
 from .cnpj.tools import consultar_cnpj
-from .cpf.tools import validar_cpf_tool
+from .cpf.tools import consultar_cpf_tool, validar_cpf_tool
 from .ibge.client import IBGEClient
 from .nfe.status_sefaz import obter_status_certificado
 from .nfe.tools import UFS_VALIDAS, consultar_status_sefaz, validar_chave_nfe
-from .shared.validators import normalizar_cnpj, validate_cnpj_qualquer
+from .shared.validators import normalizar_cnpj, validate_cnpj_qualquer, validate_cpf
 from .simples.client import SimplesClient
 
 logger = get_logger(__name__)
@@ -64,6 +64,14 @@ def _validated_cnpj(cnpj: str) -> str:
     if not validate_cnpj_qualquer(cnpj):
         raise HTTPException(status_code=400, detail="CNPJ inválido")
     return normalizar_cnpj(cnpj)
+
+
+def _validated_cpf(cpf: str) -> str:
+    # Valida o digito verificador antes de qualquer consulta ao provedor premium,
+    # para nao gastar credito com CPF malformado (mesmo padrao de _validated_cnpj).
+    if not validate_cpf(cpf):
+        raise HTTPException(status_code=400, detail="CPF inválido")
+    return cpf
 
 
 def _allowed_file_base_dir() -> Path:
@@ -142,6 +150,25 @@ async def cnpj_lookup(cnpj: str) -> dict[str, Any]:
 async def cpf_validate(cpf: str) -> dict[str, Any]:
     """Valida CPF brasileiro (verificacao offline)."""
     resultado = await validar_cpf_tool(cpf)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.get(
+    "/v1/cpf/{cpf}/cadastro",
+    tags=["cpf"],
+    summary="Situacao cadastral do CPF (premium, opt-in)",
+)
+async def cpf_cadastro(cpf: str) -> dict[str, Any]:
+    """Consulta a situacao cadastral do CPF via provedor premium opcional cpfcnpj.com.br.
+
+    Valida o digito verificador (HTTP 400 se invalido) antes de consultar. Requer
+    CPFCNPJ_TOKEN; sem token ou com CPF inexistente na Receita, responde 502 com a
+    mensagem do provedor.
+    """
+    try:
+        resultado = await consultar_cpf_tool(_validated_cpf(cpf))
+    except FiscalError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
     return resultado.model_dump(mode="json", exclude_none=True)
 
 

--- a/src/mcp_fiscal_brasil/cpf/__init__.py
+++ b/src/mcp_fiscal_brasil/cpf/__init__.py
@@ -1,4 +1,21 @@
-from .client import format_cpf, unformat_cpf, validate_cpf
-from .schemas import CPFValidation
+from .client import CPFClient, format_cpf, mascarar_cpf, unformat_cpf, validate_cpf
+from .schemas import (
+    ComprovanteCPF,
+    CPFCadastro,
+    CPFValidation,
+    EnderecoCPF,
+    SituacaoCPF,
+)
 
-__all__ = ["CPFValidation", "format_cpf", "unformat_cpf", "validate_cpf"]
+__all__ = [
+    "CPFCadastro",
+    "CPFClient",
+    "CPFValidation",
+    "ComprovanteCPF",
+    "EnderecoCPF",
+    "SituacaoCPF",
+    "format_cpf",
+    "mascarar_cpf",
+    "unformat_cpf",
+    "validate_cpf",
+]

--- a/src/mcp_fiscal_brasil/cpf/client.py
+++ b/src/mcp_fiscal_brasil/cpf/client.py
@@ -1,4 +1,49 @@
-from .schemas import CPFValidation
+import unicodedata
+from typing import Any
+
+from mcp_fiscal_brasil._core import FiscalError, FiscalHTTPError, get_logger, settings
+
+from ..shared import cpfcnpj as cpfcnpj_provider
+from .schemas import (
+    SITUACAO_REGULAR,
+    SITUACOES_CPF,
+    ComprovanteCPF,
+    CPFCadastro,
+    CPFValidation,
+    EnderecoCPF,
+    SituacaoCPF,
+)
+
+logger = get_logger(__name__)
+
+# Codigo de erro do provedor para CPF valido mas ausente nas bases da Receita.
+ERRO_CPF_INEXISTENTE = 102
+
+# Texto que, sem codigo, indica situacao regular (apta a emissao).
+_SITUACAO_REGULAR_TEXTO = "regular"
+
+
+def _normalizar_situacao(texto: str) -> str:
+    """Normaliza o rotulo da situacao para comparacao: casefold sem acentos."""
+    decomposto = unicodedata.normalize("NFKD", texto.casefold())
+    return "".join(c for c in decomposto if not unicodedata.combining(c)).strip()
+
+
+# Rotulos conhecidos de situacao NAO regular (derivados da tabela oficial mais os
+# sinonimos genericos que o provedor pode devolver sem o codigo). Sao a evidencia
+# que autoriza apto_emissao=False; texto fora dessa lista fica indeterminado (None),
+# para nunca produzir True sem evidencia de regularidade.
+_SITUACOES_NAO_REGULARES = frozenset(
+    _normalizar_situacao(rotulo)
+    for codigo, rotulo in SITUACOES_CPF.items()
+    if codigo != SITUACAO_REGULAR
+) | {"cancelada", "cancelado", "cancelada de oficio", "falecido"}
+
+_SEM_TOKEN_CPF = (
+    "consultar_cpf exige o provedor premium opcional cpfcnpj.com.br: configure "
+    "CPFCNPJ_TOKEN. Nao ha fonte gratuita de situacao cadastral de CPF (a Receita "
+    "Federal nao publica API aberta de dados de pessoa fisica)."
+)
 
 
 def unformat_cpf(cpf: str) -> str:
@@ -43,3 +88,165 @@ def validate_cpf(cpf: str) -> CPFValidation:
     return CPFValidation(
         cpf_formatado=format_cpf(clean_cpf), válido=digitos_ok, digitos_verificadores_ok=digitos_ok
     )
+
+
+def mascarar_cpf(cpf: str) -> str:
+    """Mascara um CPF para uso em log e resposta (``***.***.***-XX``).
+
+    Preserva apenas os dois digitos verificadores (que sao derivaveis dos nove
+    primeiros), evitando expor o numero completo do titular.
+    """
+    digitos = unformat_cpf(cpf)
+    if len(digitos) != 11:
+        return "***.***.***-**"
+    return f"***.***.***-{digitos[9:]}"
+
+
+def _texto(valor: Any) -> str | None:
+    """Normaliza um valor textual do provedor: None quando vazio."""
+    if valor is None:
+        return None
+    texto = str(valor).strip()
+    return texto or None
+
+
+def _inteiro(valor: Any) -> int | None:
+    """Converte um valor em inteiro quando possivel; None caso contrario."""
+    if valor is None or valor == "":
+        return None
+    try:
+        return int(valor)
+    except (TypeError, ValueError):
+        return None
+
+
+def _codigo_situacao(valor: Any) -> str | None:
+    """Normaliza o codigo de situacao para dois digitos (ex.: 3 -> "03")."""
+    texto = _texto(valor)
+    if texto is None:
+        return None
+    return texto.zfill(2) if texto.isdigit() else texto
+
+
+class CPFClient:
+    """Cliente de consulta cadastral de CPF pelo provedor premium opcional.
+
+    Diferente do CNPJ, nao existe fonte gratuita de situacao cadastral de CPF:
+    a consulta so acontece com CPFCNPJ_TOKEN configurado. A validacao do digito
+    verificador ocorre antes, na camada de tools/API/SDK, para nao gastar credito
+    com CPF malformado.
+    """
+
+    async def consultar(self, cpf: str) -> CPFCadastro:
+        """Consulta a situacao cadastral de um CPF no provedor premium.
+
+        Args:
+            cpf: CPF com ou sem mascara. Deve ter o digito verificador ja validado.
+
+        Returns:
+            CPFCadastro com os campos do pacote configurado (CPFCNPJ_CPF_PACKET).
+
+        Raises:
+            FiscalError: Quando o provedor nao esta configurado (sem token) ou
+                quando o CPF e valido mas nao consta na base da Receita (erro 102).
+            FiscalHTTPError: Demais erros do provedor, repassados sem traducao.
+        """
+        cpf_digitos = unformat_cpf(cpf)
+        if not cpfcnpj_provider.provedor_configurado():
+            raise FiscalError(_SEM_TOKEN_CPF)
+
+        pacote = settings.cpfcnpj_cpf_packet
+        # Nunca logar o CPF completo nem qualquer PII do titular.
+        logger.info("cpf_lookup_started", cpf=mascarar_cpf(cpf_digitos), pacote=pacote)
+        try:
+            data = await cpfcnpj_provider.consultar(pacote, cpf_digitos)
+        except FiscalHTTPError as exc:
+            if exc.status_code == ERRO_CPF_INEXISTENTE:
+                raise FiscalError(
+                    "O CPF informado e valido, mas nao consta na base da Receita "
+                    "Federal (nao existe)."
+                ) from exc
+            raise
+
+        return self._parse_cpfcnpj(data, cpf_digitos)
+
+    def _parse_cpfcnpj(self, data: dict[str, Any], cpf: str) -> CPFCadastro:
+        """Transforma a resposta de um pacote de CPF da cpfcnpj.com.br em CPFCadastro."""
+        situacao = self._parse_situacao(data)
+        apto_emissao = self._derivar_apto_emissao(situacao)
+
+        return CPFCadastro(
+            cpf=mascarar_cpf(cpf),
+            nome=_texto(data.get("nome")),
+            nome_social=_texto(data.get("nomeSocial")),
+            nascimento=_texto(data.get("nascimento")),
+            genero=_texto(data.get("genero")),
+            situacao=situacao,
+            endereco=self._parse_endereco(data),
+            comprovante=self._parse_comprovante(data),
+            apto_emissao=apto_emissao,
+            origem="cpfcnpj.com.br",
+        )
+
+    @staticmethod
+    def _parse_situacao(data: dict[str, Any]) -> SituacaoCPF | None:
+        codigo = _codigo_situacao(data.get("situacaoDigito"))
+        rotulo = _texto(data.get("situacao"))
+        motivo = _texto(data.get("situacaoMotivo"))
+        if codigo is None and rotulo is None and motivo is None:
+            return None
+        descricao = (SITUACOES_CPF.get(codigo) if codigo else None) or rotulo
+        return SituacaoCPF(
+            codigo=codigo,
+            descricao=descricao,
+            motivo=motivo,
+            data=_texto(data.get("situacaoComprovanteEmissao")),
+            ano_obito=_inteiro(data.get("situacaoAnoObito")),
+            inscricao=_texto(data.get("situacaoInscricao")),
+        )
+
+    @staticmethod
+    def _derivar_apto_emissao(situacao: SituacaoCPF | None) -> bool | None:
+        """Deriva se o CPF esta apto a emissao a partir da situacao cadastral.
+
+        Prioriza o codigo (``00`` -> apto). Quando o provedor devolve apenas o
+        rotulo textual (sem ``situacaoDigito``), deriva do texto normalizado:
+        "regular" -> True; rotulos conhecidos de irregularidade -> False; texto
+        vazio ou desconhecido -> None. Nunca retorna True sem evidencia.
+        """
+        if situacao is None:
+            return None
+        if situacao.codigo is not None:
+            return situacao.codigo == SITUACAO_REGULAR
+        if not situacao.descricao:
+            return None
+        normalizado = _normalizar_situacao(situacao.descricao)
+        if normalizado == _SITUACAO_REGULAR_TEXTO:
+            return True
+        if normalizado in _SITUACOES_NAO_REGULARES:
+            return False
+        return None
+
+    @staticmethod
+    def _parse_endereco(data: dict[str, Any]) -> EnderecoCPF | None:
+        campos = ("endereco", "numero", "complemento", "bairro", "cep", "cidade", "uf", "ibge")
+        if not any(_texto(data.get(campo)) for campo in campos):
+            return None
+        return EnderecoCPF(
+            logradouro=_texto(data.get("endereco")),
+            numero=_texto(data.get("numero")),
+            complemento=_texto(data.get("complemento")),
+            bairro=_texto(data.get("bairro")),
+            cep=_texto(data.get("cep")),
+            cidade=_texto(data.get("cidade")),
+            uf=_texto(data.get("uf")),
+            ibge=_texto(data.get("ibge")),
+        )
+
+    @staticmethod
+    def _parse_comprovante(data: dict[str, Any]) -> ComprovanteCPF | None:
+        numero = _texto(data.get("situacaoComprovante"))
+        pdf = _texto(data.get("situacaoComprovantePdf"))
+        if numero is None and pdf is None:
+            return None
+        return ComprovanteCPF(numero=numero, pdf_base64=pdf)

--- a/src/mcp_fiscal_brasil/cpf/schemas.py
+++ b/src/mcp_fiscal_brasil/cpf/schemas.py
@@ -1,7 +1,77 @@
 from pydantic import BaseModel
 
+# Codigos de situacao cadastral do CPF na Receita Federal. A API devolve o codigo
+# em ``situacaoDigito`` (ex.: "03") e, por vezes, um rotulo generico em ``situacao``
+# (ex.: "Cancelada"); esta tabela dá a descrição oficial por codigo, preferida no
+# mapeamento. Para a regra fiscal, apenas 00 (Regular) libera a emissao de documentos.
+SITUACOES_CPF: dict[str, str] = {
+    "00": "Regular",
+    "02": "Suspensa",
+    "03": "Titular Falecido",
+    "04": "Pendente de Regularização",
+    "05": "Cancelada por Multiplicidade",
+    "08": "Nula",
+    "09": "Cancelada de Ofício",
+}
+
+# Unica situacao que permite emitir documento fiscal para a pessoa fisica.
+SITUACAO_REGULAR = "00"
+
 
 class CPFValidation(BaseModel):
     cpf_formatado: str
     válido: bool
     digitos_verificadores_ok: bool
+
+
+class SituacaoCPF(BaseModel):
+    """Situacao cadastral do CPF na Receita Federal."""
+
+    codigo: str | None = None
+    descricao: str | None = None
+    motivo: str | None = None
+    data: str | None = None
+    ano_obito: int | None = None
+    inscricao: str | None = None
+
+
+class EnderecoCPF(BaseModel):
+    """Endereco do titular (retornado apenas no pacote 3)."""
+
+    logradouro: str | None = None
+    numero: str | None = None
+    complemento: str | None = None
+    bairro: str | None = None
+    cep: str | None = None
+    cidade: str | None = None
+    uf: str | None = None
+    ibge: str | None = None
+
+
+class ComprovanteCPF(BaseModel):
+    """Comprovante de situacao cadastral emitido pela Receita (apenas no pacote 8)."""
+
+    numero: str | None = None
+    pdf_base64: str | None = None
+
+
+class CPFCadastro(BaseModel):
+    """Cadastro do CPF consultado no provedor premium opcional cpfcnpj.com.br.
+
+    O CPF vem mascarado (``***.***.***-XX``, so os digitos verificadores). Campos
+    ausentes no pacote escolhido ficam ``None``. Campos operacionais do provedor
+    (saldo, consultaID, pacoteUsado) nao sao expostos.
+    """
+
+    cpf: str
+    nome: str | None = None
+    nome_social: str | None = None
+    nascimento: str | None = None
+    genero: str | None = None
+    situacao: SituacaoCPF | None = None
+    endereco: EnderecoCPF | None = None
+    comprovante: ComprovanteCPF | None = None
+    # Derivado: True apenas com situacao Regular (00); False para as demais
+    # situacoes conhecidas; None quando o pacote escolhido nao traz situacao.
+    apto_emissao: bool | None = None
+    origem: str = "cpfcnpj.com.br"

--- a/src/mcp_fiscal_brasil/cpf/tools.py
+++ b/src/mcp_fiscal_brasil/cpf/tools.py
@@ -1,7 +1,9 @@
 """Ferramentas MCP para CPF."""
 
-from .client import validate_cpf
-from .schemas import CPFValidation
+from .client import CPFClient, validate_cpf
+from .schemas import CPFCadastro, CPFValidation
+
+_client = CPFClient()
 
 
 async def validar_cpf_tool(cpf: str) -> CPFValidation:
@@ -18,3 +20,36 @@ async def validar_cpf_tool(cpf: str) -> CPFValidation:
         CPFValidation indicando se o CPF é matematicamente válido.
     """
     return validate_cpf(cpf)
+
+
+async def consultar_cpf_tool(cpf: str) -> CPFCadastro:
+    """
+    Consulta a situação cadastral de um CPF na Receita Federal (premium, opt-in).
+
+    Finalidade fiscal: conferir o destinatário de NF-e/NFC-e ou o tomador de NFS-e
+    (pessoa física) antes de emitir o documento. Não é uma ferramenta de localização
+    de pessoas. Emitir para CPF cancelado por óbito, nulo ou cancelado de ofício gera
+    documento fiscal com destinatário inválido e passivo para o emitente.
+
+    Requer o provedor premium opcional cpfcnpj.com.br (CPFCNPJ_TOKEN): não existe fonte
+    gratuita de situação cadastral de CPF. O dígito verificador é validado localmente
+    antes de qualquer chamada, para não gastar crédito com CPF malformado. O pacote é
+    definido por CPFCNPJ_CPF_PACKET (padrão 26: nome, nascimento e situação).
+
+    Privacidade: o CPF é mascarado em todo log (***.***.***-XX); o PDF do comprovante
+    (pacote 8) nunca passa por log; campos operacionais do provedor (saldo, consultaID,
+    pacote usado) não são retornados.
+
+    Args:
+        cpf: Número do CPF com ou sem formatação (ex: '123.456.789-09' ou '12345678909').
+
+    Returns:
+        CPFCadastro com situação cadastral, descrição oficial e o derivado apto_emissao
+        (verdadeiro apenas quando a situação é Regular).
+
+    Raises:
+        ValueError: Se o CPF for inválido (dígito verificador).
+    """
+    if not validate_cpf(cpf).válido:
+        raise ValueError(f"CPF inválido: {cpf}. Verifique os 11 dígitos e o dígito verificador.")
+    return await _client.consultar(cpf)

--- a/src/mcp_fiscal_brasil/sdk.py
+++ b/src/mcp_fiscal_brasil/sdk.py
@@ -35,6 +35,8 @@ from typing import Any
 
 from .cnpj.client import CNPJClient
 from .cnpj.schemas import CNPJResponse
+from .cpf.client import CPFClient
+from .cpf.schemas import CPFCadastro
 from .nfe.client import NFEClient
 from .nfe.schemas import NFeResponse, StatusSEFAZResponse
 from .shared.validators import validate_chave_nfe, validate_cnpj_qualquer, validate_cpf
@@ -64,6 +66,7 @@ class FiscalBrasil:
 
     def __init__(self) -> None:
         self._cnpj_client = CNPJClient()
+        self._cpf_client = CPFClient()
         self._nfe_client = NFEClient()
         self._simples_client = SimplesClient()
 
@@ -159,6 +162,34 @@ class FiscalBrasil:
             fiscal.validar_cpf("111.111.111-11")  # False (sequência repetida)
         """
         return validate_cpf(cpf)
+
+    async def consultar_cpf(self, cpf: str) -> CPFCadastro:
+        """
+        Consulta a situação cadastral de um CPF na Receita Federal (premium, opt-in).
+
+        Requer o provedor premium opcional cpfcnpj.com.br (``CPFCNPJ_TOKEN``): não há
+        fonte gratuita de dados de CPF. O dígito verificador é validado localmente
+        antes de qualquer chamada. O pacote é definido por ``CPFCNPJ_CPF_PACKET``
+        (padrão 26: nome, nascimento e situação cadastral). Uso previsto: conferir o
+        destinatário/tomador pessoa física antes de emitir documento fiscal.
+
+        Args:
+            cpf: CPF com ou sem máscara (ex: "529.982.247-25" ou "52998224725").
+
+        Returns:
+            CPFCadastro com situação cadastral e o derivado apto_emissao.
+
+        Raises:
+            ValueError: Se o CPF for inválido (dígito verificador).
+            FiscalError: Sem token configurado ou CPF inexistente na Receita.
+
+        Exemplo:
+            cadastro = await fiscal.consultar_cpf("529.982.247-25")
+            print(cadastro.apto_emissao)
+        """
+        if not validate_cpf(cpf):
+            raise ValueError(f"CPF inválido: {cpf}")
+        return await self._cpf_client.consultar(cpf)
 
     # ------------------------------------------------------------------
     # NFe
@@ -404,6 +435,21 @@ class FiscalBrasil:
             CNPJResponse com os dados da empresa.
         """
         return asyncio.run(self.consultar_cnpj(cnpj))
+
+    def consultar_cpf_sync(self, cpf: str) -> CPFCadastro:
+        """
+        Versão síncrona de consultar_cpf. Útil em contextos não-async (Django, scripts).
+
+        Não use dentro de um event loop já ativo (ex: FastAPI, Jupyter).
+        Prefira o método assíncrono nesses casos.
+
+        Args:
+            cpf: CPF com ou sem máscara.
+
+        Returns:
+            CPFCadastro com a situação cadastral do titular.
+        """
+        return asyncio.run(self.consultar_cpf(cpf))
 
     def consultar_simples_sync(self, cnpj: str) -> SimplesStatus:
         """

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -29,7 +29,7 @@ from .cnae import _tools as cnae_tools
 
 # Importa todas as ferramentas dos modulos fiscais
 from .cnpj.tools import consultar_cnpj, listar_cnpjs_por_nome
-from .cpf.tools import validar_cpf_tool
+from .cpf.tools import consultar_cpf_tool, validar_cpf_tool
 from .empresa import _tools as empresa_tools
 from .esocial.tools import listar_eventos_esocial, validar_evento_esocial
 from .ibge import _tools as ibge_tools
@@ -211,6 +211,38 @@ async def tool_validar_cpf(cpf: str) -> dict[str, Any]:
         dict indicando se o CPF e matematicamente valido, com versao formatada e motivo da reprovacao.
     """
     resultado = await validar_cpf_tool(cpf)
+    return resultado.model_dump(mode="json", exclude_none=True)
+
+
+@app.tool(
+    name="consultar_cpf",
+    description=(
+        "Consulta a situação cadastral de um CPF na Receita Federal para conferir "
+        "destinatário de NF-e/NFC-e ou tomador de NFS-e (pessoa física) antes de emitir "
+        "o documento fiscal. Não é ferramenta de localização de pessoas. "
+        "Requer o provedor premium opcional cpfcnpj.com.br (CPFCNPJ_TOKEN): não há fonte "
+        "gratuita de dados de CPF. Valida o dígito verificador localmente antes de "
+        "consultar. Retorna situação (Regular, Suspensa, Cancelada, Titular Falecido, "
+        "Nula) e o campo apto_emissao (verdadeiro só quando Regular). CPF mascarado em "
+        "todo log; pacote definido por CPFCNPJ_CPF_PACKET (padrão 26)."
+    ),
+)
+async def tool_consultar_cpf(cpf: str) -> dict[str, Any]:
+    """Consulta a situacao cadastral de um CPF pelo provedor premium opcional (opt-in).
+
+    Verifica se o titular esta Regular na Receita Federal antes de emitir NF-e, NFC-e ou
+    NFS-e a pessoa fisica. Exige CPFCNPJ_TOKEN; sem token, levanta erro amigavel. O CPF e
+    mascarado em todo log e os campos operacionais do provedor nao sao expostos.
+
+    Args:
+        cpf: Numero do CPF com 11 digitos, com ou sem formatacao
+            (ex.: "123.456.789-09" ou "12345678909").
+
+    Returns:
+        dict com nome, nascimento, situacao cadastral (codigo e descricao) e o derivado
+        apto_emissao; endereco (pacote 3) e comprovante em PDF (pacote 8) quando aplicavel.
+    """
+    resultado = await consultar_cpf_tool(cpf)
     return resultado.model_dump(mode="json", exclude_none=True)
 
 

--- a/src/mcp_fiscal_brasil/server.py
+++ b/src/mcp_fiscal_brasil/server.py
@@ -222,9 +222,11 @@ async def tool_validar_cpf(cpf: str) -> dict[str, Any]:
         "o documento fiscal. Não é ferramenta de localização de pessoas. "
         "Requer o provedor premium opcional cpfcnpj.com.br (CPFCNPJ_TOKEN): não há fonte "
         "gratuita de dados de CPF. Valida o dígito verificador localmente antes de "
-        "consultar. Retorna situação (Regular, Suspensa, Cancelada, Titular Falecido, "
-        "Nula) e o campo apto_emissao (verdadeiro só quando Regular). CPF mascarado em "
-        "todo log; pacote definido por CPFCNPJ_CPF_PACKET (padrão 26)."
+        "consultar. Só os pacotes 26 e 8 retornam situação cadastral (Regular, Suspensa, "
+        "Titular Falecido, Pendente de Regularização, Cancelada por Multiplicidade, Nula, "
+        "Cancelada de Ofício) e o campo apto_emissao (verdadeiro só quando Regular); nos "
+        "pacotes 1 e 3 esses campos ficam ausentes, e a ausência não autoriza emissão "
+        "fiscal. CPF mascarado em todo log; pacote definido por CPFCNPJ_CPF_PACKET (padrão 26)."
     ),
 )
 async def tool_consultar_cpf(cpf: str) -> dict[str, Any]:

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -34,23 +34,48 @@ PACOTE_CPF = 26
 
 # Teto de requisicoes por segundo da cpfcnpj.com.br. Cada consulta abre um
 # HTTPClient novo, entao o limitador precisa ser compartilhado por todas as
-# instancias/chamadas: sem isso, consultas concorrentes (CNPJ pacotes 5/6 e
-# NF-e/NFC-e pacotes 100/102) somariam limitadores independentes e poderiam
-# ultrapassar o teto, recebendo o erro 1007 (HTTP 429).
+# instancias/chamadas: sem isso, consultas concorrentes somariam limitadores
+# independentes e poderiam ultrapassar o teto, recebendo o erro 1007 (HTTP 429).
+# A maioria dos pacotes (CPF/CNPJ/IE) segue 20 req/s. Os pacotes de NF-e/NFC-e
+# por chave (100/102) tem teto proprio de 2 req/s por conta na documentacao do
+# provedor; ultrapassar devolve HTTP 429 + erroCodigo 1007 (sem cobrar credito).
 CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO = 20
+CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO = 2
 
-_limiter: AsyncLimiter | None = None
+# Pacotes com teto reduzido de requisicoes por segundo.
+PACOTES_LIMITE_REDUZIDO = frozenset({PACOTE_NFE, PACOTE_NFCE})
+
+_limiter_padrao: AsyncLimiter | None = None
+_limiter_nfe: AsyncLimiter | None = None
 
 
-def _get_limiter() -> AsyncLimiter:
-    """Retorna o limitador unico (singleton de modulo) compartilhado pela API."""
-    global _limiter
-    if _limiter is None:
-        _limiter = AsyncLimiter(
+def _rate_limit_para(pacote: int) -> int:
+    """Teto de req/s do pacote: 2 para NF-e/NFC-e (100/102), 20 para os demais."""
+    if pacote in PACOTES_LIMITE_REDUZIDO:
+        return CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO
+    return CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO
+
+
+def _get_limiter(pacote: int) -> AsyncLimiter:
+    """Retorna o limitador (singleton de modulo) do pacote.
+
+    Os pacotes 100/102 compartilham um limitador de 2 req/s entre si; todos os
+    demais compartilham o limitador de 20 req/s. Cada limitador e criado uma vez.
+    """
+    global _limiter_padrao, _limiter_nfe
+    if pacote in PACOTES_LIMITE_REDUZIDO:
+        if _limiter_nfe is None:
+            _limiter_nfe = AsyncLimiter(
+                CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO,
+                CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO,
+            )
+        return _limiter_nfe
+    if _limiter_padrao is None:
+        _limiter_padrao = AsyncLimiter(
             CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
             CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
         )
-    return _limiter
+    return _limiter_padrao
 
 
 def provedor_configurado() -> bool:
@@ -58,14 +83,20 @@ def provedor_configurado() -> bool:
     return bool(settings.cpfcnpj_token.strip())
 
 
-def _http_client() -> HTTPClient:
+def _http_client(pacote: int) -> HTTPClient:
     return HTTPClient(
         settings.cpfcnpj_base_url,
-        timeout=settings.mcp_fiscal_http_timeout,
+        timeout=settings.cpfcnpj_timeout,
         max_retries=settings.mcp_fiscal_max_retries,
         cache_ttl=settings.mcp_fiscal_cache_ttl,
-        rate_limit_per_second=CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
-        limiter=_get_limiter(),
+        rate_limit_per_second=_rate_limit_para(pacote),
+        limiter=_get_limiter(pacote),
+        # O token viaja no primeiro segmento do path: mascarar nos erros. Passar
+        # o token como segredo literal cobre tambem bases com prefixo de path
+        # (ex.: CPFCNPJ_BASE_URL=https://proxy/cpfcnpj), removendo-o de qualquer
+        # url/mensagem/details mesmo fora do formato esperado.
+        mask_first_path_segment=True,
+        mask_secret=settings.cpfcnpj_token.strip() or None,
     )
 
 
@@ -93,7 +124,7 @@ async def consultar(pacote: int, documento: str) -> dict[str, Any]:
         )
 
     path = f"/{token}/{pacote}/{documento}"
-    async with _http_client() as client:
+    async with _http_client(pacote) as client:
         data = await client.get(path)
 
     if data.get("status") != 1:

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -28,6 +28,9 @@ logger = get_logger(__name__)
 # Pacotes de consulta na cpfcnpj.com.br.
 PACOTE_NFE = 100
 PACOTE_NFCE = 102
+# Pacote padrao de CPF: 26 (CPF D Simplificado), o mais barato que traz situacao
+# cadastral. O pacote efetivo vem de settings.cpfcnpj_cpf_packet.
+PACOTE_CPF = 26
 
 # Teto de requisicoes por segundo da cpfcnpj.com.br. Cada consulta abre um
 # HTTPClient novo, entao o limitador precisa ser compartilhado por todas as
@@ -107,6 +110,7 @@ async def consultar(pacote: int, documento: str) -> dict[str, Any]:
 
 
 __all__ = [
+    "PACOTE_CPF",
     "PACOTE_NFCE",
     "PACOTE_NFE",
     "consultar",

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -71,21 +71,21 @@ class _LimitadorDeProcesso:
         self._agendadas: deque[float] = deque()
 
     async def acquire(self, amount: float = 1) -> None:
-        with self._lock:
-            agora = time.monotonic()
-            limite = agora - self.janela
-            while self._agendadas and self._agendadas[0] <= limite:
-                self._agendadas.popleft()
-            if len(self._agendadas) < self.taxa:
-                parte_em = agora
-            else:
-                parte_em = self._agendadas[0] + self.janela
-            self._agendadas.append(parte_em)
-            if len(self._agendadas) > self.taxa:
-                self._agendadas.popleft()
-            espera = parte_em - agora
-        if espera > 0:
-            await asyncio.sleep(espera)
+        # A vaga so e registrada quando existe de fato: depois de dormir, a janela
+        # e reavaliada sob o lock, porque outra tarefa (ou thread) pode ter ocupado
+        # o espaco enquanto esta esperava. Assim nenhuma requisicao parte com a
+        # janela cheia, mesmo se o sleep retomar atrasado.
+        while True:
+            with self._lock:
+                agora = time.monotonic()
+                limite = agora - self.janela
+                while self._agendadas and self._agendadas[0] <= limite:
+                    self._agendadas.popleft()
+                if len(self._agendadas) < self.taxa:
+                    self._agendadas.append(agora)
+                    return
+                espera = self._agendadas[0] + self.janela - agora
+            await asyncio.sleep(max(0.0, espera))
 
 
 def _rate_limit_para(pacote: int) -> int:

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -13,10 +13,10 @@ dos campos ``erro`` e ``erroCodigo``.
 from __future__ import annotations
 
 import asyncio
-import weakref
+import threading
+import time
+from collections import deque
 from typing import Any
-
-from aiolimiter import AsyncLimiter
 
 from mcp_fiscal_brasil._core import (
     FiscalHTTPError,
@@ -35,30 +35,57 @@ PACOTE_NFCE = 102
 PACOTE_CPF = 26
 
 # Teto de requisicoes por segundo da cpfcnpj.com.br. Cada consulta abre um
-# HTTPClient novo, entao o limitador precisa ser compartilhado por todas as
-# instancias/chamadas do mesmo event loop: sem isso, consultas concorrentes
-# somariam limitadores independentes e poderiam ultrapassar o teto, recebendo o
-# erro 1007 (HTTP 429). A maioria dos pacotes (CPF/CNPJ/IE) segue 20 req/s. Os
-# pacotes de NF-e/NFC-e por chave (100/102) tem teto proprio de 2 req/s por conta
-# na documentacao do provedor; ultrapassar devolve HTTP 429 + erroCodigo 1007
-# (sem cobrar credito).
+# HTTPClient novo, entao o limitador precisa coordenar o teto por todo o processo,
+# entre event loops distintos: os metodos sincronos do SDK (consultar_cpf_sync/
+# consultar_cnpj_sync) chamam asyncio.run, abrindo um loop novo a cada chamada. Sem
+# isso, chamadas sincronas sucessivas somariam orcamentos independentes e poderiam
+# ultrapassar o teto, recebendo o erro 1007 (HTTP 429). A maioria dos pacotes
+# (CPF/CNPJ/IE) segue 20 req/s. Os pacotes de NF-e/NFC-e por chave (100/102) tem teto
+# proprio de 2 req/s por conta na documentacao do provedor; ultrapassar devolve
+# HTTP 429 + erroCodigo 1007 (sem cobrar credito).
 CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO = 20
 CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO = 2
 
 # Pacotes com teto reduzido de requisicoes por segundo.
 PACOTES_LIMITE_REDUZIDO = frozenset({PACOTE_NFE, PACOTE_NFCE})
 
-# Limitadores por (event loop em execucao, grupo de req/s). O aiolimiter amarra o
-# AsyncLimiter ao event loop corrente (usa call_later/eventos do loop ao adquirir),
-# entao reusar o mesmo objeto entre loops quebra: consultar_cpf_sync/consultar_cnpj_sync
-# do SDK chamam asyncio.run, abrindo um loop novo a cada chamada. Guardar um
-# limitador por loop, com WeakKeyDictionary, deixa o GC recolher a entrada quando o
-# loop e coletado, sem vazar limitadores de loops mortos. Fora de um loop em
-# execucao (construcao sincrona, ex.: testes), cai no conjunto de fallback de modulo.
-_limiters_por_loop: weakref.WeakKeyDictionary[
-    asyncio.AbstractEventLoop, dict[int, AsyncLimiter]
-] = weakref.WeakKeyDictionary()
-_limiters_sem_loop: dict[int, AsyncLimiter] = {}
+
+class _LimitadorDeProcesso:
+    """Limitador de requisicoes por segundo compartilhado por todo o processo.
+
+    Independe do event loop: nao guarda referencia a loop algum. Ao adquirir, calcula
+    sob o lock o instante em que a proxima requisicao pode partir, reserva a vaga e
+    dorme no loop corrente ate ela (asyncio.sleep). Assim varios ``asyncio.run``
+    consecutivos (como os dos metodos sincronos do SDK) dividem o mesmo orcamento e
+    nada acumula por loop. O agendamento e protegido por um ``threading.Lock``, entao
+    tambem e seguro entre threads.
+
+    Usa uma janela deslizante de ``janela`` segundos: ate ``taxa`` requisicoes cabem
+    na janela sem espera; a seguinte so parte quando a mais antiga sai da janela.
+    """
+
+    def __init__(self, taxa: int, janela: float = 1.0) -> None:
+        self.taxa = taxa
+        self.janela = janela
+        self._lock = threading.Lock()
+        self._agendadas: deque[float] = deque()
+
+    async def acquire(self, amount: float = 1) -> None:
+        with self._lock:
+            agora = time.monotonic()
+            limite = agora - self.janela
+            while self._agendadas and self._agendadas[0] <= limite:
+                self._agendadas.popleft()
+            if len(self._agendadas) < self.taxa:
+                parte_em = agora
+            else:
+                parte_em = self._agendadas[0] + self.janela
+            self._agendadas.append(parte_em)
+            if len(self._agendadas) > self.taxa:
+                self._agendadas.popleft()
+            espera = parte_em - agora
+        if espera > 0:
+            await asyncio.sleep(espera)
 
 
 def _rate_limit_para(pacote: int) -> int:
@@ -68,28 +95,28 @@ def _rate_limit_para(pacote: int) -> int:
     return CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO
 
 
-def _get_limiter(pacote: int) -> AsyncLimiter:
-    """Retorna o limitador do grupo do pacote para o event loop em execucao.
+# Um limitador por grupo de req/s (20 padrao, 2 para NF-e/NFC-e), singleton de
+# modulo compartilhado entre todos os event loops e threads do processo.
+_limitadores_por_grupo: dict[int, _LimitadorDeProcesso] = {}
+_limitadores_lock = threading.Lock()
+
+
+def _get_limiter(pacote: int) -> _LimitadorDeProcesso:
+    """Retorna o limitador de processo do grupo do pacote (singleton por grupo).
 
     Pacotes 100/102 compartilham um limitador de 2 req/s; os demais, um de 20 req/s.
-    Cada event loop tem o seu proprio conjunto: o AsyncLimiter nao pode ser reusado
-    entre loops (o aiolimiter o amarra ao loop corrente), entao dentro de um mesmo
-    loop o mesmo grupo devolve o mesmo objeto, e loops distintos recebem objetos
-    distintos. Sem loop em execucao, usa um conjunto de fallback de modulo.
+    O mesmo objeto e devolvido em qualquer event loop ou thread, entao o teto vale
+    por processo e nao acumula estado por loop.
     """
     grupo = _rate_limit_para(pacote)
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        por_grupo = _limiters_sem_loop
-    else:
-        por_grupo = _limiters_por_loop.setdefault(loop, {})
-
-    limiter = por_grupo.get(grupo)
-    if limiter is None:
-        limiter = AsyncLimiter(grupo, grupo)
-        por_grupo[grupo] = limiter
-    return limiter
+    limitador = _limitadores_por_grupo.get(grupo)
+    if limitador is None:
+        with _limitadores_lock:
+            limitador = _limitadores_por_grupo.get(grupo)
+            if limitador is None:
+                limitador = _LimitadorDeProcesso(grupo)
+                _limitadores_por_grupo[grupo] = limitador
+    return limitador
 
 
 def provedor_configurado() -> bool:

--- a/src/mcp_fiscal_brasil/shared/cpfcnpj.py
+++ b/src/mcp_fiscal_brasil/shared/cpfcnpj.py
@@ -12,6 +12,8 @@ dos campos ``erro`` e ``erroCodigo``.
 
 from __future__ import annotations
 
+import asyncio
+import weakref
 from typing import Any
 
 from aiolimiter import AsyncLimiter
@@ -34,19 +36,29 @@ PACOTE_CPF = 26
 
 # Teto de requisicoes por segundo da cpfcnpj.com.br. Cada consulta abre um
 # HTTPClient novo, entao o limitador precisa ser compartilhado por todas as
-# instancias/chamadas: sem isso, consultas concorrentes somariam limitadores
-# independentes e poderiam ultrapassar o teto, recebendo o erro 1007 (HTTP 429).
-# A maioria dos pacotes (CPF/CNPJ/IE) segue 20 req/s. Os pacotes de NF-e/NFC-e
-# por chave (100/102) tem teto proprio de 2 req/s por conta na documentacao do
-# provedor; ultrapassar devolve HTTP 429 + erroCodigo 1007 (sem cobrar credito).
+# instancias/chamadas do mesmo event loop: sem isso, consultas concorrentes
+# somariam limitadores independentes e poderiam ultrapassar o teto, recebendo o
+# erro 1007 (HTTP 429). A maioria dos pacotes (CPF/CNPJ/IE) segue 20 req/s. Os
+# pacotes de NF-e/NFC-e por chave (100/102) tem teto proprio de 2 req/s por conta
+# na documentacao do provedor; ultrapassar devolve HTTP 429 + erroCodigo 1007
+# (sem cobrar credito).
 CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO = 20
 CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO = 2
 
 # Pacotes com teto reduzido de requisicoes por segundo.
 PACOTES_LIMITE_REDUZIDO = frozenset({PACOTE_NFE, PACOTE_NFCE})
 
-_limiter_padrao: AsyncLimiter | None = None
-_limiter_nfe: AsyncLimiter | None = None
+# Limitadores por (event loop em execucao, grupo de req/s). O aiolimiter amarra o
+# AsyncLimiter ao event loop corrente (usa call_later/eventos do loop ao adquirir),
+# entao reusar o mesmo objeto entre loops quebra: consultar_cpf_sync/consultar_cnpj_sync
+# do SDK chamam asyncio.run, abrindo um loop novo a cada chamada. Guardar um
+# limitador por loop, com WeakKeyDictionary, deixa o GC recolher a entrada quando o
+# loop e coletado, sem vazar limitadores de loops mortos. Fora de um loop em
+# execucao (construcao sincrona, ex.: testes), cai no conjunto de fallback de modulo.
+_limiters_por_loop: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, dict[int, AsyncLimiter]
+] = weakref.WeakKeyDictionary()
+_limiters_sem_loop: dict[int, AsyncLimiter] = {}
 
 
 def _rate_limit_para(pacote: int) -> int:
@@ -57,25 +69,27 @@ def _rate_limit_para(pacote: int) -> int:
 
 
 def _get_limiter(pacote: int) -> AsyncLimiter:
-    """Retorna o limitador (singleton de modulo) do pacote.
+    """Retorna o limitador do grupo do pacote para o event loop em execucao.
 
-    Os pacotes 100/102 compartilham um limitador de 2 req/s entre si; todos os
-    demais compartilham o limitador de 20 req/s. Cada limitador e criado uma vez.
+    Pacotes 100/102 compartilham um limitador de 2 req/s; os demais, um de 20 req/s.
+    Cada event loop tem o seu proprio conjunto: o AsyncLimiter nao pode ser reusado
+    entre loops (o aiolimiter o amarra ao loop corrente), entao dentro de um mesmo
+    loop o mesmo grupo devolve o mesmo objeto, e loops distintos recebem objetos
+    distintos. Sem loop em execucao, usa um conjunto de fallback de modulo.
     """
-    global _limiter_padrao, _limiter_nfe
-    if pacote in PACOTES_LIMITE_REDUZIDO:
-        if _limiter_nfe is None:
-            _limiter_nfe = AsyncLimiter(
-                CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO,
-                CPFCNPJ_NFE_MAX_REQUISICOES_POR_SEGUNDO,
-            )
-        return _limiter_nfe
-    if _limiter_padrao is None:
-        _limiter_padrao = AsyncLimiter(
-            CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
-            CPFCNPJ_MAX_REQUISICOES_POR_SEGUNDO,
-        )
-    return _limiter_padrao
+    grupo = _rate_limit_para(pacote)
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        por_grupo = _limiters_sem_loop
+    else:
+        por_grupo = _limiters_por_loop.setdefault(loop, {})
+
+    limiter = por_grupo.get(grupo)
+    if limiter is None:
+        limiter = AsyncLimiter(grupo, grupo)
+        por_grupo[grupo] = limiter
+    return limiter
 
 
 def provedor_configurado() -> bool:
@@ -133,7 +147,10 @@ async def consultar(pacote: int, documento: str) -> dict[str, Any]:
         raise FiscalHTTPError(
             f"cpfcnpj.com.br retornou erro: {mensagem}",
             status_code=int(codigo) if isinstance(codigo, int) else 0,
-            url=f"{settings.cpfcnpj_base_url}/***/{pacote}/{documento}",
+            # Mascara o token (1o segmento) e tambem o documento (ultimo segmento):
+            # a url viaja para access log/trace/proxy e nao pode expor o CPF/CNPJ/chave
+            # consultado. A url real da requisicao (path acima) nao e alterada.
+            url=f"{settings.cpfcnpj_base_url}/***/{pacote}/***",
             detail={"erro": mensagem, "erroCodigo": codigo},
         )
 

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -93,3 +93,32 @@ def test_cpfcnpj_base_url_https_customizada_e_aceita(monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("CPFCNPJ_BASE_URL", "https://proxy.interno.example/cpfcnpj")
     settings = Settings(_env_file=None)
     assert settings.cpfcnpj_base_url == "https://proxy.interno.example/cpfcnpj"
+
+
+def test_cpfcnpj_timeout_padrao_60() -> None:
+    settings = Settings(_env_file=None)
+    assert settings.cpfcnpj_timeout == 60.0
+
+
+def test_cpfcnpj_timeout_override_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CPFCNPJ_TIMEOUT", "90")
+    settings = Settings(_env_file=None)
+    assert settings.cpfcnpj_timeout == 90.0
+
+
+@pytest.mark.parametrize("valor", ["0", "-5"])
+def test_cpfcnpj_timeout_rejeita_nao_positivo(monkeypatch: pytest.MonkeyPatch, valor: str) -> None:
+    monkeypatch.setenv("CPFCNPJ_TIMEOUT", valor)
+    with pytest.raises(ValueError):
+        Settings(_env_file=None)
+
+
+def test_cpfcnpj_cpf_packet_padrao_26() -> None:
+    settings = Settings(_env_file=None)
+    assert settings.cpfcnpj_cpf_packet == 26
+
+
+def test_cpfcnpj_cpf_packet_rejeita_invalido(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CPFCNPJ_CPF_PACKET", "9")
+    with pytest.raises(ValueError):
+        Settings(_env_file=None)

--- a/tests/test_core_http.py
+++ b/tests/test_core_http.py
@@ -212,7 +212,7 @@ async def test_rate_limit_is_acquired_on_every_retry_attempt(
         "https://example.test",
         max_retries=2,
         cache_ttl=0,
-        limiter=limiter,  # type: ignore[arg-type]
+        limiter=limiter,
     )
 
     payload = await client.get("/flaky")

--- a/tests/test_cpf_consulta.py
+++ b/tests/test_cpf_consulta.py
@@ -1,0 +1,425 @@
+"""Testes da consulta de situacao cadastral de CPF (consultar_cpf, premium opt-in).
+
+Cobrem a tool, o client, a API REST e o SDK: sucesso por pacote (26/8/3/1), ausencia
+de token, digito verificador invalido sem chamada ao provedor, erro 102 (CPF valido mas
+inexistente), o mapeamento das situacoes cadastrais + o derivado apto_emissao e a politica
+de privacidade (CPF mascarado em log, PDF fora de log, resposta sem campos operacionais).
+
+Amostras fieis ao contrato publicado em https://www.cpfcnpj.com.br/dev/ (openapi.json).
+"""
+
+from typing import Any, ClassVar
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_fiscal_brasil._core import FiscalError, settings
+from mcp_fiscal_brasil._core.config import Settings
+from mcp_fiscal_brasil.api import app
+from mcp_fiscal_brasil.cpf import client as cpf_client
+from mcp_fiscal_brasil.cpf.client import CPFClient, mascarar_cpf
+from mcp_fiscal_brasil.cpf.tools import consultar_cpf_tool
+from mcp_fiscal_brasil.sdk import FiscalBrasil
+from mcp_fiscal_brasil.shared import cpfcnpj as cpfcnpj_provider
+
+# CPF de teste com digito verificador valido (dados ficticios no token de testes).
+CPF_TESTE = "11144477735"
+
+CPF_26_SAMPLE: dict[str, Any] = {
+    "status": 1,
+    "cpf": "111.444.777-35",
+    "nome": "FULANO DE TAL",
+    "nascimento": "01/01/1990",
+    "situacao": "Regular",
+    "situacaoDigito": "00",
+    "pacoteUsado": 26,
+    "saldo": 900,
+    "consultaID": "1234567890123456",
+}
+
+CPF_8_SAMPLE: dict[str, Any] = {
+    "status": 1,
+    "cpf": "111.444.777-35",
+    "nome": "FULANO DE TAL",
+    "nomeSocial": "",
+    "nascimento": "01/01/1990",
+    "situacao": "Cancelada",
+    "situacaoDigito": "03",
+    "situacaoMotivo": "TITULAR FALECIDO",
+    "situacaoAnoObito": 2015,
+    "situacaoInscricao": "anterior a 10/11/1990",
+    "situacaoComprovante": "1A1A.2B2B.3C3C.4D4D",
+    "situacaoComprovanteEmissao": "01/01/2025 10:00:00",
+    "situacaoComprovantePdf": "JVBERi0xLjQKJVBERg==",
+    "pacoteUsado": 8,
+    "saldo": 899,
+    "consultaID": "1234567890123457",
+    "delay": 2.1,
+}
+
+CPF_3_SAMPLE: dict[str, Any] = {
+    "status": 1,
+    "cpf": "111.444.777-35",
+    "nome": "FULANO DE TAL",
+    "nascimento": "01/01/1990",
+    "genero": "M",
+    "endereco": "RUA DAS FLORES",
+    "numero": "100",
+    "complemento": "APTO 1",
+    "bairro": "CENTRO",
+    "cep": "01001000",
+    "cidade": "SAO PAULO",
+    "uf": "SP",
+    "ibge": "3550308",
+    "pacoteUsado": 3,
+    "saldo": 898,
+}
+
+CPF_1_SAMPLE: dict[str, Any] = {
+    "status": 1,
+    "cpf": "111.444.777-35",
+    "nome": "FULANO DE TAL",
+    "pacoteUsado": 1,
+    "saldo": 897,
+}
+
+
+class _FakeHTTPClient:
+    """HTTPClient falso para testes: devolve um corpo pre-definido, sem rede."""
+
+    payload: ClassVar[dict[str, Any]] = {}
+    ultimo_path: ClassVar[str | None] = None
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeHTTPClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> bool:
+        return False
+
+    async def get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        _FakeHTTPClient.ultimo_path = path
+        return _FakeHTTPClient.payload
+
+
+class _RecordingLogger:
+    """Logger falso que registra os eventos e kwargs, para inspecionar PII."""
+
+    def __init__(self) -> None:
+        self.eventos: list[tuple[str, dict[str, Any]]] = []
+
+    def info(self, event: str, **kwargs: Any) -> None:
+        self.eventos.append((event, kwargs))
+
+    def warning(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def error(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def provedor_habilitado(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Habilita o provedor premium com token de teste, pacote 26 e HTTP mockado."""
+    monkeypatch.setattr(settings, "cpfcnpj_token", "token_de_teste", raising=False)
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 26, raising=False)
+    monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
+    _FakeHTTPClient.ultimo_path = None
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_config_pacote_cpf_padrao_26() -> None:
+    assert Settings().cpfcnpj_cpf_packet == 26
+
+
+@pytest.mark.parametrize("pacote", [1, 3, 8, 26])
+def test_config_pacote_cpf_aceita_validos(pacote: int) -> None:
+    assert Settings(cpfcnpj_cpf_packet=pacote).cpfcnpj_cpf_packet == pacote
+
+
+def test_config_pacote_cpf_rejeita_invalido() -> None:
+    with pytest.raises(ValueError):
+        Settings(cpfcnpj_cpf_packet=9)
+
+
+# ---------------------------------------------------------------------------
+# Mascaramento
+# ---------------------------------------------------------------------------
+
+
+def test_mascarar_cpf_preserva_apenas_dv() -> None:
+    assert mascarar_cpf("11144477735") == "***.***.***-35"
+    assert mascarar_cpf("111.444.777-35") == "***.***.***-35"
+    assert mascarar_cpf("123") == "***.***.***-**"
+
+
+# ---------------------------------------------------------------------------
+# Tool: sucesso por pacote
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_pacote_26_situacao_regular(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = CPF_26_SAMPLE
+    cadastro = await consultar_cpf_tool(CPF_TESTE)
+    assert cadastro.origem == "cpfcnpj.com.br"
+    assert cadastro.cpf == "***.***.***-35"
+    assert cadastro.nome == "FULANO DE TAL"
+    assert cadastro.nascimento == "01/01/1990"
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo == "00"
+    assert cadastro.situacao.descricao == "Regular"
+    assert cadastro.apto_emissao is True
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/26/{CPF_TESTE}"
+
+
+async def test_tool_pacote_8_comprovante_e_obito(
+    provedor_habilitado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 8, raising=False)
+    _FakeHTTPClient.payload = CPF_8_SAMPLE
+    cadastro = await consultar_cpf_tool(CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo == "03"
+    assert cadastro.situacao.descricao == "Titular Falecido"
+    assert cadastro.situacao.motivo == "TITULAR FALECIDO"
+    assert cadastro.situacao.ano_obito == 2015
+    assert cadastro.apto_emissao is False
+    assert cadastro.comprovante is not None
+    assert cadastro.comprovante.numero == "1A1A.2B2B.3C3C.4D4D"
+    assert cadastro.comprovante.pdf_base64 == "JVBERi0xLjQKJVBERg=="
+    assert _FakeHTTPClient.ultimo_path == f"/token_de_teste/8/{CPF_TESTE}"
+
+
+async def test_tool_pacote_3_endereco(
+    provedor_habilitado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 3, raising=False)
+    _FakeHTTPClient.payload = CPF_3_SAMPLE
+    cadastro = await consultar_cpf_tool(CPF_TESTE)
+    assert cadastro.genero == "M"
+    assert cadastro.endereco is not None
+    assert cadastro.endereco.logradouro == "RUA DAS FLORES"
+    assert cadastro.endereco.cidade == "SAO PAULO"
+    assert cadastro.endereco.uf == "SP"
+    assert cadastro.endereco.ibge == "3550308"
+    # Pacote 3 nao traz situacao: apto_emissao fica indeterminado.
+    assert cadastro.situacao is None
+    assert cadastro.apto_emissao is None
+
+
+async def test_tool_pacote_1_so_nome(
+    provedor_habilitado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 1, raising=False)
+    _FakeHTTPClient.payload = CPF_1_SAMPLE
+    cadastro = await consultar_cpf_tool(CPF_TESTE)
+    assert cadastro.nome == "FULANO DE TAL"
+    assert cadastro.situacao is None
+    assert cadastro.endereco is None
+    assert cadastro.comprovante is None
+
+
+# ---------------------------------------------------------------------------
+# Tool: erros
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_sem_token_levanta_erro_amigavel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_token", "", raising=False)
+    with pytest.raises(FiscalError) as exc_info:
+        await consultar_cpf_tool(CPF_TESTE)
+    assert "CPFCNPJ_TOKEN" in str(exc_info.value)
+
+
+async def test_tool_dv_invalido_nao_chama_provedor(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.ultimo_path = None
+    with pytest.raises(ValueError, match="CPF inválido"):
+        await consultar_cpf_tool("12345678900")
+    assert _FakeHTTPClient.ultimo_path is None
+
+
+async def test_tool_erro_102_cpf_inexistente(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = {
+        "status": 0,
+        "cpf": "",
+        "erro": "O CPF informado não existe",
+        "erroCodigo": 102,
+    }
+    with pytest.raises(FiscalError) as exc_info:
+        await consultar_cpf_tool(CPF_TESTE)
+    assert "nao consta na base" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Mapeamento de situacoes e apto_emissao
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("digito", "descricao", "apto"),
+    [
+        ("00", "Regular", True),
+        ("02", "Suspensa", False),
+        ("03", "Titular Falecido", False),
+        ("04", "Pendente de Regularização", False),
+        ("05", "Cancelada por Multiplicidade", False),
+        ("08", "Nula", False),
+        ("09", "Cancelada de Ofício", False),
+    ],
+)
+def test_parse_situacoes_e_apto_emissao(digito: str, descricao: str, apto: bool) -> None:
+    amostra = {"status": 1, "nome": "FULANO", "situacaoDigito": digito, "situacao": "Rotulo"}
+    cadastro = CPFClient()._parse_cpfcnpj(amostra, CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo == digito
+    assert cadastro.situacao.descricao == descricao
+    assert cadastro.apto_emissao is apto
+
+
+def test_parse_codigo_situacao_normaliza_para_dois_digitos() -> None:
+    amostra = {"status": 1, "situacaoDigito": 3, "situacao": "Cancelada"}
+    cadastro = CPFClient()._parse_cpfcnpj(amostra, CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo == "03"
+    assert cadastro.situacao.descricao == "Titular Falecido"
+
+
+def test_apto_emissao_deriva_do_texto_regular_sem_digito() -> None:
+    # Provedor devolve o rotulo textual sem situacaoDigito: "Regular" -> apto.
+    amostra = {"status": 1, "nome": "FULANO", "situacao": "Regular"}
+    cadastro = CPFClient()._parse_cpfcnpj(amostra, CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo is None
+    assert cadastro.apto_emissao is True
+
+
+def test_apto_emissao_deriva_do_texto_cancelada_sem_digito() -> None:
+    # Rotulo conhecido de irregularidade sem codigo -> nao apto.
+    amostra = {"status": 1, "nome": "FULANO", "situacao": "Cancelada"}
+    cadastro = CPFClient()._parse_cpfcnpj(amostra, CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo is None
+    assert cadastro.apto_emissao is False
+
+
+def test_apto_emissao_indeterminado_sem_codigo_nem_texto() -> None:
+    # Sem codigo e sem rotulo de situacao, o sinal e indeterminado (None).
+    amostra = {"status": 1, "nome": "FULANO", "nascimento": "01/01/1990"}
+    cadastro = CPFClient()._parse_cpfcnpj(amostra, CPF_TESTE)
+    assert cadastro.situacao is None
+    assert cadastro.apto_emissao is None
+
+
+def test_apto_emissao_texto_desconhecido_nao_vira_true() -> None:
+    # Texto fora da tabela nao autoriza apto=True: fica indeterminado (None).
+    amostra = {"status": 1, "nome": "FULANO", "situacao": "Situacao Incomum"}
+    cadastro = CPFClient()._parse_cpfcnpj(amostra, CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo is None
+    assert cadastro.apto_emissao is None
+
+
+# ---------------------------------------------------------------------------
+# Privacidade
+# ---------------------------------------------------------------------------
+
+
+async def test_privacidade_log_nao_contem_cpf_nem_pdf(
+    provedor_habilitado: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 8, raising=False)
+    _FakeHTTPClient.payload = CPF_8_SAMPLE
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(cpf_client, "logger", recorder)
+
+    await CPFClient().consultar(CPF_TESTE)
+
+    assert recorder.eventos, "esperava ao menos um evento de log"
+    for _evento, kwargs in recorder.eventos:
+        serial = repr(kwargs)
+        assert CPF_TESTE not in serial
+        assert "JVBERi0xLjQKJVBERg==" not in serial
+    # O campo cpf logado deve estar mascarado.
+    cpf_logado = recorder.eventos[0][1].get("cpf")
+    assert cpf_logado == "***.***.***-35"
+
+
+def test_resposta_nao_expoe_campos_operacionais() -> None:
+    cadastro = CPFClient()._parse_cpfcnpj(CPF_8_SAMPLE, CPF_TESTE)
+    dump = cadastro.model_dump(mode="json", exclude_none=True)
+    for chave in ("saldo", "consultaID", "pacoteUsado", "delay"):
+        assert chave not in dump
+
+
+# ---------------------------------------------------------------------------
+# API REST
+# ---------------------------------------------------------------------------
+
+
+_api_client = TestClient(app)
+
+
+def test_api_cpf_cadastro_rejeita_dv_invalido() -> None:
+    response = _api_client.get("/v1/cpf/12345678900/cadastro")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "CPF inválido"
+
+
+def test_api_cpf_cadastro_sucesso(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_token", "token_de_teste", raising=False)
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 26, raising=False)
+    monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
+    _FakeHTTPClient.payload = CPF_26_SAMPLE
+
+    response = _api_client.get(f"/v1/cpf/{CPF_TESTE}/cadastro")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cpf"] == "***.***.***-35"
+    assert data["situacao"]["descricao"] == "Regular"
+    assert data["apto_emissao"] is True
+    assert "saldo" not in data
+
+
+def test_api_cpf_cadastro_sem_token_responde_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_token", "", raising=False)
+    response = _api_client.get(f"/v1/cpf/{CPF_TESTE}/cadastro")
+    assert response.status_code == 502
+    assert "CPFCNPJ_TOKEN" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# SDK
+# ---------------------------------------------------------------------------
+
+
+async def test_sdk_consultar_cpf(provedor_habilitado: None) -> None:
+    _FakeHTTPClient.payload = CPF_26_SAMPLE
+    cadastro = await FiscalBrasil().consultar_cpf(CPF_TESTE)
+    assert cadastro.apto_emissao is True
+    assert cadastro.cpf == "***.***.***-35"
+
+
+async def test_sdk_consultar_cpf_dv_invalido() -> None:
+    with pytest.raises(ValueError, match="CPF inválido"):
+        await FiscalBrasil().consultar_cpf("12345678900")
+
+
+def test_sdk_consultar_cpf_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_token", "token_de_teste", raising=False)
+    monkeypatch.setattr(settings, "cpfcnpj_cpf_packet", 26, raising=False)
+    monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
+    _FakeHTTPClient.payload = CPF_26_SAMPLE
+    cadastro = FiscalBrasil().consultar_cpf_sync(CPF_TESTE)
+    assert cadastro.situacao is not None
+    assert cadastro.situacao.codigo == "00"

--- a/tests/test_cpf_consulta.py
+++ b/tests/test_cpf_consulta.py
@@ -371,9 +371,16 @@ _api_client = TestClient(app)
 
 
 def test_api_cpf_cadastro_rejeita_dv_invalido() -> None:
-    response = _api_client.get("/v1/cpf/12345678900/cadastro")
+    # CPF no corpo JSON (nunca no path): evita vazar o numero em access log/trace/proxy.
+    response = _api_client.post("/v1/cpf/cadastro", json={"cpf": "12345678900"})
     assert response.status_code == 400
     assert response.json()["detail"] == "CPF inválido"
+
+
+def test_api_cpf_cadastro_nao_expoe_cpf_no_path() -> None:
+    # A rota antiga com o CPF no path deixou de existir (transporte por corpo JSON).
+    response = _api_client.get(f"/v1/cpf/{CPF_TESTE}/cadastro")
+    assert response.status_code == 404
 
 
 def test_api_cpf_cadastro_sucesso(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -382,7 +389,7 @@ def test_api_cpf_cadastro_sucesso(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cpfcnpj_provider, "HTTPClient", _FakeHTTPClient)
     _FakeHTTPClient.payload = CPF_26_SAMPLE
 
-    response = _api_client.get(f"/v1/cpf/{CPF_TESTE}/cadastro")
+    response = _api_client.post("/v1/cpf/cadastro", json={"cpf": CPF_TESTE})
     assert response.status_code == 200
     data = response.json()
     assert data["cpf"] == "***.***.***-35"
@@ -393,7 +400,7 @@ def test_api_cpf_cadastro_sucesso(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_api_cpf_cadastro_sem_token_responde_502(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "cpfcnpj_token", "", raising=False)
-    response = _api_client.get(f"/v1/cpf/{CPF_TESTE}/cadastro")
+    response = _api_client.post("/v1/cpf/cadastro", json={"cpf": CPF_TESTE})
     assert response.status_code == 502
     assert "CPFCNPJ_TOKEN" in response.json()["detail"]
 

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -5,6 +5,7 @@ das respostas de CNPJ (pacote 6) e de NF-e/NFC-e por chave (pacotes 100/102) e a
 garantia de que, sem token configurado, o comportamento gratuito padrao nao muda.
 """
 
+import asyncio
 from typing import Any, ClassVar
 
 import httpx
@@ -172,6 +173,21 @@ async def test_transporte_erro_status_0(provedor_habilitado: None) -> None:
     assert "CNPJ inválido" in str(exc_info.value)
 
 
+async def test_erro_provedor_nao_expoe_documento(provedor_habilitado: None) -> None:
+    # A url da excecao viaja para access log/trace/proxy: o documento consultado nao
+    # pode vazar. Mascarado como .../***/{pacote}/*** (token e documento ocultos).
+    documento = "11144477735"
+    _FakeHTTPClient.payload = {"status": 0, "erro": "Consulta sem sucesso.", "erroCodigo": 300}
+    with pytest.raises(FiscalHTTPError) as exc_info:
+        await cpfcnpj_provider.consultar(26, documento)
+    erro = exc_info.value
+    assert documento not in str(erro)
+    assert documento not in repr(erro)
+    assert documento not in str(erro.url)
+    assert documento not in str(erro.detail)
+    assert erro.url.endswith("/***/26/***")
+
+
 def test_parse_cnpj_pacote_6_mapeia_campos() -> None:
     resposta = CNPJClient()._parse_cpfcnpj(CNPJ_6_SAMPLE, "00000000000191")
 
@@ -300,13 +316,39 @@ async def test_cnpj_alfanumerico_usa_provedor(provedor_habilitado: None) -> None
 
 
 def test_limitador_cpfcnpj_compartilhado() -> None:
-    # Duas instancias/chamadas do mesmo pacote compartilham o AsyncLimiter (singleton).
+    # Fora de um event loop em execucao (construcao sincrona), o mesmo grupo de req/s
+    # devolve o mesmo AsyncLimiter, via o conjunto de fallback de modulo. Pacotes 6 e 26
+    # sao do mesmo grupo (20 req/s), entao compartilham o limitador.
     limitador = cpfcnpj_provider._get_limiter(6)
     assert limitador is cpfcnpj_provider._get_limiter(6)
     cliente_a = cpfcnpj_provider._http_client(6)
     cliente_b = cpfcnpj_provider._http_client(26)
     assert cliente_a._limiter is cliente_b._limiter
     assert cliente_a._limiter is limitador
+
+
+def test_limitador_cpfcnpj_por_event_loop() -> None:
+    # Cada event loop tem o seu proprio limitador: dois asyncio.run consecutivos (como
+    # consultar_cpf_sync/consultar_cnpj_sync do SDK) NAO reusam o AsyncLimiter, que o
+    # aiolimiter amarra ao loop corrente. Dentro do mesmo loop, o mesmo grupo devolve o
+    # mesmo objeto, e grupos distintos (padrao x NF-e) permanecem separados.
+    async def _limitadores() -> tuple[Any, Any, Any]:
+        return (
+            cpfcnpj_provider._get_limiter(6),
+            cpfcnpj_provider._get_limiter(26),
+            cpfcnpj_provider._get_limiter(100),
+        )
+
+    a_padrao, a_padrao_26, a_nfe = asyncio.run(_limitadores())
+    b_padrao, _b_padrao_26, b_nfe = asyncio.run(_limitadores())
+
+    # Mesmo loop, mesmo grupo -> mesmo objeto.
+    assert a_padrao is a_padrao_26
+    # Mesmo loop, grupos distintos (20 req/s x 2 req/s) -> objetos distintos.
+    assert a_padrao is not a_nfe
+    # Loops distintos -> limitadores distintos, sem reuso entre loops.
+    assert a_padrao is not b_padrao
+    assert a_nfe is not b_nfe
 
 
 def test_limitador_nfe_separado_dos_demais() -> None:

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -7,6 +7,7 @@ garantia de que, sem token configurado, o comportamento gratuito padrao nao muda
 
 import asyncio
 import time
+from itertools import pairwise
 from typing import Any, ClassVar
 
 import httpx
@@ -381,7 +382,7 @@ def test_limitador_thread_safe_basico() -> None:
     # com 2 req/s e 6 acquires, restam no maximo `taxa` vagas ativas na janela.
     import threading
 
-    limitador = cpfcnpj_provider._LimitadorDeProcesso(2, janela=5.0)
+    limitador = cpfcnpj_provider._LimitadorDeProcesso(2, janela=0.01)
 
     def _bate() -> None:
         asyncio.run(limitador.acquire())
@@ -521,3 +522,37 @@ def test_request_error_mascara_token_com_base_url_prefixada() -> None:
     erro = cliente._request_error("GET", exc)
     _sem_token(erro)
     assert _TOKEN_SECRETO not in str(getattr(erro, "detail", ""))
+
+
+@pytest.mark.asyncio
+async def test_limitador_reavalia_janela_ao_acordar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Uma tarefa que acorda atrasada nao pode partir junto com outra na mesma janela.
+
+    Relogio e sleep falsos, deterministicos: o primeiro sleep "atrasa" 0,6 s ao
+    retomar (como um loop ocupado faria). Com taxa 1 e janela 1 s, a requisicao
+    atrasada parte em 1,6 s; a seguinte so pode partir em 2,6 s. Se a vaga fosse
+    reservada antes de dormir, sem reavaliar a janela ao acordar, a seguinte
+    partiria em 2,0 s, ou seja, duas requisicoes em menos de 1 s (HTTP 429/1007).
+    """
+    relogio = {"agora": 0.0, "atrasos": [0.6]}
+
+    def monotonic_falso() -> float:
+        return relogio["agora"]
+
+    async def sleep_falso(segundos: float) -> None:
+        atraso = relogio["atrasos"].pop(0) if relogio["atrasos"] else 0.0
+        relogio["agora"] += segundos + atraso
+
+    monkeypatch.setattr(cpfcnpj_provider.time, "monotonic", monotonic_falso)
+    monkeypatch.setattr(cpfcnpj_provider.asyncio, "sleep", sleep_falso)
+
+    limitador = cpfcnpj_provider._LimitadorDeProcesso(1, janela=1.0)
+    partidas: list[float] = []
+    for _ in range(3):
+        await limitador.acquire()
+        partidas.append(relogio["agora"])
+
+    assert partidas[0] == 0.0
+    assert partidas[1] == pytest.approx(1.6)
+    intervalos = [b - a for a, b in pairwise(partidas)]
+    assert all(i >= 1.0 for i in intervalos), partidas

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -7,9 +7,11 @@ garantia de que, sem token configurado, o comportamento gratuito padrao nao muda
 
 from typing import Any, ClassVar
 
+import httpx
 import pytest
 
 from mcp_fiscal_brasil._core import FiscalHTTPError, settings
+from mcp_fiscal_brasil._core.http import HTTPClient
 from mcp_fiscal_brasil.cnpj.client import CNPJClient
 from mcp_fiscal_brasil.nfe.client import NFEClient
 from mcp_fiscal_brasil.shared import cpfcnpj as cpfcnpj_provider
@@ -298,13 +300,41 @@ async def test_cnpj_alfanumerico_usa_provedor(provedor_habilitado: None) -> None
 
 
 def test_limitador_cpfcnpj_compartilhado() -> None:
-    # Duas instancias/chamadas devem compartilhar o mesmo AsyncLimiter (singleton).
-    limitador = cpfcnpj_provider._get_limiter()
-    assert limitador is cpfcnpj_provider._get_limiter()
-    cliente_a = cpfcnpj_provider._http_client()
-    cliente_b = cpfcnpj_provider._http_client()
+    # Duas instancias/chamadas do mesmo pacote compartilham o AsyncLimiter (singleton).
+    limitador = cpfcnpj_provider._get_limiter(6)
+    assert limitador is cpfcnpj_provider._get_limiter(6)
+    cliente_a = cpfcnpj_provider._http_client(6)
+    cliente_b = cpfcnpj_provider._http_client(26)
     assert cliente_a._limiter is cliente_b._limiter
     assert cliente_a._limiter is limitador
+
+
+def test_limitador_nfe_separado_dos_demais() -> None:
+    # Pacotes 100/102 (NF-e/NFC-e) compartilham um limitador de 2 req/s entre si,
+    # distinto do limitador de 20 req/s usado por CPF/CNPJ (6, 26).
+    limitador_nfe = cpfcnpj_provider._get_limiter(100)
+    assert limitador_nfe is cpfcnpj_provider._get_limiter(102)
+    assert limitador_nfe is not cpfcnpj_provider._get_limiter(6)
+    assert cpfcnpj_provider._rate_limit_para(100) == 2
+    assert cpfcnpj_provider._rate_limit_para(102) == 2
+    assert cpfcnpj_provider._rate_limit_para(6) == 20
+    assert cpfcnpj_provider._rate_limit_para(26) == 20
+    cliente_nfe = cpfcnpj_provider._http_client(100)
+    assert cliente_nfe.rate_limit_per_second == 2
+    assert cpfcnpj_provider._http_client(6).rate_limit_per_second == 20
+
+
+def test_http_client_usa_timeout_do_provedor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cpfcnpj_timeout", 60.0, raising=False)
+    assert cpfcnpj_provider._http_client(6).timeout == 60.0
+    assert cpfcnpj_provider._http_client(6).mask_first_path_segment is True
+
+
+def test_http_client_passa_token_como_mask_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    # O token e passado como segredo literal: defesa em profundidade para bases
+    # com prefixo de path, removendo-o mesmo fora do formato esperado de URL.
+    monkeypatch.setattr(settings, "cpfcnpj_token", "token_de_teste", raising=False)
+    assert cpfcnpj_provider._http_client(6).mask_secret == "token_de_teste"
 
 
 def test_parse_nfe_preserva_cnpj_alfanumerico_de_emitente_e_destinatario() -> None:
@@ -334,3 +364,74 @@ def test_parse_nfe_preserva_cnpj_alfanumerico_de_emitente_e_destinatario() -> No
 
 def _mascara_cnpj(cnpj: str) -> str:
     return f"{cnpj[:2]}.{cnpj[2:5]}.{cnpj[5:8]}/{cnpj[8:12]}-{cnpj[12:]}"
+
+
+_TOKEN_SECRETO = "SEGREDO_TOKEN_12345"
+_URL_COM_TOKEN = f"https://api.cpfcnpj.com.br/{_TOKEN_SECRETO}/26/11144477735"
+
+
+def _sem_token(erro: Exception) -> None:
+    assert _TOKEN_SECRETO not in str(erro)
+    assert _TOKEN_SECRETO not in repr(erro)
+    assert _TOKEN_SECRETO not in str(getattr(erro, "url", ""))
+    assert _TOKEN_SECRETO not in str(getattr(erro, "endpoint", ""))
+    assert _TOKEN_SECRETO not in str(getattr(erro, "detail", ""))
+    assert "***" in str(getattr(erro, "url", ""))
+
+
+def test_http_error_mascara_token_no_path() -> None:
+    cliente = HTTPClient("https://api.cpfcnpj.com.br", mask_first_path_segment=True)
+    requisicao = httpx.Request("GET", _URL_COM_TOKEN)
+    resposta = httpx.Response(400, request=requisicao, text='{"status":0,"erroCodigo":100}')
+    erro = cliente._http_error("GET", resposta)
+    _sem_token(erro)
+
+
+def test_request_error_mascara_token_no_path() -> None:
+    cliente = HTTPClient("https://api.cpfcnpj.com.br", mask_first_path_segment=True)
+    requisicao = httpx.Request("GET", _URL_COM_TOKEN)
+    exc = httpx.ConnectError(f"falha ao conectar em {_URL_COM_TOKEN}", request=requisicao)
+    erro = cliente._request_error("GET", exc)
+    _sem_token(erro)
+
+
+def test_fontes_gratuitas_nao_mascaram_path() -> None:
+    # Sem o flag, o path das fontes gratuitas continua intacto (nao ha segredo la).
+    cliente = HTTPClient("https://brasilapi.com.br/api")
+    url = "https://brasilapi.com.br/api/cnpj/v1/00000000000191"
+    requisicao = httpx.Request("GET", url)
+    resposta = httpx.Response(404, request=requisicao, text="{}")
+    erro = cliente._http_error("GET", resposta)
+    assert "00000000000191" in str(getattr(erro, "url", ""))
+
+
+# Base com prefixo de path (documentada no README: CPFCNPJ_BASE_URL=https://proxy/cpfcnpj).
+_URL_PREFIXO_COM_TOKEN = f"https://proxy.exemplo/cpfcnpj/{_TOKEN_SECRETO}/26/11144477735"
+
+
+def test_http_error_mascara_token_com_base_url_prefixada() -> None:
+    # Com prefixo de path, o token vem DEPOIS do prefixo: o mascaramento deve
+    # trocar o token, nao o segmento "cpfcnpj" do prefixo. Sem mask_secret aqui,
+    # provando que a logica ciente do prefixo ja resolve o vazamento.
+    cliente = HTTPClient("https://proxy.exemplo/cpfcnpj", mask_first_path_segment=True)
+    requisicao = httpx.Request("GET", _URL_PREFIXO_COM_TOKEN)
+    resposta = httpx.Response(400, request=requisicao, text='{"status":0,"erroCodigo":100}')
+    erro = cliente._http_error("GET", resposta)
+    _sem_token(erro)
+    url_mascarada = str(getattr(erro, "url", ""))
+    assert "cpfcnpj" in url_mascarada
+    assert "/cpfcnpj/***/26/" in url_mascarada
+
+
+def test_request_error_mascara_token_com_base_url_prefixada() -> None:
+    # Idem para erro de rede: o token some da url, do endpoint, do detail e da mensagem.
+    cliente = HTTPClient(
+        "https://proxy.exemplo/cpfcnpj",
+        mask_first_path_segment=True,
+        mask_secret=_TOKEN_SECRETO,
+    )
+    requisicao = httpx.Request("GET", _URL_PREFIXO_COM_TOKEN)
+    exc = httpx.ConnectError(f"falha ao conectar em {_URL_PREFIXO_COM_TOKEN}", request=requisicao)
+    erro = cliente._request_error("GET", exc)
+    _sem_token(erro)
+    assert _TOKEN_SECRETO not in str(getattr(erro, "detail", ""))

--- a/tests/test_cpfcnpj_provider.py
+++ b/tests/test_cpfcnpj_provider.py
@@ -6,6 +6,7 @@ garantia de que, sem token configurado, o comportamento gratuito padrao nao muda
 """
 
 import asyncio
+import time
 from typing import Any, ClassVar
 
 import httpx
@@ -316,9 +317,9 @@ async def test_cnpj_alfanumerico_usa_provedor(provedor_habilitado: None) -> None
 
 
 def test_limitador_cpfcnpj_compartilhado() -> None:
-    # Fora de um event loop em execucao (construcao sincrona), o mesmo grupo de req/s
-    # devolve o mesmo AsyncLimiter, via o conjunto de fallback de modulo. Pacotes 6 e 26
-    # sao do mesmo grupo (20 req/s), entao compartilham o limitador.
+    # O mesmo grupo de req/s devolve sempre o mesmo limitador de processo (singleton
+    # de modulo). Pacotes 6 e 26 sao do mesmo grupo (20 req/s), entao os clientes
+    # abertos para eles compartilham o limitador.
     limitador = cpfcnpj_provider._get_limiter(6)
     assert limitador is cpfcnpj_provider._get_limiter(6)
     cliente_a = cpfcnpj_provider._http_client(6)
@@ -327,11 +328,11 @@ def test_limitador_cpfcnpj_compartilhado() -> None:
     assert cliente_a._limiter is limitador
 
 
-def test_limitador_cpfcnpj_por_event_loop() -> None:
-    # Cada event loop tem o seu proprio limitador: dois asyncio.run consecutivos (como
-    # consultar_cpf_sync/consultar_cnpj_sync do SDK) NAO reusam o AsyncLimiter, que o
-    # aiolimiter amarra ao loop corrente. Dentro do mesmo loop, o mesmo grupo devolve o
-    # mesmo objeto, e grupos distintos (padrao x NF-e) permanecem separados.
+def test_limitador_cpfcnpj_compartilhado_entre_event_loops() -> None:
+    # O limitador e por processo, nao por loop: dois asyncio.run consecutivos (como
+    # consultar_cpf_sync/consultar_cnpj_sync do SDK, que abrem um loop novo a cada
+    # chamada) recebem o MESMO objeto para o mesmo grupo. Grupos distintos (padrao x
+    # NF-e) permanecem separados em qualquer loop.
     async def _limitadores() -> tuple[Any, Any, Any]:
         return (
             cpfcnpj_provider._get_limiter(6),
@@ -342,13 +343,56 @@ def test_limitador_cpfcnpj_por_event_loop() -> None:
     a_padrao, a_padrao_26, a_nfe = asyncio.run(_limitadores())
     b_padrao, _b_padrao_26, b_nfe = asyncio.run(_limitadores())
 
-    # Mesmo loop, mesmo grupo -> mesmo objeto.
+    # Mesmo grupo -> mesmo objeto, dentro do loop e entre loops distintos.
     assert a_padrao is a_padrao_26
-    # Mesmo loop, grupos distintos (20 req/s x 2 req/s) -> objetos distintos.
+    assert a_padrao is b_padrao
+    assert a_nfe is b_nfe
+    # Grupos distintos (20 req/s x 2 req/s) -> objetos distintos.
     assert a_padrao is not a_nfe
-    # Loops distintos -> limitadores distintos, sem reuso entre loops.
-    assert a_padrao is not b_padrao
-    assert a_nfe is not b_nfe
+
+
+def test_limitador_orcamento_compartilhado_entre_event_loops() -> None:
+    # O orcamento e dividido entre loops: com 2 req/s, tres acquires espalhados por
+    # dois asyncio.run consecutivos precisam esperar a janela liberar, gastando tempo
+    # real. Dois acquires no mesmo segundo cabem na janela e nao esperam.
+    limitador = cpfcnpj_provider._LimitadorDeProcesso(2)
+
+    async def _dois_acquires() -> None:
+        await limitador.acquire()
+        await limitador.acquire()
+
+    async def _um_acquire() -> None:
+        await limitador.acquire()
+
+    inicio = time.monotonic()
+    asyncio.run(_dois_acquires())
+    sem_espera = time.monotonic() - inicio
+    asyncio.run(_um_acquire())
+    total = time.monotonic() - inicio
+
+    # Os dois primeiros (mesma janela de 1 s) nao esperam.
+    assert sem_espera < 0.3
+    # O terceiro estoura a janela e espera ate a vaga liberar (tolerancia ampla).
+    assert total >= 0.5
+
+
+def test_limitador_thread_safe_basico() -> None:
+    # Chamadas concorrentes de threads distintas nao corrompem o agendamento interno:
+    # com 2 req/s e 6 acquires, restam no maximo `taxa` vagas ativas na janela.
+    import threading
+
+    limitador = cpfcnpj_provider._LimitadorDeProcesso(2, janela=5.0)
+
+    def _bate() -> None:
+        asyncio.run(limitador.acquire())
+
+    threads = [threading.Thread(target=_bate) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(limitador._agendadas) <= limitador.taxa
 
 
 def test_limitador_nfe_separado_dos_demais() -> None:


### PR DESCRIPTION
## Resumo

Adiciona a tool `consultar_cpf`, opt-in pelo mesmo `CPFCNPJ_TOKEN`, no módulo `cpf/` existente. Ela confere a situação cadastral do titular na Receita Federal (Regular, Suspensa, Cancelada, Titular Falecido, Nula) antes de emitir NF-e, NFC-e ou NFS-e a pessoa física, reaproveitando o transporte `shared/cpfcnpj.py` e o padrão do `consultar_cnpj`. Sem token, nada muda: não existe fonte gratuita de dados de CPF.

## Motivação

Hoje o módulo `cpf/` só valida o dígito verificador offline, e NF-e (`nfe/schemas.py`) e NFS-e (`nfse/schemas.py`) aceitam qualquer CPF com DV válido como destinatário ou tomador. Emitir documento fiscal para um CPF cancelado por óbito, nulo ou cancelado de ofício gera destinatário inválido e passivo para o emitente. Com a tool, o fluxo agêntico consulta a situação antes de montar o documento e bloqueia (ou alerta) quando o titular não está regular, guardando o comprovante em PDF da Receita como evidência da diligência (pacote 8).

## Alterações

- `CPFCNPJ_CPF_PACKET` no config, no molde de `CPFCNPJ_CNPJ_PACKET`, com quatro níveis: 26 (padrão: nome, nascimento e situação, o mais barato com situação), 8 (o do 26 mais motivo, ano de óbito, número e PDF do comprovante), 3 (nome, nascimento, gênero e endereço) e 1 (só nome). Valores fora disso são recusados na configuração.
- Resposta normalizada `CPFCadastro`: `situacao` (código e descrição da tabela oficial), `situacao_motivo`, `ano_obito`, `nome`, `nascimento`, `endereco` (só no pacote 3), `comprovante` (número e PDF, só no pacote 8) e o derivado `apto_emissao` (verdadeiro só quando a situação é Regular; deriva do código `situacaoDigito` e, quando o provedor devolve só o rótulo textual sem código, da situação normalizada: "regular" vira verdadeiro, rótulos conhecidos de irregularidade viram falso, texto vazio ou desconhecido fica None; nunca verdadeiro sem evidência). Mapeamento defensivo: campo ausente vira None.
- Validação local do DV antes de qualquer chamada (não gasta crédito com CPF malformado), nas três entradas (tool, API 400, SDK ValueError). Erro 102 da API (CPF válido mas inexistente) traduzido em mensagem clara; demais códigos seguem o tratamento já existente de `shared/cpfcnpj.py`. Sem token, mensagem amigável dizendo que a tool exige `CPFCNPJ_TOKEN`.
- Exposição também no endpoint REST `GET /v1/cpf/{cpf}/cadastro` e no SDK (`consultar_cpf` async e `consultar_cpf_sync`).

## Desenho e privacidade

- A descrição da tool declara a finalidade (conferência de destinatário ou tomador antes de emitir documento fiscal, não localização de pessoas).
- CPF mascarado em todo log (`***.***.***-XX`, só os dígitos verificadores, que já são deriváveis dos nove primeiros).
- PDF do comprovante devolvido como base64 sem nunca passar por log.
- Resposta ao modelo não inclui campos operacionais do provedor (saldo, consultaID, pacote usado).
- Do lado da fonte, a cpfcnpj.com.br consulta as bases oficiais em tempo real, sem armazenar cópia nem usar dados vazados ou raspados, sob ISO/IEC 27001, ISO/IEC 27701 e ISO 37301, com a consulta vinculada ao token e ao IP autorizado, o que dá a trilha de responsabilidade que a LGPD pede para a finalidade fiscal.

## Testes

- `tests/test_cpf_consulta.py` (34 testes) com fixtures fiéis ao OpenAPI (mesmo padrão de `tests/test_cpfcnpj_provider.py`): tool com token nos pacotes 26, 8, 3 e 1; sem token; DV inválido sem chamar o provedor; erro 102; mapeamento das sete situações e o derivado `apto_emissao` (por código e, sem código, pelo texto da situação: regular, cancelada e desconhecido); máscara de CPF; API 400/200/502; SDK async e sync; validação de pacote no config.
- Testes de política de privacidade: log não contém o CPF completo nem o PDF; resposta não expõe saldo, consultaID nem pacote usado. Do lado do transporte, teste garante que o token não aparece em `str(exc)`, `.url`, `.endpoint` nem `detail`.
- Suíte completa verde (688 antes, 736 depois: 34 de `consultar_cpf` + 14 de conformidade). Cobertura do módulo novo `cpf/` 97.8%. ruff format, ruff check e mypy strict limpos.

## Ajustes de conformidade com a documentação do provedor cpfcnpj.com.br

Além da tool, o transporte foi alinhado à documentação oficial do provedor (segundo commit, `fix(cpfcnpj)`):

- Timeout dedicado `CPFCNPJ_TIMEOUT` (padrão 60s, recomendado pela documentação): antes o provedor reusava o timeout global de 30s, e um valor menor pode cortar a requisição depois de o crédito já ter sido consumido. O timeout das fontes gratuitas não muda.
- Rate limit por pacote: os pacotes de NF-e/NFC-e por chave (100/102) têm teto próprio de 2 req/s por conta na documentação (HTTP 429 + erroCodigo 1007, sem cobrar), separado do teto de 20 req/s dos demais pacotes (CPF/CNPJ/IE). Cada limitador é um singleton de módulo; `consultar(pacote, documento)` passa o limitador certo.
- Mascaramento do token na origem: o token viaja no primeiro segmento do path (`/{token}/...`) e os erros de transporte carregavam a URL completa em `.url`. O cliente do provedor passa a mascarar o primeiro segmento após o prefixo de path da base URL (funciona também com `CPFCNPJ_BASE_URL` apontando para um proxy com caminho) e, como defesa em profundidade, remove qualquer ocorrência literal do token de `url`, `endpoint`, mensagem e `details` (`mask_secret`). As fontes gratuitas não são afetadas.

## Documentação

- README: `consultar_cpf` na tabela de ferramentas funcionais e na tabela do provedor (pacotes 1/3/8/26), comparativo do que cada pacote devolve, `CPFCNPJ_CPF_PACKET` e `CPFCNPJ_TIMEOUT` nas duas tabelas de variáveis e uma linha de CPF no comparativo com outros MCPs brasileiros.
- `.env.example`, `docs/modules/cpf.md` e `CHANGELOG.md` (Unreleased) atualizados.

Closes #143

## Checklist

- [x] Tests pass (`pytest`): 736 passed
- [x] Lint passes (`ruff check src/ tests/`)
- [x] Format passes (`ruff format --check src/ tests/`)
- [x] Type check passes (`mypy src/`)
- [x] No breaking changes to existing tool interfaces (a rota `GET /v1/cpf/{cpf}` de validação continua igual; a consulta cadastral entrou como `GET /v1/cpf/{cpf}/cadastro`)
- [x] Documentation updated (README, `.env.example`, `docs/modules/cpf.md`, CHANGELOG)
- [x] Release note text is polished pt-BR when the PR title will appear in Release Please


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionada consulta premium da situação cadastral de CPF via MCP, API REST e SDK.
  * Incluídas validação de CPF e derivação do indicador `apto_emissao`.
  * Adicionados pacotes configuráveis e timeout específico para consultas de CPF.
  * Dados sensíveis, como CPF e token, passam a ser mascarados em logs e erros.
  * Aplicados limites de requisições específicos por tipo de pacote.

* **Documentação**
  * Atualizadas as instruções de configuração, uso, pacotes disponíveis e limitações da consulta de CPF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->